### PR TITLE
Мультивиджет на стартовом экране #2

### DIFF
--- a/Plugins/org.mitk.gui.qt.datamanager/src/QmitkDataManagerView.cpp
+++ b/Plugins/org.mitk.gui.qt.datamanager/src/QmitkDataManagerView.cpp
@@ -984,9 +984,7 @@ void QmitkDataManagerView::NodeTreeViewRowsInserted( const QModelIndex & parent,
   m_NodeTreeView->setExpanded(viewIndex, true);
 
   // a new row was inserted
-  if( m_CurrentRowCount == 0 && m_NodeTreeModel->rowCount() == 1 )
-  {
-    this->OpenRenderWindowPart();
+  if (m_CurrentRowCount == 0 && m_NodeTreeModel->rowCount() == 1) {
     m_CurrentRowCount = m_NodeTreeModel->rowCount();
   }
 }

--- a/Plugins/org.mitk.gui.qt.datamanager/src/QmitkDataManagerView.cpp
+++ b/Plugins/org.mitk.gui.qt.datamanager/src/QmitkDataManagerView.cpp
@@ -984,7 +984,9 @@ void QmitkDataManagerView::NodeTreeViewRowsInserted( const QModelIndex & parent,
   m_NodeTreeView->setExpanded(viewIndex, true);
 
   // a new row was inserted
-  if (m_CurrentRowCount == 0 && m_NodeTreeModel->rowCount() == 1) {
+  if( m_CurrentRowCount == 0 && m_NodeTreeModel->rowCount() == 1 )
+  {
+    this->OpenRenderWindowPart();
     m_CurrentRowCount = m_NodeTreeModel->rowCount();
   }
 }
@@ -1035,10 +1037,10 @@ mitk::IRenderWindowPart* QmitkDataManagerView::OpenRenderWindowPart(bool activat
 {
   if (activatedEditor)
   {
-    return this->GetRenderWindowPart(QmitkAbstractView::ACTIVATE | QmitkAbstractView::OPEN);
+    return this->GetRenderWindowPart(QmitkAbstractView::ACTIVATE);
   }
   else
   {
-    return this->GetRenderWindowPart(QmitkAbstractView::BRING_TO_FRONT | QmitkAbstractView::OPEN);
+    return this->GetRenderWindowPart(QmitkAbstractView::BRING_TO_FRONT);
   }
 }


### PR DESCRIPTION
AUT-1010

Мультивиджет на стартовом экране появлялся из-за менеджера данных.
Менеджер данных открывал редактор при добавлении первого узла в дерево.
Но узел добавлялся в хранилище еще на стартовом экране, так что и редактор открывался на стартовом экране.
Нам эта функциональность не нужна, потому что за доступностью редактора следит универсальный кейс.

В других плагинах такой проблемы нет.

Тестовые шаги:
1. Загрузить данные в универсальный кейс.
2. Активировать менеджер данных.
3. Всё закрыть.
4. Открыть данные снова.
   - Проверить, что на стартовом экране нет мультивиджета.
