### PR TITLE
События от view coordinator

### DIFF
--- a/Plugins/org.mitk.gui.qt.common/src/internal/QmitkViewCoordinator.cpp
+++ b/Plugins/org.mitk.gui.qt.common/src/internal/QmitkViewCoordinator.cpp
@@ -106,18 +106,6 @@ void QmitkViewCoordinator::PartDeactivated(const berry::IWorkbenchPartReference:
   //MITK_INFO << "*** PartDeactivated (" << partRef->GetPart(false)->GetPartName() << ")";
   berry::IWorkbenchPart* part = partRef->GetPart(false).GetPointer();
 
-  // Check for a render window part and inform IRenderWindowPartListener views
-  // that it was deactivated
-  if (mitk::IRenderWindowPart* renderPart = dynamic_cast<mitk::IRenderWindowPart*>(part))
-  {
-    if (m_ActiveRenderWindowPart == renderPart)
-    {
-      RenderWindowPartDeactivated(renderPart);
-      m_ActiveRenderWindowPart = nullptr;
-      m_VisibleRenderWindowPart = nullptr;
-    }
-  }
-
   if (mitk::ILifecycleAwarePart* lifecycleAwarePart = dynamic_cast<mitk::ILifecycleAwarePart*>(part))
   {
     lifecycleAwarePart->Deactivated();
@@ -155,10 +143,11 @@ void QmitkViewCoordinator::PartHidden(const berry::IWorkbenchPartReference::Poin
   // Inform IRenderWindowPartListener views that it has been hidden.
   if ( mitk::IRenderWindowPart* renderPart = dynamic_cast<mitk::IRenderWindowPart*>(part) )
   {
-    if (!m_ActiveRenderWindowPart && m_VisibleRenderWindowPart == renderPart)
+    if (m_VisibleRenderWindowPart == renderPart)
     {
       RenderWindowPartDeactivated(renderPart);
       m_VisibleRenderWindowPart = nullptr;
+      m_ActiveRenderWindowPart = nullptr;
     }
   }
 
@@ -181,6 +170,7 @@ void QmitkViewCoordinator::PartVisible(const berry::IWorkbenchPartReference::Poi
     {
       RenderWindowPartActivated(renderPart);
       m_VisibleRenderWindowPart = renderPart;
+      m_ActiveRenderWindowPart = renderPart;
     }
   }
 


### PR DESCRIPTION
AUT-1205

Проблема была в событиях от view coordinator'а.
После некоторых действий любое снятие фокуса с мультивиджета приводило к тому, что плагин "Segmentation Tools" думал, что мультивиджет недоступен.

Тестовые шаги:
1. Загрузить данные в классический кейс.
2. Открыть плагин "Segmentation Tools".
3. Вернуться на стартовый экран, загрузить еще данные в классический кейс.
4. Активировать менеджер данных.
   - Плагин "Segmentation Tools" доступен.
