### PR TITLE
Проверка дайком-тэгов

### DIFF
--- a/Modules/Core/src/IO/mitkDicomSeriesReader.cpp
+++ b/Modules/Core/src/IO/mitkDicomSeriesReader.cpp
@@ -864,6 +864,15 @@ DicomSeriesReader::GetSeries(const StringContainer& files, bool sortTo3DPlust, b
     if ( std::string(fileIter->first).empty() ) continue; // TODO understand why Scanner has empty string entries
     if ( std::string(fileIter->first) == std::string("DICOMDIR") ) continue;
 
+    gdcm::Scanner::TagToValue& tagMap = const_cast<gdcm::Scanner::TagToValue&>(fileIter->second);
+    const char* seriesInstanceUid = tagMap[tagSeriesInstanceUID];
+    const char* imagePosition = tagMap[tagImagePositionPatient];
+    const char* imageOrientation = tagMap[tagImageOrientation];
+
+    if (!seriesInstanceUid || !imagePosition || !imageOrientation) {
+      continue;
+    }
+
     /* sort out multi-frame
     if ( scanner.GetValue( fileIter->first , tagNumberOfFrames ) )
     {


### PR DESCRIPTION
AUT-1084

Перенес проверку дайком-тэгов из Автоплана в МИТК.
Это позволяет сэкономить немного времени на запуске gdcm-сканнера (теперь он запускается только один раз, в МИТК).
