### PR TITLE
Picking и его цвет

### DIFF
--- a/Modules/Segmentation/Interactions/mitkPickingTool.cpp
+++ b/Modules/Segmentation/Interactions/mitkPickingTool.cpp
@@ -63,7 +63,6 @@ mitk::PickingTool::PickingTool()
   // set some properties
   m_ResultNode->SetProperty("name", mitk::StringProperty::New("result"));
   m_ResultNode->SetProperty("helper object", mitk::BoolProperty::New(true));
-  m_ResultNode->SetProperty("color", mitk::ColorProperty::New(0, 1, 0));
   m_ResultNode->SetProperty("layer", mitk::IntProperty::New(1));
   m_ResultNode->SetProperty("opacity", mitk::FloatProperty::New(0.33f));
 }
@@ -179,6 +178,7 @@ void mitk::PickingTool::OnPointAdded()
     {
       AccessByItk_2(orgImage, StartRegionGrowing, orgImage->GetGeometry(), seedPoint);
     }
+    m_ResultNode->SetProperty("color", mitk::ColorProperty::New(1, 1, 0));
     this->m_PointSet->Clear();
   }
 }

--- a/Plugins/org.mitk.gui.qt.measurementtoolbox/src/internal/QmitkMeasurementView.cpp
+++ b/Plugins/org.mitk.gui.qt.measurementtoolbox/src/internal/QmitkMeasurementView.cpp
@@ -463,10 +463,12 @@ void QmitkMeasurementView::NodeRemoved(const mitk::DataNode* node)
       this->PlanarFigureInitialized(); // normally called when a figure is finished, to reset all buttons
 
     d->m_DataNodeToPlanarFigureData.erase( it );
+
+    if (nonConstNode != nullptr) {
+      nonConstNode->SetDataInteractor(nullptr);
+    }
   }
 
-  if (nonConstNode != nullptr)
-    nonConstNode->SetDataInteractor(nullptr);
 
   auto isPlanarFigure = mitk::TNodePredicateDataType<mitk::PlanarFigure>::New();
   auto nodes = this->GetDataStorage()->GetDerivations(node, isPlanarFigure);


### PR DESCRIPTION
AUT-1199

Обе проблемы есть в ванильном МИТК.

Во-первых, picking перестает работать, если его выключить и снова включить, потому что Measurement плагин (и еще наш код, который оттуда скопирован) удаляет интерактор из узла, который убирается из хранилища. А picking tool ожидает, что интерактор у узла останется нетронутым. 
Этот ПР решает проблему с плагином.
Отдельный ПР в Автоплан решит проблему с тулбаром инструментов позже.

Во-вторых, цвет picking'а после любого действия меняется на красный и начинает сливаться с самой сегментацией. Это происходит из-за того, что цвет данных перезаписывается mulitlabel image из region growing'а, где красный - цвет по умолчанию.
Я добавил установку цвета после генерации данных picking'а.

Тестовые шаги:
1. Загрузить данные в универсальный кейс, открыть плагин сегментаций.
2. Создать сегментацию, добавить туда две области инструментом Add.
3. Выбрать инструмент Picking.
4. Выбрать одну из областей.
   - У нее появилась желтая окантовка.
5. Выключить picking, включить его снова, выбрать область.
   - Picking работает как и раньше.
