### PR TITLE
Краш в QmitkSliceInterpolator

### DIFF
--- a/Plugins/org.mitk.gui.qt.segmentation/src/internal/QmitkSegmentationView.cpp
+++ b/Plugins/org.mitk.gui.qt.segmentation/src/internal/QmitkSegmentationView.cpp
@@ -217,15 +217,19 @@ void QmitkSegmentationView::SetMultiWidget(QmitkStdMultiWidget* multiWidget)
    }
 
    // tell the interpolation about toolmanager and multiwidget (and data storage)
-   if (m_Controls && m_MultiWidget)
+   if (m_Controls)
    {
-      mitk::ToolManager* toolManager = mitk::ToolManagerProvider::GetInstance()->GetToolManager();
-      m_Controls->m_SlicesInterpolator->SetDataStorage( this->GetDefaultDataStorage());
-      QList<mitk::SliceNavigationController*> controllers;
-      controllers.push_back(m_MultiWidget->GetRenderWindow1()->GetSliceNavigationController());
-      controllers.push_back(m_MultiWidget->GetRenderWindow2()->GetSliceNavigationController());
-      controllers.push_back(m_MultiWidget->GetRenderWindow3()->GetSliceNavigationController());
-      m_Controls->m_SlicesInterpolator->Initialize( toolManager, controllers );
+     if (m_MultiWidget) {
+       mitk::ToolManager* toolManager = mitk::ToolManagerProvider::GetInstance()->GetToolManager();
+       m_Controls->m_SlicesInterpolator->SetDataStorage(this->GetDefaultDataStorage());
+       QList<mitk::SliceNavigationController*> controllers;
+       controllers.push_back(m_MultiWidget->GetRenderWindow1()->GetSliceNavigationController());
+       controllers.push_back(m_MultiWidget->GetRenderWindow2()->GetSliceNavigationController());
+       controllers.push_back(m_MultiWidget->GetRenderWindow3()->GetSliceNavigationController());
+       m_Controls->m_SlicesInterpolator->Initialize(toolManager, controllers);
+     } else {
+       m_Controls->m_SlicesInterpolator->Uninitialize();
+     }
    }
 }
 


### PR DESCRIPTION
AUT-1227

Одна из проблем, приводящих к крашу, заключается в том, что QmitkSliceInterpolator знает о том, когда мультивиджет становится активным, но не знает, когда он перестает быть активным.

Если QmitkSliceInterpolator попробует сделать что-нибудь в промежутке когда старый мультивиджет закрыт, а новый еще недоступен, то будет краш, потому что SliceNavigationControllers в этот отрезок времени невалидны.

Этот пулл реквест исправляет проблему для QmitkSliceInterpolator в плагине сегментации из МИТК.
Для плагинов Автоплана будет отдельный пулл реквест в Автоплане.
