### PR TITLE
AUT-95: Correct path handling for Russian profile

### DIFF
--- a/Applications/Workbench/MitkWorkbench.cpp
+++ b/Applications/Workbench/MitkWorkbench.cpp
@@ -147,7 +147,7 @@ int main(int argc, char** argv)
   Poco::Util::MapConfiguration* extConfig(new Poco::Util::MapConfiguration());
   if (!storageDir.isEmpty())
   {
-    extConfig->setString(berry::Platform::ARG_STORAGE_DIR, storageDir.toStdString());
+    extConfig->setString(berry::Platform::ARG_STORAGE_DIR, storageDir.toUtf8().constData());
   }
   extConfig->setString(berry::Platform::ARG_PLUGIN_DIRS, pluginDirs);
   extConfig->setString(berry::Platform::ARG_PROVISIONING, provFile.toString());

--- a/Modules/SceneSerialization/mitkSceneIO.cpp
+++ b/Modules/SceneSerialization/mitkSceneIO.cpp
@@ -197,16 +197,16 @@ mitk::DataStorage::Pointer mitk::SceneIO::LoadScene( const std::string& filename
 
   // test if index.xml exists
   // parse index.xml with TinyXML
-  std::string m_WorkingDirectory_WIN = Poco::Path::transcode ( m_WorkingDirectory );
-  TiXmlDocument document( m_WorkingDirectory_WIN + mitk::IOUtil::GetDirectorySeparator() + "index.xml" );
+  std::string defaultLocale_WorkingDirectory = Poco::Path::transcode ( m_WorkingDirectory );
+  TiXmlDocument document( defaultLocale_WorkingDirectory + mitk::IOUtil::GetDirectorySeparator() + "index.xml" );
   if (!document.LoadFile())
   {
-    MITK_ERROR << "Could not open/read/parse " << m_WorkingDirectory_WIN << mitk::IOUtil::GetDirectorySeparator() << "index.xml\nTinyXML reports: " << document.ErrorDesc() << std::endl;
+    MITK_ERROR << "Could not open/read/parse " << defaultLocale_WorkingDirectory << mitk::IOUtil::GetDirectorySeparator() << "index.xml\nTinyXML reports: " << document.ErrorDesc() << std::endl;
     return storage;
   }
 
   SceneReader::Pointer reader = SceneReader::New();
-  if ( !reader->LoadScene( document, m_WorkingDirectory_WIN, storage ) )
+  if ( !reader->LoadScene( document, defaultLocale_WorkingDirectory, storage ) )
   {
     MITK_ERROR << "There were errors while loading scene file " << filename << ". Your data may be corrupted";
   }
@@ -426,10 +426,10 @@ bool mitk::SceneIO::SaveScene( DataStorage::SetOfObjects::ConstPointer sceneNode
       } // end for all nodes
     } // end if sceneNodes
 
-    std::string m_WorkingDirectory_WIN = Poco::Path::transcode( m_WorkingDirectory );
-    if ( !document.SaveFile( m_WorkingDirectory_WIN + Poco::Path::separator() + "index.xml" ) )
+    std::string defaultLocale_WorkingDirectory = Poco::Path::transcode( m_WorkingDirectory );
+    if ( !document.SaveFile( defaultLocale_WorkingDirectory + Poco::Path::separator() + "index.xml" ) )
     {
-      MITK_ERROR << "Could not write scene to " << m_WorkingDirectory_WIN << Poco::Path::separator() << "index.xml" << "\nTinyXML reports '" << document.ErrorDesc() << "'";
+      MITK_ERROR << "Could not write scene to " << defaultLocale_WorkingDirectory << Poco::Path::separator() << "index.xml" << "\nTinyXML reports '" << document.ErrorDesc() << "'";
       return false;
     }
     else
@@ -443,11 +443,11 @@ bool mitk::SceneIO::SaveScene( DataStorage::SetOfObjects::ConstPointer sceneNode
         }
 
         // create zip at filename
-        std::string filename_WIN = Poco::Path::transcode( filename );
-        std::ofstream file( filename_WIN.c_str(), std::ios::binary | std::ios::out);
+        std::string defaultLocaleFilename = Poco::Path::transcode( filename );
+        std::ofstream file( defaultLocaleFilename.c_str(), std::ios::binary | std::ios::out);
         if (!file.good())
         {
-          MITK_ERROR << "Could not open a zip file for writing: '" << filename_WIN << "'";
+          MITK_ERROR << "Could not open a zip file for writing: '" << defaultLocaleFilename << "'";
           return false;
         }
         else
