### PR TITLE
Порядок следования дайкомов

### DIFF
--- a/Modules/Core/include/mitkStandaloneDataStorage.h
+++ b/Modules/Core/include/mitkStandaloneDataStorage.h
@@ -127,6 +127,10 @@ namespace mitk {
     //##Documentation
     //## @brief Nodes are stored in reverse relation for easier traversal in the opposite direction of the relation
     AdjacencyList m_DerivedNodes;
+
+    //##Documentation
+    //## @brief Count for added nodes, used to save their initial loading order
+    int m_AddedNodesCount;
   };
 } // namespace mitk
 #endif /* MITKSTANDALONEDATASTORAGE_H_HEADER_INCLUDED_ */


### PR DESCRIPTION
AUT-1186

Проблема в том, что ноды внутри хранилиза лежат в std::map, где ключом выступают их указатели.
Так как значение указателей разное каждый запуск программы, порядок следования нод в хранилище меняется на каждый запуск.
И если менеджер сегментаций или вьювер отображают уже загруженные узлы, а не реагируют на их добавление, то порядок следования нод будет случайным.

Я добавил свойство, по которому ноды можно сортировать в том порядке, в каком они были загружены. Хранилище теперь так и делает, когда возвращает список своих нод.

Тестовые шаги:
1. Загрузить все серии из одной директории.
   - Проверить, что они загружены в том порядке, в каком расположены их директории.
2. Закрыть Автоплан, удалить профиль.
3. Загрузить те же серии.
   - Проверить, что они загружены в том же самом порядке.
   - Проверить, что порядок следования совпадает во вьювере и в менеджере сегментаций.
   - NOTE: Менеджер данных добавляет новые серии в начало, так что порядок в нем может отличаться после загрузки дополнительных серий.
