### PR TITLE
Краш при отрисовке фигур на другом изображении

### DIFF
--- a/Modules/PlanarFigure/src/DataManagement/mitkPlanarCircle.cpp
+++ b/Modules/PlanarFigure/src/DataManagement/mitkPlanarCircle.cpp
@@ -171,6 +171,8 @@ mitk::PlanarCircle::MeasurementStatistics* mitk::PlanarCircle::EvaluateStatistic
         ImageType3D::Pointer itkImage;
         mitk::CastToItkImage(image, itkImage);
 
+        BoundingBox::BoundsArrayType bounds = this->GetPlaneGeometry()->GetBounds();
+
         ImageType3D::IndexType currentIndex;
         currentIndex[Z] = centerIndex[Z];
 
@@ -196,6 +198,16 @@ mitk::PlanarCircle::MeasurementStatistics* mitk::PlanarCircle::EvaluateStatistic
           currentIndex[Y] = centerIndex[Y];
           for (int rowX = lIndex; rowX <= rIndex; rowX++) {
             currentIndex[X] = rowX;
+
+            if  (currentIndex[X] <= bounds[0]
+              || currentIndex[X] >= bounds[1]
+              || currentIndex[Y] <= bounds[0]
+              || currentIndex[Y] >= bounds[1]
+              || currentIndex[Z] <= bounds[2]
+              || currentIndex[Z] >= bounds[3]) {
+              return nullptr;
+            }
+
             short val = itkImage->GetPixel(currentIndex);
             values.push_back(val);
             if (val < minValue) {
@@ -230,7 +242,7 @@ mitk::PlanarCircle::MeasurementStatistics* mitk::PlanarCircle::EvaluateStatistic
       }
     }
   }
-  return NULL;
+  return nullptr;
 }
 
 std::string mitk::PlanarCircle::EvaluateAnnotation()


### PR DESCRIPTION
AUT-1053, AUT-1054

Проблема в том, что у фигуры может быть одно родительское изображение, но рисовать ее можно на другом изображении.
При этом при подсчете статистики внутри круга код пытался взять пиксели из родительского изображения, использую в качестве опорной точки изображение из рендерера.
Если изображения находятся далеко друг от друга, это приводит к крашу (потому что у родительского изображения нет пикселя с таким индексом).

Тестовые шаги:
1. Загрузить два набора данных от разных пациентов.
2. Перейти на классический кейс.
3. В менеджере сегментаций выбрать одну из серий.
4. В менеджере данных перетащить другую серию на первое место и сделать ее видимой.
5. Добавить круг, нарисовать его на мультивиджете.
   - Проверить, что круг рисуется, но статистики у него нет (ее не будет, если пациенты достаточно далеки друг от друга в пространстве).
6. Создать еще несколько кругов в разных позициях.
   - Проверить, что Автоплан не падает.
