### PR TITLE
Увеличен допуск расстояния между срезами при сортировке серий

### DIFF
--- a/Modules/Core/include/mitkDicomSeriesReader.h
+++ b/Modules/Core/include/mitkDicomSeriesReader.h
@@ -404,6 +404,9 @@ public:
       // Image orientation
       std::string GetOrientation() const;
 
+      // Contains bad slicing distance or not
+      bool IsBadSlicingDistance() const;
+
       ImageBlockDescriptor();
       ~ImageBlockDescriptor();
 
@@ -437,6 +440,8 @@ public:
 
       void SetOrientation(std::string orientation);
 
+      void SetBadSlicingDistance(bool badSlicingDistance);
+      
       StringContainer m_Filenames;
       std::string m_ImageBlockUID;
       std::string m_SeriesInstanceUID;
@@ -448,6 +453,7 @@ public:
       bool m_HasMultipleTimePoints;
       bool m_IsMultiFrameImage;
       std::string m_Orientation;
+      bool m_BadSlicingDistance;
   };
 
   typedef std::map<std::string, ImageBlockDescriptor> FileNamesGrouping;
@@ -596,6 +602,11 @@ protected:
       bool ContainsGantryTilt();
 
       /**
+      \brief Wheter or not the grouped result contain unexpected distance between slices.
+      */
+      bool ContainsBadSlicingDistance();
+
+      /**
         \brief Meant for internal use by AnalyzeFileForITKImageSeriesReaderSpacingAssumption only.
       */
       void AddFileToSortedBlock(const std::string& filename);
@@ -617,12 +628,18 @@ protected:
       */
       void UndoPrematureGrouping();
 
+      /**
+        \brief Meant for internal use by AnalyzeFileForITKImageSeriesReaderSpacingAssumption only.
+      */
+      void FlagBadSlicingDistance();
+
     protected:
 
       StringContainer m_GroupedFiles;
       StringContainer m_UnsortedFiles;
 
       bool m_GantryTilt;
