### PR TITLE
Fixed ERROR: No property reader found for GenericProperty.

### DIFF
--- a/Core/Code/IO/mitkDicomSeriesReader.cpp
+++ b/Core/Code/IO/mitkDicomSeriesReader.cpp
@@ -1501,9 +1501,9 @@ void DicomSeriesReader::CopyMetaDataToImageProperties( std::list<StringContainer
   // copy imageblockdescriptor as properties
   image->SetProperty("dicomseriesreader.SOPClass", StringProperty::New(blockInfo.GetSOPClassUIDAsString()));
   image->SetProperty("dicomseriesreader.ReaderImplementationLevelString", StringProperty::New(ReaderImplementationLevelToString( blockInfo.GetReaderImplementationLevel() )));
-  image->SetProperty("dicomseriesreader.ReaderImplementationLevel", GenericProperty<ReaderImplementationLevel>::New( blockInfo.GetReaderImplementationLevel() ));
+  image->SetProperty("dicomseriesreader.ReaderImplementationLevel", IntProperty::New( blockInfo.GetReaderImplementationLevel() ));
   image->SetProperty("dicomseriesreader.PixelSpacingInterpretationString", StringProperty::New(PixelSpacingInterpretationToString( blockInfo.GetPixelSpacingType() )));
-  image->SetProperty("dicomseriesreader.PixelSpacingInterpretation", GenericProperty<PixelSpacingInterpretation>::New(blockInfo.GetPixelSpacingType()));
+  image->SetProperty("dicomseriesreader.PixelSpacingInterpretation", IntProperty::New(blockInfo.GetPixelSpacingType()));
   image->SetProperty("dicomseriesreader.MultiFrameImage", BoolProperty::New(blockInfo.IsMultiFrameImage()));
   image->SetProperty("dicomseriesreader.GantyTiltCorrected", BoolProperty::New(blockInfo.HasGantryTiltCorrected()));
   image->SetProperty("dicomseriesreader.3D+t", BoolProperty::New(blockInfo.HasMultipleTimePoints()));

--- a/Modules/DICOMReader/mitkDICOMImageBlockDescriptor.cpp
+++ b/Modules/DICOMReader/mitkDICOMImageBlockDescriptor.cpp
@@ -488,12 +488,12 @@ mitk::DICOMImageBlockDescriptor
   mitkImage->SetProperty("dicomseriesreader.PixelSpacingInterpretationString",
       StringProperty::New( PixelSpacingInterpretationToString( this->GetPixelSpacingInterpretation() )) );
   mitkImage->SetProperty("dicomseriesreader.PixelSpacingInterpretation",
-      GenericProperty<PixelSpacingInterpretation>::New( this->GetPixelSpacingInterpretation() ));
+      IntProperty::New( this->GetPixelSpacingInterpretation() ));
 
   mitkImage->SetProperty("dicomseriesreader.ReaderImplementationLevelString",
       StringProperty::New( ReaderImplementationLevelToString( m_ReaderImplementationLevel ) ));
   mitkImage->SetProperty("dicomseriesreader.ReaderImplementationLevel",
-      GenericProperty<ReaderImplementationLevel>::New( m_ReaderImplementationLevel ));
+      IntProperty::New( m_ReaderImplementationLevel ));
 
   mitkImage->SetProperty("dicomseriesreader.GantyTiltCorrected",
       BoolProperty::New( this->GetTiltInformation().IsRegularGantryTilt() ));


### PR DESCRIPTION
GenericProperty can not be saved to a file. He was replaced by IntProperty, as it does not violate the logic of the code.