### PR TITLE
Кисть и принятые срезы интерполяции

### DIFF
--- a/Modules/Segmentation/Interactions/mitkPaintbrushTool.h
+++ b/Modules/Segmentation/Interactions/mitkPaintbrushTool.h
@@ -93,6 +93,7 @@ class MITKSEGMENTATION_EXPORT PaintbrushTool : public FeedbackContourTool
     void CheckIfCurrentSliceHasChanged(const InteractionPositionEvent* event);
 
     void OnToolManagerWorkingDataModified();
+    void OnToolManagerImageModified(const itk::EventObject&);
 
     int m_PaintingPixelValue;
     static int m_Size;
@@ -105,6 +106,8 @@ class MITKSEGMENTATION_EXPORT PaintbrushTool : public FeedbackContourTool
     PlaneGeometry::Pointer m_CurrentPlane;
     DataNode::Pointer m_WorkingNode;
     mitk::Point3D m_LastPosition;
+    Image::Pointer m_WorkingImage;
+    int m_ImageObserverTag;
 };
 
 } // namespace


### PR DESCRIPTION
AUT-1214

Проблема была в том, что кисть не знала о том, что текущий срез интерполяции был принят, и использовала старые пустые данные среза.

Тестовые шаги:
1. Создать сегментацию, включить 2Д-интерполяцию.
2. Принять изображение на срезе, кистью изменить изображение.
3. Переместиться на следующий срез.
   - Проверить, что кисть добавляет новые области к изображению, а не переписывает его.
4. Повторить шаги 2-3 для стерки.
