### PR TITLE
Краш при активации Segmentation плагина

### DIFF
--- a/Modules/Segmentation/Controllers/mitkToolManager.cpp
+++ b/Modules/Segmentation/Controllers/mitkToolManager.cpp
@@ -67,6 +67,13 @@ mitk::ToolManager::~ToolManager()
 
 void mitk::ToolManager::InitializeTools()
 {
+  if (m_ActiveTool) {
+    m_ActiveTool->Deactivated();
+    m_ActiveToolRegistration.Unregister();
+
+    m_ActiveTool = nullptr;
+    m_ActiveToolID = -1;
+  }
 
   m_Tools.resize(0);
   // get a list of all known mitk::Tools


### PR DESCRIPTION
AUT-1071

При активации Segmentation плагин пересоздает набор инструментов.
Если при этом уже есть активный инструмент, то он не обнуляется, но становится невалидным.

Я добавил корректное обновление активного инструмента.
