### PR TITLE
Загрузка time geometry

### DIFF
--- a/Modules/Core/src/IO/mitkDicomSeriesReader.cpp
+++ b/Modules/Core/src/IO/mitkDicomSeriesReader.cpp
@@ -1026,7 +1026,7 @@ DicomSeriesReader::GetSeries(const StringContainer& files, bool sortTo3DPlust, b
             identicalOrigins = false;
           }
 
-          if (identicalOrigins && (numberOfFilesInPreviousBlock == numberOfFilesInThisBlock))
+          if (identicalOrigins && (numberOfFilesInPreviousBlock == numberOfFilesInThisBlock) && numberOfFilesInThisBlock == 1)
           {
             // group with previous block
             groupsOf3DPlusTBlocks[previousBlockKey].AddFiles( block3DIter->second.GetFilenames() );


### PR DESCRIPTION
AUT-1059

МИТК по умолчанию сливает серии с несколькими временными измерениями в одну серию.
Я изменил это, теперь в одну серию пойдут только измерения с одним срезом.
В остальных случаях разные временные измерения будут разнесены по разным сериям.

Тестовые шаги:
1. Проверить серии 
   0265\dicom\S117980\S30
   0015\dicom\MRI\PA0\ST0\SE11
   0015\dicom\MRI\PA0\ST0\SE12
   0015\dicom\MRI\PA0\ST0\SE13
   - В них должно быть по две серии.
2. Проверить серию 0059\dicom\MRI\Dicom\PAT0\STUDY0\SERIES14
   - В ней должна быть одна серия из 15 срезов.
