### PR TITLE
Регистрация интеракторов

### DIFF
--- a/Modules/Core/src/Interactions/mitkBindDispatcherInteractor.cpp
+++ b/Modules/Core/src/Interactions/mitkBindDispatcherInteractor.cpp
@@ -47,6 +47,13 @@ void mitk::BindDispatcherInteractor::SetDataStorage(mitk::DataStorage::Pointer d
     UnRegisterDataStorageEvents();
     m_DataStorage = dataStorage;
     RegisterDataStorageEvents();
+
+    // Register existing interactors
+    auto nodes = m_DataStorage->GetAll();
+    for (auto node : *nodes) 
+    {
+      RegisterInteractor(node);
+    }
   }
 }
 


### PR DESCRIPTION
Это один из фиксов, необходимых для AUT-1330.
Сейчас возможна ситуация, когда у планарной фигуры есть интерактор, но диспетчер событий о нем не знает, так как он был добавлен до того, как BindDispatcherInteractor был привязан к хранилищу данных.

Эта проблема теперь решена.
