### PR TITLE
Исчезновение плоскостей мультивиджета

### DIFF
--- a/Modules/Core/include/mitkStandaloneDataStorage.h
+++ b/Modules/Core/include/mitkStandaloneDataStorage.h
@@ -131,6 +131,10 @@ namespace mitk {
     //##Documentation
     //## @brief Count for added nodes, used to save their initial loading order
     int m_AddedNodesCount;
+
+    //##Documentation
+    //## @brief Map with info about nodes' indices
+    std::map<mitk::DataNode::ConstPointer, int> m_NodesIndices;
   };
 } // namespace mitk
 #endif /* MITKSTANDALONEDATASTORAGE_H_HEADER_INCLUDED_ */

--- a/Modules/Core/src/DataManagement/mitkStandaloneDataStorage.cpp
+++ b/Modules/Core/src/DataManagement/mitkStandaloneDataStorage.cpp
@@ -70,7 +70,7 @@ void mitk::StandaloneDataStorage::Add(mitk::DataNode* node, const mitk::DataStor
     else
       sp = mitk::DataStorage::SetOfObjects::New();
     /* Store node and parent list in sources adjacency list */
-    node->SetIntProperty("loadIndex", m_AddedNodesCount++);
+    m_NodesIndices[node] = m_AddedNodesCount++;
     m_SourceNodes.insert(std::make_pair(node, sp));
 
     /* Store node and an empty children list in derivations adjacency list */
@@ -168,8 +168,7 @@ mitk::DataStorage::SetOfObjects::ConstPointer mitk::StandaloneDataStorage::GetAl
     }
     else
     {
-      int loadIndex = 0;
-      it->first->GetIntProperty("loadIndex", loadIndex);
+      int loadIndex = m_NodesIndices.at(it->first);
       tempResult[loadIndex] = const_cast<mitk::DataNode*>(it->first.GetPointer());
     }
   }


### PR DESCRIPTION
AUT-1186

Проблема была в индексе, который хранилище данных добавляло к каждому узлу при добавлении.
Если один и тот же узел (планарная фигура) добавлялся в несколько хранилищ, этот индекс перезаписывался и в одном из хранилищ оказывалось несколько узлов с одни и тем же индексом.
Что, в свою очередь, приводило к потере узлов в функции GetAll().

Теперь данные о порядке узлов хранятся в самом хранилище, а не в узлах.

Тестовые шаги:
1. Загрузить данные в универсальный кейс.
2. Нарисовать планарную фигуру.
   - Проверить, что плоскости мультивиджета не исчезли.
