### PR TITLE
Поведение mitk::MouseModeSwitcher и регистрация глобальных DisplayInteractors

### DIFF
--- a/Modules/Core/TestingHelper/src/mitkInteractionTestHelper.cpp
+++ b/Modules/Core/TestingHelper/src/mitkInteractionTestHelper.cpp
@@ -173,7 +173,7 @@ void mitk::InteractionTestHelper::Initialize(const std::string &interactionXmlFi
 
     //########### register display interactor to handle scroll events ##################
     //use MouseModeSwitcher to ensure that the statemachine of DisplayInteractor is loaded correctly
-    m_MouseModeSwitcher = mitk::MouseModeSwitcher::New();
+    m_MouseModeSwitcher = mitk::MouseModeSwitcher::New("InteractionTestHelper");
   }
   else
   {

--- a/Modules/Core/include/mitkMouseModeSwitcher.h
+++ b/Modules/Core/include/mitkMouseModeSwitcher.h
@@ -71,8 +71,8 @@ namespace mitk {
 #pragma GCC visibility pop
 
     mitkClassMacroItkParent( MouseModeSwitcher, itk::Object );
-    itkFactorylessNewMacro(Self)
-    itkCloneMacro(Self)
+    mitkNewMacro1Param(Self, const std::string&);
+    itkCloneMacro(Self);
 
     // enum of the different interaction schemes that are available
     enum InteractionScheme
@@ -115,13 +115,13 @@ namespace mitk {
     void SetSelectionMode(bool selection);
 
   protected:
-    MouseModeSwitcher();
+    MouseModeSwitcher(const std::string& rendererName = "");
     virtual ~MouseModeSwitcher();
   private:
     /**
     * \brief Initializes the listener with the MITK default behavior.
     */
-    void InitializeListeners();
+    void InitializeListeners(const std::string& rendererName);
 
     InteractionScheme m_ActiveInteractionScheme;
     MouseMode         m_ActiveMouseMode;

--- a/Modules/Core/src/Interactions/mitkMouseModeSwitcher.cpp
+++ b/Modules/Core/src/Interactions/mitkMouseModeSwitcher.cpp
@@ -21,10 +21,10 @@
 
 #include "mitkInteractionEventObserver.h"
 
-mitk::MouseModeSwitcher::MouseModeSwitcher() :
+mitk::MouseModeSwitcher::MouseModeSwitcher(const std::string& rendererName) :
     m_ActiveInteractionScheme(MITK), m_ActiveMouseMode(MousePointer), m_CurrentObserver(NULL)
 {
-  this->InitializeListeners();
+  this->InitializeListeners(rendererName);
   this->SetInteractionScheme(m_ActiveInteractionScheme);
 }
 
@@ -33,7 +33,7 @@ mitk::MouseModeSwitcher::~MouseModeSwitcher()
   m_ServiceRegistration.Unregister();
 }
 
-void mitk::MouseModeSwitcher::InitializeListeners()
+void mitk::MouseModeSwitcher::InitializeListeners(const std::string& rendererName)
 {
   if (m_CurrentObserver.IsNull())
   {
@@ -43,6 +43,9 @@ void mitk::MouseModeSwitcher::InitializeListeners()
     // Register as listener via micro services
     us::ServiceProperties props;
     props["name"] = std::string("DisplayInteractor");
+    if (!rendererName.empty()) {
+      props["rendererName"] = rendererName;
+    }
     m_ServiceRegistration = us::GetModuleContext()->RegisterService<InteractionEventObserver>(
         m_CurrentObserver.GetPointer(),props);
   }

--- a/Modules/QmlItems/src/QmlMitkStdMultiItem.cpp
+++ b/Modules/QmlItems/src/QmlMitkStdMultiItem.cpp
@@ -61,7 +61,7 @@ void QmlMitkStdMultiItem::init()
     if(QmlMitkStdMultiItem::storage.IsNull())
         QmlMitkStdMultiItem::storage = mitk::StandaloneDataStorage::New();
 
-    this->m_mouseMode = mitk::MouseModeSwitcher::New();
+    this->m_mouseMode = mitk::MouseModeSwitcher::New("QmlMitkStdMultiItem");
     this->m_mouseMode->SetInteractionScheme(mitk::MouseModeSwitcher::InteractionScheme::MITK);
 
     this->m_viewerAxial->SetDataStorage(QmlMitkStdMultiItem::storage);

--- a/Modules/QtWidgets/include/QmitkStdMultiWidget.h
+++ b/Modules/QtWidgets/include/QmitkStdMultiWidget.h
@@ -418,6 +418,9 @@ protected:
 
   bool m_PendingCrosshairPositionEvent;
   bool m_CrosshairNavigationEnabled;
+
+  QString m_Name;
+
   /**
    * @brief CreateCornerAnnotation helper method to create a corner annotation.
    * @param text of the annotation.

--- a/Modules/QtWidgets/src/QmitkStdMultiWidget.cpp
+++ b/Modules/QtWidgets/src/QmitkStdMultiWidget.cpp
@@ -74,7 +74,8 @@ QmitkStdMultiWidget::QmitkStdMultiWidget(QWidget* parent, Qt::WindowFlags f, mit
   m_CrosshairNavigationEnabled(false),
   m_drawTextInStatusBar(true),
   imageMTime(0),
-  m_displayMetaInfo(false)
+  m_displayMetaInfo(false),
+  m_Name(name)
 {
   /******************************************************
   * Use the global RenderingManager if none was specified
@@ -160,23 +161,23 @@ QmitkStdMultiWidget::QmitkStdMultiWidget(QWidget* parent, Qt::WindowFlags f, mit
   m_SubSplit2->addWidget( mitkWidget4Container );
 
   //Create RenderWindows 1
-  mitkWidget1 = new QmitkRenderWindow(mitkWidget1Container, name + ".widget1", NULL, m_RenderingManager,renderingMode);
+  mitkWidget1 = new QmitkRenderWindow(mitkWidget1Container, name, NULL, m_RenderingManager,renderingMode);
   mitkWidget1->SetLayoutIndex( AXIAL );
   mitkWidgetLayout1->addWidget(mitkWidget1);
 
   //Create RenderWindows 2
-  mitkWidget2 = new QmitkRenderWindow(mitkWidget2Container, name + ".widget2", NULL, m_RenderingManager,renderingMode);
+  mitkWidget2 = new QmitkRenderWindow(mitkWidget2Container, name, NULL, m_RenderingManager,renderingMode);
   mitkWidget2->setEnabled( true );
   mitkWidget2->SetLayoutIndex( SAGITTAL );
   mitkWidgetLayout2->addWidget(mitkWidget2);
 
   //Create RenderWindows 3
-  mitkWidget3 = new QmitkRenderWindow(mitkWidget3Container, name + ".widget3", NULL, m_RenderingManager,renderingMode);
+  mitkWidget3 = new QmitkRenderWindow(mitkWidget3Container, name, NULL, m_RenderingManager,renderingMode);
   mitkWidget3->SetLayoutIndex( CORONAL );
   mitkWidgetLayout3->addWidget(mitkWidget3);
 
   //Create RenderWindows 4
-  mitkWidget4 = new QmitkRenderWindow(mitkWidget4Container, name + ".widget4", NULL, m_RenderingManager,renderingMode);
+  mitkWidget4 = new QmitkRenderWindow(mitkWidget4Container, name, NULL, m_RenderingManager,renderingMode);
   mitkWidget4->SetLayoutIndex( THREE_D );
   mitkWidgetLayout4->addWidget(mitkWidget4);
 
@@ -326,7 +327,7 @@ void QmitkStdMultiWidget::InitializeWidget()
   //mitkWidget4->GetSliceNavigationController()
   //  ->ConnectGeometryTimeEvent(m_TimeNavigationController, false);
 
-  m_MouseModeSwitcher = mitk::MouseModeSwitcher::New();
+  m_MouseModeSwitcher = mitk::MouseModeSwitcher::New(m_Name.toStdString());
 
   mitkWidget1->GetSliceNavigationController()->crosshairPositionEvent.AddListener(mitk::MessageDelegate<QmitkStdMultiWidget>(this, &QmitkStdMultiWidget::HandleCrosshairPositionEvent));
   mitkWidget2->GetSliceNavigationController()->crosshairPositionEvent.AddListener(mitk::MessageDelegate<QmitkStdMultiWidget>(this, &QmitkStdMultiWidget::HandleCrosshairPositionEvent));


### PR DESCRIPTION
AUT-1046

Теперь mitk::MouseModeSwitcher, который является частью мультивиджета, регистрирует DisplayInteractors не глобально, а только для рендереров с именем, которое было передано ему в конструкторе.
Если имя пустое, то DisplayInteractor будет глобальным, как и прежде.

Так как mitk::MouseModeSwitcher принадлежит мультивиджету, а не отдельному окну внутри мультивиджета, из этого изменения следует, что все окна мультивиджета должны иметь одно и тоже имя (то, что мультивиджет использует для создания mitk::MouseModeSwitcher), чтобы DisplayInteractors для них работали. Это не должно привести к проблемам, но надо быть настороже.
