### PR TITLE
Поддержка unsigned char и short пикселей в маппере.

### DIFF
--- a/Modules/Core/src/Rendering/mitkImageVtkMapper2D.cpp
+++ b/Modules/Core/src/Rendering/mitkImageVtkMapper2D.cpp
@@ -337,9 +337,13 @@ void mitk::ImageVtkMapper2D::GenerateDataForRenderer( mitk::BaseRenderer *render
 
       if (componentType == itk::ImageIOBase::CHAR) {
         localStorage->m_OutlinePolyData = CreateOutlinePolyData<char>(renderer);
+      } else if (componentType == itk::ImageIOBase::UCHAR) {
+        localStorage->m_OutlinePolyData = CreateOutlinePolyData<unsigned char>(renderer);
+      } else if (componentType == itk::ImageIOBase::SHORT) {
+        localStorage->m_OutlinePolyData = CreateOutlinePolyData<short>(renderer);
       } else if (componentType == itk::ImageIOBase::USHORT) {
         localStorage->m_OutlinePolyData = CreateOutlinePolyData<unsigned short>(renderer);
-      } else {
+      } else{
         supportedPixelType = false;
       }
 

--- a/Modules/Core/src/Rendering/mitkImageVtkMapper2D.cpp
+++ b/Modules/Core/src/Rendering/mitkImageVtkMapper2D.cpp
@@ -343,7 +343,7 @@ void mitk::ImageVtkMapper2D::GenerateDataForRenderer( mitk::BaseRenderer *render
         localStorage->m_OutlinePolyData = CreateOutlinePolyData<short>(renderer);
       } else if (componentType == itk::ImageIOBase::USHORT) {
         localStorage->m_OutlinePolyData = CreateOutlinePolyData<unsigned short>(renderer);
-      } else{
+      } else {
         supportedPixelType = false;
       }
 


### PR DESCRIPTION
AUT-1209

После последних изменений 2Д-маппер стал всегда заливать сегментации с unsinged  char пикселями.
Теперь эта проблема исправлена.
