### PR TITLE
Экспорт тэга 0008 0005 из itk в mitk::Image

### DIFF
--- a/Modules/Core/src/IO/mitkDicomSeriesReader.cpp
+++ b/Modules/Core/src/IO/mitkDicomSeriesReader.cpp
@@ -212,6 +212,9 @@ const DicomSeriesReader::TagToPropertyMapType& DicomSeriesReader::GetDICOMTagsTo
     dictionary["0028|0030"] = "dicom.PixelSpacing";
     dictionary["0018|1164"] = "dicom.ImagerPixelSpacing";
 
+    // Misc 
+    dictionary["0008|0005"] = "dicom.SpecificCharacterSet";
+
     initialized = true;
   }
 


### PR DESCRIPTION
AUT-1146

Это тэг "Specific Character Set", и он нужен для конвертации строк из свойств дайкома из их родной кодировки в UTF-8.