+      bool m_BadSlicingDistance;
   };
 
   /**

--- a/Modules/Core/src/IO/mitkDicomSR_ImageBlockDescriptor.cpp
+++ b/Modules/Core/src/IO/mitkDicomSR_ImageBlockDescriptor.cpp
@@ -24,7 +24,8 @@ namespace mitk
 DicomSeriesReader::ImageBlockDescriptor::ImageBlockDescriptor()
 :m_HasGantryTiltCorrected(false)
 ,m_HasMultipleTimePoints(false)
-,m_IsMultiFrameImage(false)
+,m_IsMultiFrameImage(false),
+m_BadSlicingDistance(false)
 {
 }
 
@@ -36,7 +37,8 @@ DicomSeriesReader::ImageBlockDescriptor::~ImageBlockDescriptor()
 DicomSeriesReader::ImageBlockDescriptor::ImageBlockDescriptor(const StringContainer& files)
 :m_HasGantryTiltCorrected(false)
 ,m_HasMultipleTimePoints(false)
-,m_IsMultiFrameImage(false)
+,m_IsMultiFrameImage(false),
+m_BadSlicingDistance(false)
 {
   m_Filenames = files;
 }
@@ -247,6 +249,16 @@ std::string DicomSeriesReader::ImageBlockDescriptor::GetOrientation() const
 void DicomSeriesReader::ImageBlockDescriptor::SetOrientation(std::string orientation)
 {
   m_Orientation = orientation;
+}
+
+bool DicomSeriesReader::ImageBlockDescriptor::IsBadSlicingDistance() const
+{
+  return m_BadSlicingDistance;
+}
+
+void DicomSeriesReader::ImageBlockDescriptor::SetBadSlicingDistance(bool badSlicingDistance)
+{
+  m_BadSlicingDistance = badSlicingDistance;
 }
 
 } // end namespace mitk

--- a/Modules/Core/src/IO/mitkDicomSR_SliceGroupingResult.cpp
+++ b/Modules/Core/src/IO/mitkDicomSR_SliceGroupingResult.cpp
@@ -20,7 +20,8 @@ namespace mitk
 {
 
 DicomSeriesReader::SliceGroupingAnalysisResult::SliceGroupingAnalysisResult()
-:m_GantryTilt(false)
+  : m_GantryTilt(false),
+    m_BadSlicingDistance(false)
 {
 }
 
@@ -37,6 +38,11 @@ DicomSeriesReader::StringContainer DicomSeriesReader::SliceGroupingAnalysisResul
 bool DicomSeriesReader::SliceGroupingAnalysisResult::ContainsGantryTilt()
 {
   return m_GantryTilt;
+}
+
+bool DicomSeriesReader::SliceGroupingAnalysisResult::ContainsBadSlicingDistance()
+{
+  return m_BadSlicingDistance;
 }
 
 void DicomSeriesReader::SliceGroupingAnalysisResult::AddFileToSortedBlock(const std::string& filename)
@@ -57,6 +63,11 @@ void DicomSeriesReader::SliceGroupingAnalysisResult::AddFilesToUnsortedBlock(con
 void DicomSeriesReader::SliceGroupingAnalysisResult::FlagGantryTilt()
 {
   m_GantryTilt = true;
+}
+
+void DicomSeriesReader::SliceGroupingAnalysisResult::FlagBadSlicingDistance()
+{
+  m_BadSlicingDistance = true;
 }
 
 void DicomSeriesReader::SliceGroupingAnalysisResult::UndoPrematureGrouping()

--- a/Modules/Core/src/IO/mitkDicomSeriesReader.cpp
+++ b/Modules/Core/src/IO/mitkDicomSeriesReader.cpp
@@ -717,14 +717,21 @@ DicomSeriesReader::AnalyzeFileForITKImageSeriesReaderSpacingAssumption(
         Point3D assumedOrigin = lastDifferentOrigin + fromFirstToSecondOrigin;
 
         Vector3D originError = assumedOrigin - thisOrigin;
+        double expectedDistance = fromFirstToSecondOrigin.GetNorm();
         double norm = originError.GetNorm();
-        double toleratedError(0.005); // max. 1/10mm error when measurement crosses 20 slices in z direction
 
-        if (norm > toleratedError)
+        double toleratedError(0.005);  // Error below this value is ignored
+        double toleratedErrorWithWarning(expectedDistance * 10.0);  // Error below this value is reported but slices are still combined
+
+        if (toleratedError < norm && norm < toleratedErrorWithWarning) {
+          result.FlagBadSlicingDistance();
+        }
+
+        if (norm > toleratedErrorWithWarning)
         {
           MITK_DEBUG << "  File does not fit into the inter-slice distance pattern (diff = "
                                << norm << ", allowed "
-                               << toleratedError << ").";
+                               << toleratedErrorWithWarning << ").";
           MITK_DEBUG << "  Expected position (" << assumedOrigin[0] << ","
                                             << assumedOrigin[1] << ","
                                             << assumedOrigin[2] << "), got position ("
@@ -939,6 +946,7 @@ DicomSeriesReader::GetSeries(const StringContainer& files, bool sortTo3DPlust, b
                                             DicomSeriesReader::ConstCharStarToString( scanner.GetValue( firstFileInBlock.c_str(), tagImagerPixelSpacing ) ) );
       thisBlock.SetHasMultipleTimePoints( false );
       thisBlock.SetOrientation(DicomSeriesReader::ConstCharStarToString(scanner.GetValue(firstFileInBlock.c_str(), tagImageOrientation)));
+      thisBlock.SetBadSlicingDistance(analysisResult.ContainsBadSlicingDistance());
 
       groupsOf3DBlocks[ newGroupUID.str() ] = thisBlock;
 


### PR DESCRIPTION
AUT-1086

Теперь при нерегулярном интервале между срезами срезы все равно будут объединяться в серию, если ошибка не превышает 10 \* ожидаемое расстояние.
При этом выставляется флаг m_BadSlicingDistance.
