### PR TITLE
Краш из-за проблем в view coordinator.

### DIFF
--- a/Plugins/org.mitk.gui.qt.common/src/internal/QmitkViewCoordinator.cpp
+++ b/Plugins/org.mitk.gui.qt.common/src/internal/QmitkViewCoordinator.cpp
@@ -106,6 +106,18 @@ void QmitkViewCoordinator::PartDeactivated(const berry::IWorkbenchPartReference:
   //MITK_INFO << "*** PartDeactivated (" << partRef->GetPart(false)->GetPartName() << ")";
   berry::IWorkbenchPart* part = partRef->GetPart(false).GetPointer();
 
+  // Check for a render window part and inform IRenderWindowPartListener views
+  // that it was deactivated
+  if (mitk::IRenderWindowPart* renderPart = dynamic_cast<mitk::IRenderWindowPart*>(part))
+  {
+    if (m_ActiveRenderWindowPart == renderPart)
+    {
+      RenderWindowPartDeactivated(renderPart);
+      m_ActiveRenderWindowPart = nullptr;
+      m_VisibleRenderWindowPart = nullptr;
+    }
+  }
+
   if (mitk::ILifecycleAwarePart* lifecycleAwarePart = dynamic_cast<mitk::ILifecycleAwarePart*>(part))
   {
     lifecycleAwarePart->Deactivated();


### PR DESCRIPTION
AUT-1168

Класс QmitkViewCoordinator слушает изменения в berryPart и рассказывает о них своим слушателям.
У него есть две переменных:
  m_ActiveRenderWindowPart;
  m_VisibleRenderWindowPart;

Если активная part не равна нули, то события visible и hidden игнорируются.
Проблема в том, что как только какая-то part стала активной, она остается такой навсегда из-за проблем в коде, пока ее не перепишет другая активная part, m_ActiveRenderWindowPart не сбрасывается при событии PartDeactivated().

Дальше из-за этого не обновляются указатели на мультивиджет в плагинах, и происходит краш при обращении по невалидному указателю.

Теперь m_ActiveRenderWindowPart будет корректно сбрасываться.

Тестовые шаги:
1. Загрузить данные в классический кейс.
2. Перейти в кейс проекции переломов.
3. Вернуться в классический кейс.
4. Закрыть мультивиджет.
5. Вернуться на начальный экран и загрузить данные в классический кейс снова.
6. Повторить шаги 4-5 несколько раз.
   - Краша нет.
