### PR TITLE
Улучшение 2Д-интерполяции

### DIFF
--- a/Modules/SegmentationUI/Qmitk/QmitkSlicesInterpolator.cpp
+++ b/Modules/SegmentationUI/Qmitk/QmitkSlicesInterpolator.cpp
@@ -562,7 +562,9 @@ void QmitkSlicesInterpolator::Interpolate( mitk::PlaneGeometry* plane, unsigned 
         mitk::SegTool2D::DetermineAffectedImageSlice( m_Segmentation, plane, clickedSliceDimension, clickedSliceIndex );
 
         mitk::Image::Pointer interpolation = m_Interpolator->Interpolate( clickedSliceDimension, clickedSliceIndex, plane, timeStep );
-        m_FeedbackNode->SetData( interpolation );
+        if (interpolation) {
+          m_FeedbackNode->SetData(interpolation);
+        }
 
         m_LastSNC = slicer;
         m_LastSliceIndex = clickedSliceIndex;


### PR DESCRIPTION
AUT-1214

Раньше 2Д-интерполяция всегда рисовалась, только если переключать срезы колесиком мыши.
При кликах на срез она иногда пропадала, иногда рисовалась.

Теперь это работает более надежно, 2Д-интерполяция всегда рисуется, когда она валидна.

Тестовые шаги:
1. Загрузить данные в универсальный кейс.
2. Создать сегментацию.
3. Добавить туда данные на нескольких срезах, включить 2Д-интерполяцию.
   - Проверить, что она работает.
4. Переключать слайсы колесиком мышки и щелчком на других проекциях.
   - Проверить, что 2Д-интерполяция не пропадает при кликах на мультивиджете.
