### PR TITLE
Планарные фигуры и расчет геометрии #2

### DIFF
--- a/Modules/PlanarFigure/include/mitkPlanarFigure.h
+++ b/Modules/PlanarFigure/include/mitkPlanarFigure.h
@@ -91,6 +91,8 @@ public:
    * displayed/interacted with). */
   virtual bool IsPlaced() const { return m_FigurePlaced; };
 
+  /** \brief Handle not placed planar figures as empty */
+  virtual bool IsEmpty() const { return !IsPlaced(); };
 
   /** \brief Place figure at the given point (in 2D index coordinates) onto
    * the given 2D geometry.

--- a/Plugins/org.mitk.gui.qt.diffusionimaging/src/internal/QmitkFiberProcessingView.cpp
+++ b/Plugins/org.mitk.gui.qt.diffusionimaging/src/internal/QmitkFiberProcessingView.cpp
@@ -1071,7 +1071,6 @@ void QmitkFiberProcessingView::AddFigureToDataStorage(mitk::PlanarFigure* figure
     newNode->SetData(figure);
     newNode->SetBoolProperty("planarfigure.3drendering", true);
     newNode->SetBoolProperty("planarfigure.3drendering.fill", true);
-    newNode->SetBoolProperty("includeInBoundingBox", false);
 
     mitk::PlanarFigureInteractor::Pointer figureInteractor = dynamic_cast<mitk::PlanarFigureInteractor*>(newNode->GetDataInteractor().GetPointer());
     if(figureInteractor.IsNull())

--- a/Plugins/org.mitk.gui.qt.diffusionimaging/src/internal/QmitkPartialVolumeAnalysisView.cpp
+++ b/Plugins/org.mitk.gui.qt.diffusionimaging/src/internal/QmitkPartialVolumeAnalysisView.cpp
@@ -543,7 +543,6 @@ void QmitkPartialVolumeAnalysisView::AddFigureToDataStorage(mitk::PlanarFigure* 
     mitk::DataNode::Pointer newNode = mitk::DataNode::New();
     newNode->SetName(name.toStdString());
     newNode->SetData(figure);
-    newNode->SetBoolProperty("includeInBoundingBox", false);
 
     // Add custom property, if available
     if ( (propertyKey != NULL) && (property != NULL) )

--- a/Plugins/org.mitk.gui.qt.measurementtoolbox/src/internal/QmitkMeasurementView.cpp
+++ b/Plugins/org.mitk.gui.qt.measurementtoolbox/src/internal/QmitkMeasurementView.cpp
@@ -864,7 +864,6 @@ mitk::DataNode::Pointer QmitkMeasurementView::AddFigureToDataStorage(mitk::Plana
   newNode->SetName(name.toStdString());
   newNode->SetData(figure);
   newNode->SetSelected(true);
-  newNode->SetBoolProperty("includeInBoundingBox", false);
 
   if (d->m_SelectedImageNode.IsNotNull())
   {


### PR DESCRIPTION
AUT-1179

Нет необходимости устанавливать свойство "includeInBoundingBox" в false у планарных фигур.
Достаточно переопределить IsEmpty() и возвращать true, если фигура еще не размещена.

Тестовые шаги в AUT-1179.
