### PR TITLE
Краш при повторной загрузке данных в универсальный кейс

### DIFF
--- a/Modules/Core/include/mitkStandaloneDataStorage.h
+++ b/Modules/Core/include/mitkStandaloneDataStorage.h
@@ -134,7 +134,7 @@ namespace mitk {
 
     //##Documentation
     //## @brief Map with info about nodes' indices
-    std::map<mitk::DataNode::ConstPointer, int> m_NodesIndices;
+    std::map<mitk::DataNode*, int> m_NodesIndices;
   };
 } // namespace mitk
 #endif /* MITKSTANDALONEDATASTORAGE_H_HEADER_INCLUDED_ */

--- a/Modules/Core/src/DataManagement/mitkStandaloneDataStorage.cpp
+++ b/Modules/Core/src/DataManagement/mitkStandaloneDataStorage.cpp
@@ -168,8 +168,9 @@ mitk::DataStorage::SetOfObjects::ConstPointer mitk::StandaloneDataStorage::GetAl
     }
     else
     {
-      int loadIndex = m_NodesIndices.at(it->first);
-      tempResult[loadIndex] = const_cast<mitk::DataNode*>(it->first.GetPointer());
+      auto node = const_cast<mitk::DataNode*>(it->first.GetPointer());
+      int loadIndex = m_NodesIndices.at(node);
+      tempResult[loadIndex] = node;
     }
   }
 


### PR DESCRIPTION
AUT-1271

Из-за умных указателей плоскости мультивиджета жили дольше, чем нужно.\

Тестовые шаги:
1. Загрузить данные в универсальный кейс.
2. Закрыть всё.
3. Загрузить данные снова.
   - Краша нет.
