### PR TITLE
Заливка 2D интерполяций

### DIFF
--- a/Modules/Core/include/mitkImageVtkMapper2D.h
+++ b/Modules/Core/include/mitkImageVtkMapper2D.h
@@ -237,6 +237,7 @@ protected:
       \param renderer: Pointer to the renderer containing the needed information
       \note This code is based on code from the iil library.
       */
+  template<typename PixelType>
   vtkSmartPointer<vtkPolyData> CreateOutlinePolyData(mitk::BaseRenderer* renderer);
 
   /** Default constructor */
@@ -302,6 +303,9 @@ protected:
   bool RenderingGeometryIntersectsImage( const PlaneGeometry* renderingGeometry, SlicedGeometry3D* imageGeometry );
 };
 
+
 } // namespace mitk
+
+#include "mitkImageVtkMapper2D.txx"
 
 #endif /* MITKIMAGEVTKMAPPER2D_H_HEADER_INCLUDED_C10E906E */

--- a/Modules/Core/include/mitkImageVtkMapper2D.txx
+++ b/Modules/Core/include/mitkImageVtkMapper2D.txx
@@ -1,0 +1,148 @@
+#pragma once
+
+namespace mitk
+{
+
+template <typename PixelType>
+vtkSmartPointer<vtkPolyData> mitk::ImageVtkMapper2D::CreateOutlinePolyData(mitk::BaseRenderer* renderer ){
+  LocalStorage* localStorage = this->GetLocalStorage(renderer);
+
+  //get the min and max index values of each direction
+  int* extent = localStorage->m_ReslicedImage->GetExtent();
+  int xMin = extent[0];
+  int xMax = extent[1];
+  int yMin = extent[2];
+  int yMax = extent[3];
+
+  int* dims = localStorage->m_ReslicedImage->GetDimensions(); //dimensions of the image
+  int line = dims[0]; //how many pixels per line?
+  int x = xMin; //pixel index x
+  int y = yMin; //pixel index y
+
+  //get the depth for each contour
+  float depth = CalculateLayerDepth(renderer);
+
+  vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New(); //the points to draw
+  vtkSmartPointer<vtkCellArray> lines = vtkSmartPointer<vtkCellArray>::New(); //the lines to connect the points
+
+  // We take the pointer to the first pixel of the image
+  auto currentPixel = static_cast<PixelType*>(localStorage->m_ReslicedImage->GetScalarPointer());
+
+  while (y <= yMax)
+  {
+    //if the current pixel value is set to something
+    if ((currentPixel) && (*currentPixel != 0))
+    {
+      //check in which direction a line is necessary
+      //a line is added if the neighbor of the current pixel has the value 0
+      //and if the pixel is located at the edge of the image
+
+      //if   vvvvv  not the first line vvvvv
+      if (y > yMin && *(currentPixel-line) == 0)
+      { //x direction - bottom edge of the pixel
+        //add the 2 points
+        vtkIdType p1 = points->InsertNextPoint(x*localStorage->m_mmPerPixel[0], y*localStorage->m_mmPerPixel[1], depth);
+        vtkIdType p2 = points->InsertNextPoint((x+1)*localStorage->m_mmPerPixel[0], y*localStorage->m_mmPerPixel[1], depth);
+        //add the line between both points
+        lines->InsertNextCell(2);
+        lines->InsertCellPoint(p1);
+        lines->InsertCellPoint(p2);
+      }
+
+      //if   vvvvv  not the last line vvvvv
+      if (y < yMax && *(currentPixel+line) == 0)
+      { //x direction - top edge of the pixel
+        vtkIdType p1 = points->InsertNextPoint(x*localStorage->m_mmPerPixel[0], (y+1)*localStorage->m_mmPerPixel[1], depth);
+        vtkIdType p2 = points->InsertNextPoint((x+1)*localStorage->m_mmPerPixel[0], (y+1)*localStorage->m_mmPerPixel[1], depth);
+        lines->InsertNextCell(2);
+        lines->InsertCellPoint(p1);
+        lines->InsertCellPoint(p2);
+      }
+
+      //if   vvvvv  not the first pixel vvvvv
+      if ( (x > xMin || y > yMin) && *(currentPixel-1) == 0)
+      { //y direction - left edge of the pixel
+        vtkIdType p1 = points->InsertNextPoint(x*localStorage->m_mmPerPixel[0], y*localStorage->m_mmPerPixel[1], depth);
+        vtkIdType p2 = points->InsertNextPoint(x*localStorage->m_mmPerPixel[0], (y+1)*localStorage->m_mmPerPixel[1], depth);
+        lines->InsertNextCell(2);
+        lines->InsertCellPoint(p1);
+        lines->InsertCellPoint(p2);
+      }
+
+      //if   vvvvv  not the last pixel vvvvv
+      if ( (y < yMax || (x < xMax) ) && *(currentPixel+1) == 0)
+      { //y direction - right edge of the pixel
+        vtkIdType p1 = points->InsertNextPoint((x+1)*localStorage->m_mmPerPixel[0], y*localStorage->m_mmPerPixel[1], depth);
+        vtkIdType p2 = points->InsertNextPoint((x+1)*localStorage->m_mmPerPixel[0], (y+1)*localStorage->m_mmPerPixel[1], depth);
+        lines->InsertNextCell(2);
+        lines->InsertCellPoint(p1);
+        lines->InsertCellPoint(p2);
+      }
+
+      /*  now consider pixels at the edge of the image  */
+
+      //if   vvvvv  left edge of image vvvvv
+      if (x == xMin)
+      { //draw left edge of the pixel
+        vtkIdType p1 = points->InsertNextPoint(x*localStorage->m_mmPerPixel[0], y*localStorage->m_mmPerPixel[1], depth);
+        vtkIdType p2 = points->InsertNextPoint(x*localStorage->m_mmPerPixel[0], (y+1)*localStorage->m_mmPerPixel[1], depth);
+        lines->InsertNextCell(2);
+        lines->InsertCellPoint(p1);
+        lines->InsertCellPoint(p2);
+      }
+
+      //if   vvvvv  right edge of image vvvvv
+      if (x == xMax)
+      { //draw right edge of the pixel
+        vtkIdType p1 = points->InsertNextPoint((x+1)*localStorage->m_mmPerPixel[0], y*localStorage->m_mmPerPixel[1], depth);
+        vtkIdType p2 = points->InsertNextPoint((x+1)*localStorage->m_mmPerPixel[0], (y+1)*localStorage->m_mmPerPixel[1], depth);
+        lines->InsertNextCell(2);
+        lines->InsertCellPoint(p1);
+        lines->InsertCellPoint(p2);
+      }
+
+      //if   vvvvv  bottom edge of image vvvvv
+      if (y == yMin)
+      { //draw bottom edge of the pixel
+        vtkIdType p1 = points->InsertNextPoint(x*localStorage->m_mmPerPixel[0], y*localStorage->m_mmPerPixel[1], depth);
+        vtkIdType p2 = points->InsertNextPoint((x+1)*localStorage->m_mmPerPixel[0], y*localStorage->m_mmPerPixel[1], depth);
+        lines->InsertNextCell(2);
+        lines->InsertCellPoint(p1);
+        lines->InsertCellPoint(p2);
+      }
+
+      //if   vvvvv  top edge of image vvvvv
+      if (y == yMax)
+      { //draw top edge of the pixel
+        vtkIdType p1 = points->InsertNextPoint(x*localStorage->m_mmPerPixel[0], (y+1)*localStorage->m_mmPerPixel[1], depth);
+        vtkIdType p2 = points->InsertNextPoint((x+1)*localStorage->m_mmPerPixel[0], (y+1)*localStorage->m_mmPerPixel[1], depth);
+        lines->InsertNextCell(2);
+        lines->InsertCellPoint(p1);
+        lines->InsertCellPoint(p2);
+      }
+    }//end if currentpixel is set
+
+    x++;
+
+    if (x > xMax)
+    { //reached end of line
+      x = xMin;
+      y++;
+    }
+
+    // Increase the pointer-position to the next pixel.
+    // This is safe, as the while-loop and the x-reset logic above makes
+    // sure we do not exceed the bounds of the image
+    currentPixel++;
+  }//end of while
+
+  // Create a polydata to store everything in
+  vtkSmartPointer<vtkPolyData> polyData = vtkSmartPointer<vtkPolyData>::New();
+  // Add the points to the dataset
+  polyData->SetPoints(points);
+  // Add the lines to the dataset
+  polyData->SetLines(lines);
+  return polyData;
+}
+
+}

