### PR TITLE
Краш с открепленными окнами

### DIFF
--- a/Plugins/org.blueberry.ui.qt/src/internal/berryPartPane.cpp
+++ b/Plugins/org.blueberry.ui.qt/src/internal/berryPartPane.cpp
@@ -148,9 +148,14 @@ void PartPane::ControlActivated(GuiTk::ControlEvent::Pointer /*e*/)
   }
 }
 
+void PartPane::ControlDestroyed(GuiTk::ControlEvent::Pointer)
+{
+  control = nullptr;
+}
+
 GuiTk::IControlListener::Events::Types PartPane::GetEventTypes() const
 {
-  return GuiTk::IControlListener::Events::ACTIVATED;
+  return GuiTk::IControlListener::Events::ACTIVATED | GuiTk::IControlListener::Events::DESTROYED;
 }
 
 void PartPane::MoveAbove(QWidget* refControl)

--- a/Plugins/org.blueberry.ui.qt/src/internal/berryPartPane.h
+++ b/Plugins/org.blueberry.ui.qt/src/internal/berryPartPane.h
@@ -171,6 +171,7 @@ public:
      * @see GuiTk::IControlListener
      */
     public: void ControlActivated(GuiTk::ControlEvent::Pointer e) override;
+    public: void ControlDestroyed(GuiTk::ControlEvent::Pointer) override;
 
     /**
      * @see GuiTk::IControlListener

--- a/Plugins/org.blueberry.ui.qt/src/internal/berryPresentationSerializer.cpp
+++ b/Plugins/org.blueberry.ui.qt/src/internal/berryPresentationSerializer.cpp
@@ -40,7 +40,7 @@ IPresentablePart::Pointer PresentationSerializer::GetPart(const QString& id)
   if (!okay) return IPresentablePart::Pointer(nullptr);
 
   IPresentablePart::Pointer result;
-  if (index < parts.size())
+  if (index >= 0 && index < parts.size())
     result = parts[index];
 
   return result;


### PR DESCRIPTION
AUT-1193

Проблема была в том, что QWidget, принадлежащий berry::PartPane, мог быть удален через Qt, и PartPane об этом ничего не знал и пытался отписаться от уже удаленного контрола.

Тестовые шаги:
1. Загрузить данные в универсальный кейс.
2. Открепить одно или несколько окон.
3. Закрыть Автоплан.
   - Нет краша.
4. Открыть Автоплан, снова перейти в универсальный кейс.
   - Нет краша.
5. Переключить активную вкладку на вьювер и обратно.
   - Нет краша.
   - В открепленных окнах валидные данные.
