### PR TITLE
Reader для планарных фигур из Автоплана

### DIFF
--- a/Modules/PlanarFigure/include/mitkPlanarFigureReader.h
+++ b/Modules/PlanarFigure/include/mitkPlanarFigureReader.h
@@ -122,6 +122,8 @@ protected:
      */
     virtual int CanReadFile (const char *name);
 
+    virtual mitk::PlanarFigure::Pointer createPlanarFigure(const std::string& type);
+
     /**
     * \brief parses the element for the attributes x,y,z and returns a mitk::Vector3D filled with these values
     * \param[in] e the TiXmlElement that will be parsed

--- a/Modules/PlanarFigure/src/Algorithms/mitkPlanarFigureObjectFactory.cpp
+++ b/Modules/PlanarFigure/src/Algorithms/mitkPlanarFigureObjectFactory.cpp
@@ -120,7 +120,9 @@ mitk::CoreObjectFactoryBase::MultimapType mitk::PlanarFigureObjectFactory::GetSa
 void mitk::PlanarFigureObjectFactory::CreateFileExtensionsMap()
 {
   m_FileExtensionsMap.insert(std::pair<std::string, std::string>("*.pf", "Planar Figure Files"));
+  m_FileExtensionsMap.insert(std::pair<std::string, std::string>("*.pfa", "Autoplan Planar Figure Files"));
   m_SaveFileExtensionsMap.insert(std::pair<std::string, std::string>("*.pf", "Planar Figure Files"));
+  m_SaveFileExtensionsMap.insert(std::pair<std::string, std::string>("*.pfa", "Autoplan Planar Figure Files"));
 }
 
 void mitk::PlanarFigureObjectFactory::RegisterIOFactories()

--- a/Modules/PlanarFigure/src/IO/mitkPlanarFigureReader.cpp
+++ b/Modules/PlanarFigure/src/IO/mitkPlanarFigureReader.cpp
@@ -139,61 +139,10 @@ void mitk::PlanarFigureReader::GenerateData()
     std::string type = pfElement->Attribute("type");
 
     mitk::PlanarFigure::Pointer planarFigure = nullptr;
-    if (type == "PlanarAngle")
-    {
-      planarFigure = mitk::PlanarAngle::New();
-    }
-    else if (type == "PlanarCircle")
-    {
-      planarFigure = mitk::PlanarCircle::New();
-    }
-    else if (type == "PlanarEllipse")
-    {
-      planarFigure = mitk::PlanarEllipse::New();
-    }
-    else if (type == "PlanarCross")
-    {
-      planarFigure = mitk::PlanarCross::New();
-    }
-    else if (type == "PlanarFourPointAngle")
-    {
-      planarFigure = mitk::PlanarFourPointAngle::New();
-    }
-    else if (type == "PlanarLine")
-    {
-      planarFigure = mitk::PlanarLine::New();
-    }
-    else if (type == "PlanarPolygon")
-    {
-      planarFigure = mitk::PlanarPolygon::New();
-    }
-    else if (type == "PlanarSubdivisionPolygon")
-    {
-      planarFigure = mitk::PlanarSubdivisionPolygon::New();
-    }
-    else if (type == "PlanarRectangle")
-    {
-      planarFigure = mitk::PlanarRectangle::New();
-    }
-    else if (type == "PlanarArrow")
-    {
-      planarFigure = mitk::PlanarArrow::New();
-    }
-    else if (type == "PlanarDoubleEllipse")
-    {
-      planarFigure = mitk::PlanarDoubleEllipse::New();
-    }
-    else if (type == "PlanarBezierCurve")
-    {
-      planarFigure = mitk::PlanarBezierCurve::New();
-    }
-    else
-    {
-      // unknown type
-      MITK_WARN << "encountered unknown planar figure type '" << type << "'. Skipping this element.";
+    planarFigure = createPlanarFigure(type);
+    if (!planarFigure) {
       continue;
     }
-
 
     // Read properties of the planar figure
     for( TiXmlElement* propertyElement = pfElement->FirstChildElement("property");
@@ -357,6 +306,53 @@ void mitk::PlanarFigureReader::GenerateData()
 
   m_Success = true;
 }
+
+mitk::PlanarFigure::Pointer mitk::PlanarFigureReader::createPlanarFigure(const std::string& type)
+{
+  mitk::PlanarFigure::Pointer planarFigure = nullptr;
+  if (type == "PlanarAngle")
+  {
+    planarFigure = mitk::PlanarAngle::New();
+  } else if (type == "PlanarCircle")
+  {
+    planarFigure = mitk::PlanarCircle::New();
+  } else if (type == "PlanarEllipse")
+  {
+    planarFigure = mitk::PlanarEllipse::New();
+  } else if (type == "PlanarCross")
+  {
+    planarFigure = mitk::PlanarCross::New();
+  } else if (type == "PlanarFourPointAngle")
+  {
+    planarFigure = mitk::PlanarFourPointAngle::New();
+  } else if (type == "PlanarLine")
+  {
+    planarFigure = mitk::PlanarLine::New();
+  } else if (type == "PlanarPolygon")
+  {
+    planarFigure = mitk::PlanarPolygon::New();
+  } else if (type == "PlanarSubdivisionPolygon")
+  {
+    planarFigure = mitk::PlanarSubdivisionPolygon::New();
+  } else if (type == "PlanarRectangle")
+  {
+    planarFigure = mitk::PlanarRectangle::New();
+  } else if (type == "PlanarArrow")
+  {
+    planarFigure = mitk::PlanarArrow::New();
+  } else if (type == "PlanarDoubleEllipse")
+  {
+    planarFigure = mitk::PlanarDoubleEllipse::New();
+  } else if (type == "PlanarBezierCurve")
+  {
+    planarFigure = mitk::PlanarBezierCurve::New();
+  } else {
+    // unknown type
+    MITK_WARN << "encountered unknown planar figure type '" << type << "'. Skipping this element.";
+  }
+  return planarFigure;
+}
+
 
 mitk::Point3D mitk::PlanarFigureReader::GetPointFromXMLNode(TiXmlElement* e)
 {


### PR DESCRIPTION
AUT-1327

Подготавливает МИТК-инфраструктуру для добавления отдельного ридера для кастомных планарных фигур из Автоплана.
