### PR TITLE
Краш в multilabel segmentation

### DIFF
--- a/Modules/Multilabel/mitkLabelSetImageVtkMapper2D.cpp
+++ b/Modules/Multilabel/mitkLabelSetImageVtkMapper2D.cpp
@@ -560,28 +560,40 @@ void mitk::LabelSetImageVtkMapper2D::Update(mitk::BaseRenderer* renderer)
   else if ( (localStorage->m_LastPropertyUpdateTime < node->GetPropertyList()->GetMTime()) //was a property modified?
             || (localStorage->m_LastPropertyUpdateTime < node->GetPropertyList(renderer)->GetMTime()) )
   {
-    // Change color of first label
-    auto firstLabel = image->GetLabel(1);
-    if (firstLabel == nullptr)
+
+    // The previous update was interrupted because of no intersection between image and world geometry
+    // Have to make a full update again
+    if (localStorage->m_ReslicedImageVector[image->GetActiveLayer()] == nullptr) 
     {
-      firstLabel = image->GetActiveLabel();
-    }
-
-    mitk::Color color = firstLabel->GetColor();
-
-    if (this->GetDataNode()->GetColor(color.GetDataPointer(), renderer))
+      this->GenerateDataForRenderer(renderer);
+      localStorage->m_LastDataUpdateTime.Modified();
+      localStorage->m_LastPropertyUpdateTime.Modified();
+    } 
+    else 
     {
-      firstLabel->SetColor(color);
-      image->GetActiveLabelSet()->UpdateLookupTable(firstLabel->GetValue());
+      // Change color of first label
+      auto firstLabel = image->GetLabel(1);
+      if (firstLabel == nullptr)
+      {
+        firstLabel = image->GetActiveLabel();
+      }
+
+      mitk::Color color = firstLabel->GetColor();
+
+      if (this->GetDataNode()->GetColor(color.GetDataPointer(), renderer))
+      {
+        firstLabel->SetColor(color);
+        image->GetActiveLabelSet()->UpdateLookupTable(firstLabel->GetValue());
+      }
+
+
+      this->ApplyColor(renderer, color);
+      this->ApplyOpacity(renderer, image->GetActiveLayer());
+      this->ApplyLookuptable(renderer, image->GetActiveLayer());
+      this->ApplyContour(renderer, image->GetActiveLayer());
+
+      localStorage->m_LastPropertyUpdateTime.Modified();
     }
-
-
-    this->ApplyColor(renderer, color);
-    this->ApplyOpacity(renderer, image->GetActiveLayer());
-    this->ApplyLookuptable(renderer, image->GetActiveLayer());
-    this->ApplyContour(renderer, image->GetActiveLayer());
-
-    localStorage->m_LastPropertyUpdateTime.Modified();
   }
 }
 


### PR DESCRIPTION
AUT-1262

Проблема была в ленивом обновлении LabelSetImageVtkMapper2D.
Если изменились только свойства изображения, то LabelSetImageVtkMapper2D не генерирует все данные целиком, а обновляет только цвет, прозрачность и контур.
Для обновления контура ему необходим localStorage->m_ReslicedImageVector[layer].
Но если изображение не пересекается с глобальной геометрией, то в предыдущем полном обновлении localStorage->m_ReslicedImageVector[layer] не был инициализирован и равен 0. При следующем частичном обновлении следует краш.
Теперь этот случай обрабатывается отдельно.

Тестовые шаги:
1. Загрузить два изображения с разной геометрией (например, разных пациентов).
2. Перейти в универсальный кейс.
3. Открыть плагин "Сегментация".
4. Создать в плагине по одной сегментации для каждого изображения.
5. Переключаться между сегментациями и изображениями, использую менеджер данных.
   - Краша нет.
