### PR TITLE
Install path with russian characters support AUT-182

### DIFF
--- a/BlueBerry/Bundles/org.blueberry.osgi/src/internal/berryInternalPlatform.cpp
+++ b/BlueBerry/Bundles/org.blueberry.osgi/src/internal/berryInternalPlatform.cpp
@@ -195,7 +195,7 @@ void InternalPlatform::Initialize(int& argc, char** argv, Poco::Util::AbstractCo
   {
     BERRY_INFO(m_ConsoleLog) << "Using provisioning file: " << provisioningFile;
 
-    ProvisioningInfo provInfo(QString::fromUtf8(provisioningFile.c_str()));
+    ProvisioningInfo provInfo(provisioningFile.c_str());
 
     // it can still happen, that the encoding is not compatible with the fromUtf8 function ( i.e. when manipulating the LANG variable
     // in such case, the QStringList in provInfo is empty which we can easily check for

--- a/BlueBerry/Bundles/org.blueberry.osgi/src/internal/berryProvisioningInfo.cpp
+++ b/BlueBerry/Bundles/org.blueberry.osgi/src/internal/berryProvisioningInfo.cpp
@@ -32,7 +32,7 @@ const QString ProvisioningInfo::intermediateOutDir = QString(CMAKE_INTDIR);
 const QString ProvisioningInfo::intermediateOutDir = QString();
 #endif
 
-ProvisioningInfo::ProvisioningInfo(const QString& file)
+ProvisioningInfo::ProvisioningInfo(const std::string& file)
 {
   this->readProvisioningFile(file);
 }
@@ -52,9 +52,9 @@ QList<QUrl> ProvisioningInfo::getPluginsToStart() const
   return pluginsToStart;
 }
 
-void ProvisioningInfo::readProvisioningFile(const QString& filePath)
+void ProvisioningInfo::readProvisioningFile(const std::string& filePath)
 {
-  QFile file(filePath);
+  QFile file(QFile::decodeName(filePath.c_str()));
   file.open(QFile::ReadOnly);
   QTextStream fileStream(&file);
   QRegExp sep("\\s+");
@@ -71,7 +71,7 @@ void ProvisioningInfo::readProvisioningFile(const QString& filePath)
       if (keyword.isEmpty())
       {
         BERRY_WARN << "Keyword missing in line " << count
-                   << " of provisioning file " << filePath.toStdString();
+                   << " of provisioning file " << filePath;
         continue;
       }
 
@@ -97,7 +97,7 @@ void ProvisioningInfo::readProvisioningFile(const QString& filePath)
       {
         BERRY_WARN << "Keyword " << keyword.toStdString() << " in line "
                       << count << " of provisioning file "
-                      << filePath.toStdString() << " unknown";
+                      << filePath << " unknown";
         continue;
       }
 
@@ -105,7 +105,7 @@ void ProvisioningInfo::readProvisioningFile(const QString& filePath)
       {
         BERRY_WARN << "Value after keyword " << keyword.toStdString()
                   << " missing in line " << count
-                  << " of provisioning file " << filePath.toStdString();
+                  << " of provisioning file " << filePath;
         continue;
       }
 
@@ -120,7 +120,7 @@ void ProvisioningInfo::readProvisioningFile(const QString& filePath)
                      << "is invalid: " << readFileUrl.errorString().toStdString();
           break;
         }
-        this->readProvisioningFile(readFileUrl.toLocalFile());
+        this->readProvisioningFile(readFileUrl.toLocalFile().toUtf8().constData());
         break;
       }
       case INSTALL:

--- a/BlueBerry/Bundles/org.blueberry.osgi/src/internal/berryProvisioningInfo.h
+++ b/BlueBerry/Bundles/org.blueberry.osgi/src/internal/berryProvisioningInfo.h
@@ -28,7 +28,7 @@ namespace berry {
 class ProvisioningInfo
 {
 public:
-    ProvisioningInfo(const QString& file);
+    ProvisioningInfo(const std::string& file);
 
     QStringList getPluginDirs() const;
     QList<QUrl> getPluginsToInstall() const;
@@ -50,7 +50,7 @@ private:
 
     static const QString intermediateOutDir;
 
-    void readProvisioningFile(const QString& file);
+    void readProvisioningFile(const std::string& file);
     QUrl addPluginToInstall(const QString& file);
     void addPluginToStart(const QString& file);
 


### PR DESCRIPTION
Allow loading Provisioning file from Russan characters in the install path by using `QFile::decodeName`
