### PR TITLE
Нормали МИТК поверхностей

### DIFF
--- a/Modules/Core/src/Algorithms/mitkImageToSurfaceFilter.cpp
+++ b/Modules/Core/src/Algorithms/mitkImageToSurfaceFilter.cpp
@@ -148,7 +148,11 @@ void mitk::ImageToSurfaceFilter::CreateSurface(int time, vtkImageData *vtkimage,
   // determine point_data normals for the poly data points.
   vtkSmartPointer<vtkPolyDataNormals> normalsGenerator = vtkSmartPointer<vtkPolyDataNormals>::New();
   normalsGenerator->SetInputData( polydata );
-  normalsGenerator->FlipNormalsOn();
+  normalsGenerator->AutoOrientNormalsOn();
+  normalsGenerator->FlipNormalsOff();
+  normalsGenerator->ConsistencyOn();
+  normalsGenerator->ComputeCellNormalsOff();
+  normalsGenerator->SplittingOff();
 
   vtkSmartPointer<vtkCleanPolyData> cleanPolyDataFilter = vtkSmartPointer<vtkCleanPolyData>::New();
   cleanPolyDataFilter->SetInputConnection(normalsGenerator->GetOutputPort());


### PR DESCRIPTION
AUT-1296

Нормали для поверхностей, которые генерирует МИТК, инвертированы:
https://phabricator.mitk.org/T20075

Я убрал инвертирование и добавил установку свойств, как в алгоритме генерации плоскостей из AGTK (чтобы было больше унифицированности).

Генерация плоскостей из AGTK тоже имеет свои проблемы: https://github.com/samsmu/AutoplanApplication/issues/746

Тестовые шаги:
1. Загрузить данные в универсальный кейс.
2. Создать сегментацию.
3. Сгенерировать 3Д-модель алгоритмами из МИТК (первые два алгоритма, доступные в менеджере сегментаций или алгоритмы в выпадающем меню менеджера данных).
4. Экспортировать модель в .ply файл из менеджера сегментаций.
5. Открыть модель с помощью MeshLab.
   - Модель серая, а не черная.
