### PR TITLE
Возможность привязывать несколько окон с разными именами к MouseModeSwitcher

### DIFF
--- a/Modules/Core/include/mitkMouseModeSwitcher.h
+++ b/Modules/Core/include/mitkMouseModeSwitcher.h
@@ -114,24 +114,26 @@ namespace mitk {
     */
     void SetSelectionMode(bool selection);
 
+    /**
+    * \brief Initializes the listener with the MITK default behavior.
+    */
+    void AddRenderer(const std::string& rendererName);
+
   protected:
     MouseModeSwitcher(const std::string& rendererName = "");
     virtual ~MouseModeSwitcher();
   private:
-    /**
-    * \brief Initializes the listener with the MITK default behavior.
-    */
-    void InitializeListeners(const std::string& rendererName);
 
     InteractionScheme m_ActiveInteractionScheme;
     MouseMode         m_ActiveMouseMode;
-    DisplayInteractor::Pointer m_CurrentObserver;
+
+    std::vector<DisplayInteractor::Pointer> m_Observers;
 
     /**
      * Reference to the service registration of the observer,
      * it is needed to unregister the observer on unload.
      */
-    us::ServiceRegistration<InteractionEventObserver> m_ServiceRegistration;
+    std::vector<us::ServiceRegistration<InteractionEventObserver>> m_ServiceRegistrations;
   };
 } // namespace mitk
 

--- a/Modules/QtWidgets/src/QmitkStdMultiWidget.cpp
+++ b/Modules/QtWidgets/src/QmitkStdMultiWidget.cpp
@@ -161,23 +161,23 @@ QmitkStdMultiWidget::QmitkStdMultiWidget(QWidget* parent, Qt::WindowFlags f, mit
   m_SubSplit2->addWidget( mitkWidget4Container );
 
   //Create RenderWindows 1
-  mitkWidget1 = new QmitkRenderWindow(mitkWidget1Container, name, NULL, m_RenderingManager,renderingMode);
+  mitkWidget1 = new QmitkRenderWindow(mitkWidget1Container, name + ".widget1", NULL, m_RenderingManager, renderingMode);
   mitkWidget1->SetLayoutIndex( AXIAL );
   mitkWidgetLayout1->addWidget(mitkWidget1);
 
   //Create RenderWindows 2
-  mitkWidget2 = new QmitkRenderWindow(mitkWidget2Container, name, NULL, m_RenderingManager,renderingMode);
+  mitkWidget2 = new QmitkRenderWindow(mitkWidget2Container, name + ".widget2", NULL, m_RenderingManager, renderingMode);
   mitkWidget2->setEnabled( true );
   mitkWidget2->SetLayoutIndex( SAGITTAL );
   mitkWidgetLayout2->addWidget(mitkWidget2);
 
   //Create RenderWindows 3
-  mitkWidget3 = new QmitkRenderWindow(mitkWidget3Container, name, NULL, m_RenderingManager,renderingMode);
+  mitkWidget3 = new QmitkRenderWindow(mitkWidget3Container, name + ".widget3", NULL, m_RenderingManager, renderingMode);
   mitkWidget3->SetLayoutIndex( CORONAL );
   mitkWidgetLayout3->addWidget(mitkWidget3);
 
   //Create RenderWindows 4
-  mitkWidget4 = new QmitkRenderWindow(mitkWidget4Container, name, NULL, m_RenderingManager,renderingMode);
+  mitkWidget4 = new QmitkRenderWindow(mitkWidget4Container, name + ".widget4", NULL, m_RenderingManager, renderingMode);
   mitkWidget4->SetLayoutIndex( THREE_D );
   mitkWidgetLayout4->addWidget(mitkWidget4);
 
@@ -327,7 +327,10 @@ void QmitkStdMultiWidget::InitializeWidget()
   //mitkWidget4->GetSliceNavigationController()
   //  ->ConnectGeometryTimeEvent(m_TimeNavigationController, false);
 
-  m_MouseModeSwitcher = mitk::MouseModeSwitcher::New(m_Name.toStdString());
+  m_MouseModeSwitcher = mitk::MouseModeSwitcher::New(mitkWidget1->GetRenderer()->GetName());
+  m_MouseModeSwitcher->AddRenderer(mitkWidget2->GetRenderer()->GetName());
+  m_MouseModeSwitcher->AddRenderer(mitkWidget3->GetRenderer()->GetName());
+  m_MouseModeSwitcher->AddRenderer(mitkWidget4->GetRenderer()->GetName());
 
   mitkWidget1->GetSliceNavigationController()->crosshairPositionEvent.AddListener(mitk::MessageDelegate<QmitkStdMultiWidget>(this, &QmitkStdMultiWidget::HandleCrosshairPositionEvent));
   mitkWidget2->GetSliceNavigationController()->crosshairPositionEvent.AddListener(mitk::MessageDelegate<QmitkStdMultiWidget>(this, &QmitkStdMultiWidget::HandleCrosshairPositionEvent));


### PR DESCRIPTION
AUT-1107

Crosshair в мультивиджете вьювера пропал из-за того, что у всех окон мультивиджета были одинаковые имена. Это было необходимо, чтобы привязать к ним MouseModeSwitcher.

Теперь к MouseModeSwitcher'е может быть привязано сразу несколько имен рендереров, поэтому у окон мультивиджета снова разные имена и crosshair вернулся.

Тестовые шаги:
1. Загрузить серию.
   - Проверить, что мышка работает во вьювере.
   - Проверить, что мышка работает в мультивиджете вьювера.
   - Проверить, что в мультивиджете есть crosshair (прицел из зеленых, синих, красных плоскостей)
2. Открыть универсальный кейс.
   - Проверить, что мышка работает в мультивиджете универсального кейса.