@@ -513,8 +513,8 @@ TiXmlElement* mitk::SceneIO::SaveBaseData( BaseData* data, const std::string& fi
     {
       serializer->SetData(data);
       serializer->SetFilenameHint(filenamehint);
-      std::string m_WorkingDirectory_WIN = Poco::Path::transcode( m_WorkingDirectory );
-      serializer->SetWorkingDirectory( m_WorkingDirectory_WIN );
+      std::string defaultLocale_WorkingDirectory = Poco::Path::transcode( m_WorkingDirectory );
+      serializer->SetWorkingDirectory( defaultLocale_WorkingDirectory );
       try
       {
         std::string writtenfilename = serializer->Serialize();
@@ -544,8 +544,8 @@ TiXmlElement* mitk::SceneIO::SavePropertyList( PropertyList* propertyList, const
 
   serializer->SetPropertyList(propertyList);
   serializer->SetFilenameHint(filenamehint);
-  std::string m_WorkingDirectory_WIN = Poco::Path::transcode( m_WorkingDirectory );
-  serializer->SetWorkingDirectory( m_WorkingDirectory_WIN );
+  std::string defaultLocale_WorkingDirectory = Poco::Path::transcode( m_WorkingDirectory );
+  serializer->SetWorkingDirectory( defaultLocale_WorkingDirectory );
   try
   {
     std::string writtenfilename = serializer->Serialize();

--- a/Modules/SceneSerialization/mitkSceneIO.cpp
+++ b/Modules/SceneSerialization/mitkSceneIO.cpp
@@ -197,6 +197,7 @@ mitk::DataStorage::Pointer mitk::SceneIO::LoadScene( const std::string& filename
 
   // test if index.xml exists
   // parse index.xml with TinyXML
+  m_WorkingDirectory = Poco::Path::transcode ( m_WorkingDirectory );
   TiXmlDocument document( m_WorkingDirectory + mitk::IOUtil::GetDirectorySeparator() + "index.xml" );
   if (!document.LoadFile())
   {

--- a/Modules/SceneSerialization/mitkSceneIO.cpp
+++ b/Modules/SceneSerialization/mitkSceneIO.cpp
@@ -197,16 +197,16 @@ mitk::DataStorage::Pointer mitk::SceneIO::LoadScene( const std::string& filename
 
   // test if index.xml exists
   // parse index.xml with TinyXML
-  m_WorkingDirectory = Poco::Path::transcode ( m_WorkingDirectory );
-  TiXmlDocument document( m_WorkingDirectory + mitk::IOUtil::GetDirectorySeparator() + "index.xml" );
+  std::string m_WorkingDirectory_WIN = Poco::Path::transcode ( m_WorkingDirectory );
+  TiXmlDocument document( m_WorkingDirectory_WIN + mitk::IOUtil::GetDirectorySeparator() + "index.xml" );
   if (!document.LoadFile())
   {
-    MITK_ERROR << "Could not open/read/parse " << m_WorkingDirectory << mitk::IOUtil::GetDirectorySeparator() << "index.xml\nTinyXML reports: " << document.ErrorDesc() << std::endl;
+    MITK_ERROR << "Could not open/read/parse " << m_WorkingDirectory_WIN << mitk::IOUtil::GetDirectorySeparator() << "index.xml\nTinyXML reports: " << document.ErrorDesc() << std::endl;
     return storage;
   }
 
   SceneReader::Pointer reader = SceneReader::New();
-  if ( !reader->LoadScene( document, m_WorkingDirectory, storage ) )
+  if ( !reader->LoadScene( document, m_WorkingDirectory_WIN, storage ) )
   {
     MITK_ERROR << "There were errors while loading scene file " << filename << ". Your data may be corrupted";
   }
@@ -426,9 +426,10 @@ bool mitk::SceneIO::SaveScene( DataStorage::SetOfObjects::ConstPointer sceneNode
       } // end for all nodes
     } // end if sceneNodes
 
-    if ( !document.SaveFile( m_WorkingDirectory + Poco::Path::separator() + "index.xml" ) )
+    std::string m_WorkingDirectory_WIN = Poco::Path::transcode( m_WorkingDirectory );
+    if ( !document.SaveFile( m_WorkingDirectory_WIN + Poco::Path::separator() + "index.xml" ) )
     {
-      MITK_ERROR << "Could not write scene to " << m_WorkingDirectory << Poco::Path::separator() << "index.xml" << "\nTinyXML reports '" << document.ErrorDesc() << "'";
+      MITK_ERROR << "Could not write scene to " << m_WorkingDirectory_WIN << Poco::Path::separator() << "index.xml" << "\nTinyXML reports '" << document.ErrorDesc() << "'";
       return false;
     }
     else
@@ -442,10 +443,11 @@ bool mitk::SceneIO::SaveScene( DataStorage::SetOfObjects::ConstPointer sceneNode
         }
 
         // create zip at filename
-        std::ofstream file( filename.c_str(), std::ios::binary | std::ios::out);
+        std::string filename_WIN = Poco::Path::transcode( filename );
+        std::ofstream file( filename_WIN.c_str(), std::ios::binary | std::ios::out);
         if (!file.good())
         {
-          MITK_ERROR << "Could not open a zip file for writing: '" << filename << "'";
+          MITK_ERROR << "Could not open a zip file for writing: '" << filename_WIN << "'";
           return false;
         }
         else
@@ -511,7 +513,8 @@ TiXmlElement* mitk::SceneIO::SaveBaseData( BaseData* data, const std::string& fi
     {
       serializer->SetData(data);
       serializer->SetFilenameHint(filenamehint);
-      serializer->SetWorkingDirectory( m_WorkingDirectory );
+      std::string m_WorkingDirectory_WIN = Poco::Path::transcode( m_WorkingDirectory );
+      serializer->SetWorkingDirectory( m_WorkingDirectory_WIN );
       try
       {
         std::string writtenfilename = serializer->Serialize();
@@ -541,7 +544,8 @@ TiXmlElement* mitk::SceneIO::SavePropertyList( PropertyList* propertyList, const
 
   serializer->SetPropertyList(propertyList);
   serializer->SetFilenameHint(filenamehint);
-  serializer->SetWorkingDirectory( m_WorkingDirectory );
+  std::string m_WorkingDirectory_WIN = Poco::Path::transcode( m_WorkingDirectory );
+  serializer->SetWorkingDirectory( m_WorkingDirectory_WIN );
   try
   {
     std::string writtenfilename = serializer->Serialize();


### PR DESCRIPTION
Poco::Path::transcode

this function converts a string (usually containing a path) encoded in UTF-8 into a string encoded in the current Windows code page. )