--- a/Modules/Core/src/Rendering/mitkImageVtkMapper2D.cpp
+++ b/Modules/Core/src/Rendering/mitkImageVtkMapper2D.cpp
@@ -113,8 +113,6 @@ vtkProp* mitk::ImageVtkMapper2D::GetVtkProp(mitk::BaseRenderer* renderer)
   return m_LSH.GetLocalStorage(renderer)->m_Actors;
 }
 
-
-
 void mitk::ImageVtkMapper2D::GenerateDataForRenderer( mitk::BaseRenderer *renderer )
 {
   LocalStorage *localStorage = m_LSH.GetLocalStorage(renderer);
@@ -333,27 +331,36 @@ void mitk::ImageVtkMapper2D::GenerateDataForRenderer( mitk::BaseRenderer *render
     datanode->GetBoolProperty( "outline binary", binaryOutline, renderer );
     if(binaryOutline) //contour rendering
     {
-      if ( input->GetPixelType().GetBpe() <= 8 )
-      {
-        //generate contours/outlines
-        localStorage->m_OutlinePolyData = CreateOutlinePolyData(renderer);
+      //generate contours/outlines
+      bool supportedPixelType = true;
+      int componentType = input->GetPixelType().GetComponentType();
 
+      if (componentType == itk::ImageIOBase::CHAR) {
+        localStorage->m_OutlinePolyData = CreateOutlinePolyData<char>(renderer);
+      } else if (componentType == itk::ImageIOBase::USHORT) {
+        localStorage->m_OutlinePolyData = CreateOutlinePolyData<unsigned short>(renderer);
+      } else {
+        supportedPixelType = false;
+      }
+
+      if (supportedPixelType)
+      {
         float binaryOutlineWidth(1.0);
-        if ( datanode->GetFloatProperty( "outline width", binaryOutlineWidth, renderer ) )
+        if (datanode->GetFloatProperty("outline width", binaryOutlineWidth, renderer))
         {
-          if ( localStorage->m_Actors->GetNumberOfPaths() > 1 )
+          if (localStorage->m_Actors->GetNumberOfPaths() > 1)
           {
             float binaryOutlineShadowWidth(1.5);
-            datanode->GetFloatProperty( "outline shadow width", binaryOutlineShadowWidth, renderer );
+            datanode->GetFloatProperty("outline shadow width", binaryOutlineShadowWidth, renderer);
 
             dynamic_cast<vtkActor*>(localStorage->m_Actors->GetParts()->GetItemAsObject(0))
-                ->GetProperty()->SetLineWidth( binaryOutlineWidth * binaryOutlineShadowWidth );
+              ->GetProperty()->SetLineWidth(binaryOutlineWidth * binaryOutlineShadowWidth);
           }
 
-          localStorage->m_Actor->GetProperty()->SetLineWidth( binaryOutlineWidth );
+          localStorage->m_Actor->GetProperty()->SetLineWidth(binaryOutlineWidth);
         }
       }
-      else
+      else 
       {
         binaryOutline = false;
         this->ApplyLookuptable(renderer);
@@ -839,149 +846,6 @@ void mitk::ImageVtkMapper2D::SetDefaultProperties(mitk::DataNode* node, mitk::Ba
 mitk::ImageVtkMapper2D::LocalStorage* mitk::ImageVtkMapper2D::GetLocalStorage(mitk::BaseRenderer* renderer)
 {
   return m_LSH.GetLocalStorage(renderer);
-}
-
-vtkSmartPointer<vtkPolyData> mitk::ImageVtkMapper2D::CreateOutlinePolyData(mitk::BaseRenderer* renderer ){
-  LocalStorage* localStorage = this->GetLocalStorage(renderer);
-
-  //get the min and max index values of each direction
-  int* extent = localStorage->m_ReslicedImage->GetExtent();
-  int xMin = extent[0];
-  int xMax = extent[1];
-  int yMin = extent[2];
-  int yMax = extent[3];
-
-  int* dims = localStorage->m_ReslicedImage->GetDimensions(); //dimensions of the image
-  int line = dims[0]; //how many pixels per line?
-  int x = xMin; //pixel index x
-  int y = yMin; //pixel index y
-  char* currentPixel;
-
-
-  //get the depth for each contour
-  float depth = CalculateLayerDepth(renderer);
-
-  vtkSmartPointer<vtkPoints> points = vtkSmartPointer<vtkPoints>::New(); //the points to draw
-  vtkSmartPointer<vtkCellArray> lines = vtkSmartPointer<vtkCellArray>::New(); //the lines to connect the points
-
-  // We take the pointer to the first pixel of the image
-  currentPixel = static_cast<char*>(localStorage->m_ReslicedImage->GetScalarPointer() );
-
-  while (y <= yMax)
-  {
-    //if the current pixel value is set to something
-    if ((currentPixel) && (*currentPixel != 0))
-    {
-      //check in which direction a line is necessary
-      //a line is added if the neighbor of the current pixel has the value 0
-      //and if the pixel is located at the edge of the image
-
-      //if   vvvvv  not the first line vvvvv
-      if (y > yMin && *(currentPixel-line) == 0)
-      { //x direction - bottom edge of the pixel
-        //add the 2 points
-        vtkIdType p1 = points->InsertNextPoint(x*localStorage->m_mmPerPixel[0], y*localStorage->m_mmPerPixel[1], depth);
-        vtkIdType p2 = points->InsertNextPoint((x+1)*localStorage->m_mmPerPixel[0], y*localStorage->m_mmPerPixel[1], depth);
-        //add the line between both points
-        lines->InsertNextCell(2);
-        lines->InsertCellPoint(p1);
-        lines->InsertCellPoint(p2);
-      }
-
-      //if   vvvvv  not the last line vvvvv
-      if (y < yMax && *(currentPixel+line) == 0)
-      { //x direction - top edge of the pixel
-        vtkIdType p1 = points->InsertNextPoint(x*localStorage->m_mmPerPixel[0], (y+1)*localStorage->m_mmPerPixel[1], depth);
-        vtkIdType p2 = points->InsertNextPoint((x+1)*localStorage->m_mmPerPixel[0], (y+1)*localStorage->m_mmPerPixel[1], depth);
-        lines->InsertNextCell(2);
-        lines->InsertCellPoint(p1);
-        lines->InsertCellPoint(p2);
-      }
-
-      //if   vvvvv  not the first pixel vvvvv
-      if ( (x > xMin || y > yMin) && *(currentPixel-1) == 0)
-      { //y direction - left edge of the pixel
-        vtkIdType p1 = points->InsertNextPoint(x*localStorage->m_mmPerPixel[0], y*localStorage->m_mmPerPixel[1], depth);
-        vtkIdType p2 = points->InsertNextPoint(x*localStorage->m_mmPerPixel[0], (y+1)*localStorage->m_mmPerPixel[1], depth);
-        lines->InsertNextCell(2);
-        lines->InsertCellPoint(p1);
-        lines->InsertCellPoint(p2);
-      }
-
-      //if   vvvvv  not the last pixel vvvvv
-      if ( (y < yMax || (x < xMax) ) && *(currentPixel+1) == 0)
-      { //y direction - right edge of the pixel
-        vtkIdType p1 = points->InsertNextPoint((x+1)*localStorage->m_mmPerPixel[0], y*localStorage->m_mmPerPixel[1], depth);
-        vtkIdType p2 = points->InsertNextPoint((x+1)*localStorage->m_mmPerPixel[0], (y+1)*localStorage->m_mmPerPixel[1], depth);
-        lines->InsertNextCell(2);
-        lines->InsertCellPoint(p1);
-        lines->InsertCellPoint(p2);
-      }
-
-      /*  now consider pixels at the edge of the image  */
-
-      //if   vvvvv  left edge of image vvvvv
-      if (x == xMin)
-      { //draw left edge of the pixel
-        vtkIdType p1 = points->InsertNextPoint(x*localStorage->m_mmPerPixel[0], y*localStorage->m_mmPerPixel[1], depth);
-        vtkIdType p2 = points->InsertNextPoint(x*localStorage->m_mmPerPixel[0], (y+1)*localStorage->m_mmPerPixel[1], depth);
-        lines->InsertNextCell(2);
-        lines->InsertCellPoint(p1);
-        lines->InsertCellPoint(p2);
-      }
-
-      //if   vvvvv  right edge of image vvvvv
-      if (x == xMax)
-      { //draw right edge of the pixel
-        vtkIdType p1 = points->InsertNextPoint((x+1)*localStorage->m_mmPerPixel[0], y*localStorage->m_mmPerPixel[1], depth);
-        vtkIdType p2 = points->InsertNextPoint((x+1)*localStorage->m_mmPerPixel[0], (y+1)*localStorage->m_mmPerPixel[1], depth);
-        lines->InsertNextCell(2);
-        lines->InsertCellPoint(p1);
-        lines->InsertCellPoint(p2);
-      }
-
-      //if   vvvvv  bottom edge of image vvvvv
-      if (y == yMin)
-      { //draw bottom edge of the pixel
-        vtkIdType p1 = points->InsertNextPoint(x*localStorage->m_mmPerPixel[0], y*localStorage->m_mmPerPixel[1], depth);
-        vtkIdType p2 = points->InsertNextPoint((x+1)*localStorage->m_mmPerPixel[0], y*localStorage->m_mmPerPixel[1], depth);
-        lines->InsertNextCell(2);
-        lines->InsertCellPoint(p1);
-        lines->InsertCellPoint(p2);
-      }
-
-      //if   vvvvv  top edge of image vvvvv
-      if (y == yMax)
-      { //draw top edge of the pixel
-        vtkIdType p1 = points->InsertNextPoint(x*localStorage->m_mmPerPixel[0], (y+1)*localStorage->m_mmPerPixel[1], depth);
-        vtkIdType p2 = points->InsertNextPoint((x+1)*localStorage->m_mmPerPixel[0], (y+1)*localStorage->m_mmPerPixel[1], depth);
-        lines->InsertNextCell(2);
-        lines->InsertCellPoint(p1);
-        lines->InsertCellPoint(p2);
-      }
-    }//end if currentpixel is set
-
-    x++;
-
-    if (x > xMax)
-    { //reached end of line
-      x = xMin;
-      y++;
-    }
-
-    // Increase the pointer-position to the next pixel.
-    // This is safe, as the while-loop and the x-reset logic above makes
-    // sure we do not exceed the bounds of the image
-    currentPixel++;
-  }//end of while
-
-  // Create a polydata to store everything in
-  vtkSmartPointer<vtkPolyData> polyData = vtkSmartPointer<vtkPolyData>::New();
-  // Add the points to the dataset
-  polyData->SetPoints(points);
-  // Add the lines to the dataset
-  polyData->SetLines(lines);
-  return polyData;
 }
 
 void mitk::ImageVtkMapper2D::TransformActor(mitk::BaseRenderer* renderer)


### PR DESCRIPTION
AUT-1209

Проблема была в типе пикселей изображения интерполяции.
Так как исходное изображение являлось MultiLabelImage, у него тип пикселей был unsigned short.
Изображение интерполяции является обычным mitk::Image, но оно наследует тип пикселя от исходного изображения.

Но алгоритм из mitk::ImageVtkMapper2D, который создает границу сегментации, работает только с типом пикселями char. Он отказывался создавать границу, и маппер использовал заливку.

Я поправил алгоритм, теперь он работает и с char, и с unsigned short.

Тестовые шаги:
1. Загрузить данные в универсальный кейс.
2. Создать сегментацию.
3. Добавить туда области на нескольких срезах.
4. Включить 2D-интерполяцию.
   - Проверить, что временная область 2D-интерполяции не залита.
