### PR TITLE
Краш в Threshold-инструментах

### DIFF
--- a/Modules/Segmentation/Interactions/mitkBinaryThresholdTool.cpp
+++ b/Modules/Segmentation/Interactions/mitkBinaryThresholdTool.cpp
@@ -48,10 +48,6 @@ namespace mitk {
 }
 
 mitk::BinaryThresholdTool::BinaryThresholdTool()
-  :m_SensibleMinimumThresholdValue(-100),
-  m_SensibleMaximumThresholdValue(+100),
-  m_CurrentThresholdValue(0.0),
-  m_IsFloatImage(false)
 {
   m_ThresholdFeedbackNode = DataNode::New();
   m_ThresholdFeedbackNode->SetProperty("name", StringProperty::New("Thresholding feedback"));
@@ -61,11 +57,6 @@ mitk::BinaryThresholdTool::BinaryThresholdTool()
 
 mitk::BinaryThresholdTool::~BinaryThresholdTool()
 {
-}
-
-const char** mitk::BinaryThresholdTool::GetXPM() const
-{
-  return NULL;
 }
 
 us::ModuleResource mitk::BinaryThresholdTool::GetIconResource() const
@@ -80,270 +71,28 @@ const char* mitk::BinaryThresholdTool::GetName() const
   return "Threshold";
 }
 
-void mitk::BinaryThresholdTool::Activated()
-{
-  Superclass::Activated();
-
-  m_ToolManager->RoiDataChanged += mitk::MessageDelegate<mitk::BinaryThresholdTool>(this, &mitk::BinaryThresholdTool::OnRoiDataChanged);
-
-  m_OriginalImageNode = m_ToolManager->GetReferenceData(0);
-  m_NodeForThresholding = m_OriginalImageNode;
-
-  if (m_NodeForThresholding.IsNotNull())
-  {
-    SetupPreviewNode();
-  }
-  else
-  {
-    m_ToolManager->ActivateTool(-1);
-  }
-}
-
-void mitk::BinaryThresholdTool::Deactivated()
-{
-  m_ToolManager->RoiDataChanged -= mitk::MessageDelegate<mitk::BinaryThresholdTool>(this, &mitk::BinaryThresholdTool::OnRoiDataChanged);
-  m_NodeForThresholding = NULL;
-  m_OriginalImageNode = NULL;
-  try
-  {
-    if (DataStorage* storage = m_ToolManager->GetDataStorage())
-    {
-      storage->Remove(m_ThresholdFeedbackNode);
-      RenderingManager::GetInstance()->RequestUpdateAll();
-    }
-  }
-  catch (...)
-  {
-    // don't care
-  }
-  m_ThresholdFeedbackNode->SetData(NULL);
-
-  Superclass::Deactivated();
-}
-
 void mitk::BinaryThresholdTool::SetThresholdValue(double value)
 {
   if (m_ThresholdFeedbackNode.IsNotNull())
   {
-    m_CurrentThresholdValue = value;
+    m_CurrentLowerThresholdValue = value;
     // Bug 19250: The range of 0.01 is rather random. It was 0.001 before and probably due to rounding error propagation in VTK code
     // it leads to strange banding effects on floating point images with a huge range (like -40000 - 40000). 0.01 lowers this effect
     // enough to work with our images. Might not work on images with really huge ranges, though. Anyways, still seems to be low enough
     // to work for floating point images with a range between 0 and 1. A better solution might be to dynamically calculate the value
     // based on the value range of the current image (as big as possible, as small as necessary).
-    m_ThresholdFeedbackNode->SetProperty( "levelwindow", LevelWindowProperty::New( LevelWindow(m_CurrentThresholdValue, 0.01) ) );
+    m_ThresholdFeedbackNode->SetProperty("levelwindow", LevelWindowProperty::New(LevelWindow(m_CurrentLowerThresholdValue, 0.01)));
     UpdatePreview();
   }
 }
 
-void mitk::BinaryThresholdTool::AcceptCurrentThresholdValue()
+void mitk::BinaryThresholdTool::updateThresholdValue()
 {
-  CreateNewSegmentationFromThreshold(m_NodeForThresholding);
-
-  RenderingManager::GetInstance()->RequestUpdateAll();
-  m_ToolManager->ActivateTool(-1);
+  m_CurrentLowerThresholdValue = (m_SensibleMaximumThresholdValue + m_SensibleMinimumThresholdValue) / 2.0;
+  ThresholdingValueChanged.Send(m_CurrentLowerThresholdValue);
 }
 
-void mitk::BinaryThresholdTool::CancelThresholding()
+void mitk::BinaryThresholdTool::runItkThreshold(Image::Pointer feedbackImage3D, Image::Pointer previewImage, unsigned int timeStep)
 {
-  m_ToolManager->ActivateTool(-1);
-}
-
-void mitk::BinaryThresholdTool::SetupPreviewNode()
-{
-  if (m_NodeForThresholding.IsNotNull())
-  {
-    Image::Pointer image = dynamic_cast<Image*>(m_NodeForThresholding->GetData());
-    Image::Pointer originalImage = dynamic_cast<Image*> (m_OriginalImageNode->GetData());
-
-    if (image.IsNotNull())
-    {
-      mitk::Image* workingimage = dynamic_cast<mitk::Image*>(m_ToolManager->GetWorkingData(0)->GetData());
-
-      if (workingimage)
-      {
-        m_ThresholdFeedbackNode->SetData(workingimage->Clone());
-
-        //Let's paint the feedback node green...
-        mitk::LabelSetImage::Pointer previewImage = dynamic_cast<mitk::LabelSetImage*> (m_ThresholdFeedbackNode->GetData());
-
-        if (previewImage) {
-          itk::RGBPixel<float> pixel;
-          pixel[0] = 0.0f;
-          pixel[1] = 1.0f;
-          pixel[2] = 0.0f;
-          previewImage->GetActiveLabel()->SetColor(pixel);
-          previewImage->GetActiveLabelSet()->UpdateLookupTable(previewImage->GetActiveLabel()->GetValue());
-        }
-      }
-      else
-        m_ThresholdFeedbackNode->SetData(mitk::Image::New());
-
-      int layer(50);
-      m_NodeForThresholding->GetIntProperty("layer", layer);
-      m_ThresholdFeedbackNode->SetIntProperty("layer", layer + 1);
-
-      if (DataStorage* ds = m_ToolManager->GetDataStorage())
-      {
-        if (!ds->Exists(m_ThresholdFeedbackNode))
-          ds->Add(m_ThresholdFeedbackNode, m_OriginalImageNode);
-      }
-
-      if (image.GetPointer() == originalImage.GetPointer())
-      {
-        Image::StatisticsHolderPointer statistics = originalImage->GetStatistics();
-        m_SensibleMinimumThresholdValue = static_cast<double>(statistics->GetScalarValueMin());
-        m_SensibleMaximumThresholdValue = static_cast<double>(statistics->GetScalarValueMax());
-      }
-
-      if ((originalImage->GetPixelType().GetPixelType() == itk::ImageIOBase::SCALAR)
-        && (originalImage->GetPixelType().GetComponentType() == itk::ImageIOBase::FLOAT || originalImage->GetPixelType().GetComponentType() == itk::ImageIOBase::DOUBLE))
-        m_IsFloatImage = true;
-      else
-        m_IsFloatImage = false;
-
-
-      m_CurrentThresholdValue = (m_SensibleMaximumThresholdValue + m_SensibleMinimumThresholdValue) / 2.0;
-
-      IntervalBordersChanged.Send(m_SensibleMinimumThresholdValue, m_SensibleMaximumThresholdValue, m_IsFloatImage);
-      ThresholdingValueChanged.Send(m_CurrentThresholdValue);
-    }
-  }
-}
-
-template <typename TPixel, unsigned int VImageDimension>
-static void ITKSetVolume(itk::Image<TPixel, VImageDimension>* originalImage, mitk::Image* segmentation, unsigned int timeStep)
-{
-  segmentation->SetVolume((void*)originalImage->GetPixelContainer()->GetBufferPointer(), timeStep);
-}
-
-void mitk::BinaryThresholdTool::CreateNewSegmentationFromThreshold(DataNode* node)
-{
-  if (node)
-  {
-    Image::Pointer feedBackImage = dynamic_cast<Image*>(m_ThresholdFeedbackNode->GetData());
-    if (feedBackImage.IsNotNull())
-    {
-      DataNode::Pointer emptySegmentation = GetTargetSegmentationNode();
-
-      if (emptySegmentation)
-      {
-        // actually perform a thresholding and ask for an organ type
-        for (unsigned int timeStep = 0; timeStep < feedBackImage->GetTimeSteps(); ++timeStep)
-        {
-          try
-          {
-            ImageTimeSelector::Pointer timeSelector = ImageTimeSelector::New();
-            timeSelector->SetInput(feedBackImage);
-            timeSelector->SetTimeNr(timeStep);
-            timeSelector->UpdateLargestPossibleRegion();
-            Image::Pointer image3D = timeSelector->GetOutput();
-
-            if (image3D->GetDimension() == 2)
-            {
-              AccessFixedDimensionByItk_2(image3D, ITKSetVolume, 2, dynamic_cast<Image*>(emptySegmentation->GetData()), timeStep);
-            }
-            else
-            {
-              AccessFixedDimensionByItk_2(image3D, ITKSetVolume, 3, dynamic_cast<Image*>(emptySegmentation->GetData()), timeStep);
-            }
-          }
-          catch (...)
-          {
-            Tool::ErrorMessage("Error accessing single time steps of the original image. Cannot create segmentation.");
-          }
-        }
-
-        if (m_OriginalImageNode.GetPointer() != m_NodeForThresholding.GetPointer())
-        {
-          mitk::PadImageFilter::Pointer padFilter = mitk::PadImageFilter::New();
-
-          padFilter->SetInput(0, dynamic_cast<mitk::Image*> (emptySegmentation->GetData()));
-          padFilter->SetInput(1, dynamic_cast<mitk::Image*> (m_OriginalImageNode->GetData()));
-          padFilter->SetBinaryFilter(true);
-          padFilter->SetUpperThreshold(1);
-          padFilter->SetLowerThreshold(1);
-          padFilter->Update();
-
-          emptySegmentation->SetData(padFilter->GetOutput());
-        }
-
-        m_ToolManager->SetWorkingData(emptySegmentation);
-        m_ToolManager->GetWorkingData(0)->Modified();
-      }
-    }
-  }
-}
-
-void mitk::BinaryThresholdTool::OnRoiDataChanged()
-{
-  mitk::DataNode::Pointer node = m_ToolManager->GetRoiData(0);
-
-  if (node.IsNotNull())
-  {
-    mitk::MaskAndCutRoiImageFilter::Pointer roiFilter = mitk::MaskAndCutRoiImageFilter::New();
-    mitk::Image::Pointer image = dynamic_cast<mitk::Image*> (m_NodeForThresholding->GetData());
-
-    if (image.IsNull())
-      return;
-
-    roiFilter->SetInput(image);
-    roiFilter->SetRegionOfInterest(node->GetData());
-    roiFilter->Update();
-
-    mitk::DataNode::Pointer tmpNode = mitk::DataNode::New();
-    tmpNode->SetData(roiFilter->GetOutput());
-
-    m_SensibleMaximumThresholdValue = static_cast<double> (roiFilter->GetMaxValue());
-    m_SensibleMinimumThresholdValue = static_cast<double> (roiFilter->GetMinValue());
-
-    m_NodeForThresholding = tmpNode;
-  }
-  else
-  {
-    m_NodeForThresholding = m_OriginalImageNode;
-  }
-
-  this->SetupPreviewNode();
-  this->UpdatePreview();
-}
-
-template <typename TPixel, unsigned int VImageDimension>
-void mitk::BinaryThresholdTool::ITKThresholding(itk::Image<TPixel, VImageDimension>* originalImage, Image* segmentation, double thresholdValue, unsigned int timeStep)
-{
-  typedef itk::Image<TPixel, VImageDimension> ImageType;
-  typedef itk::Image<mitk::Tool::DefaultSegmentationDataType, VImageDimension> SegmentationType;
-  typedef itk::BinaryThresholdImageFilter<ImageType, SegmentationType> ThresholdFilterType;
-
-  typename ThresholdFilterType::Pointer filter = ThresholdFilterType::New();
-  filter->SetInput(originalImage);
-  filter->SetLowerThreshold(thresholdValue);
-  filter->SetUpperThreshold(m_SensibleMaximumThresholdValue);
-  filter->SetInsideValue(1);
-  filter->SetOutsideValue(0);
-  filter->Update();
-
-  segmentation->SetVolume((void*)(filter->GetOutput()->GetPixelContainer()->GetBufferPointer()), timeStep);
-}
-
-
-
-void mitk::BinaryThresholdTool::UpdatePreview()
-{
-  mitk::Image::Pointer thresholdImage = dynamic_cast<mitk::Image*> (m_NodeForThresholding->GetData());
-  mitk::LabelSetImage::Pointer previewImage = dynamic_cast<mitk::LabelSetImage*> (m_ThresholdFeedbackNode->GetData());
-  if (thresholdImage && previewImage)
-  {
-    for (unsigned int timeStep = 0; timeStep < thresholdImage->GetTimeSteps(); ++timeStep)
-    {
-      ImageTimeSelector::Pointer timeSelector = ImageTimeSelector::New();
-      timeSelector->SetInput(thresholdImage);
-      timeSelector->SetTimeNr(timeStep);
-      timeSelector->UpdateLargestPossibleRegion();
-      Image::Pointer feedBackImage3D = timeSelector->GetOutput();
-      AccessByItk_n(feedBackImage3D, ITKThresholding, (previewImage, m_CurrentThresholdValue, timeStep));
-    }
-
-    RenderingManager::GetInstance()->RequestUpdateAll();
-  }
+  AccessByItk_n(feedbackImage3D, ITKThresholding, (previewImage, m_CurrentLowerThresholdValue, m_SensibleMaximumThresholdValue, timeStep));
 }

--- a/Modules/Segmentation/Interactions/mitkBinaryThresholdTool.h
+++ b/Modules/Segmentation/Interactions/mitkBinaryThresholdTool.h
@@ -20,6 +20,7 @@ See LICENSE.txt or http://www.mitk.org for details.
 #include "mitkCommon.h"
 #include <MitkSegmentationExports.h>
 #include "mitkAutoSegmentationTool.h"
+#include "mitkBinaryThresholdULTool.h"
 #include "mitkDataNode.h"
 
 #include <itkImage.h>
@@ -40,53 +41,28 @@ namespace mitk
 
   Last contributor: $Author$
   */
-  class MITKSEGMENTATION_EXPORT BinaryThresholdTool : public AutoSegmentationTool
+  class MITKSEGMENTATION_EXPORT BinaryThresholdTool : public BinaryThresholdULTool
   {
   public:
 
-    Message3<double,double, bool> IntervalBordersChanged;
     Message1<double>     ThresholdingValueChanged;
 
-    mitkClassMacro(BinaryThresholdTool, AutoSegmentationTool);
+    mitkClassMacro(BinaryThresholdTool, BinaryThresholdULTool);
     itkFactorylessNewMacro(Self)
     itkCloneMacro(Self)
 
-    virtual const char** GetXPM() const override;
     us::ModuleResource GetIconResource() const override;
     virtual const char* GetName() const override;
 
-    virtual void Activated() override;
-    virtual void Deactivated() override;
-
     virtual void SetThresholdValue(double value);
-    virtual void AcceptCurrentThresholdValue();
-    virtual void CancelThresholding();
-
 
   protected:
 
     BinaryThresholdTool(); // purposely hidden
     virtual ~BinaryThresholdTool();
 
-    void SetupPreviewNode();
-
-    void CreateNewSegmentationFromThreshold(DataNode* node);
-
-    void OnRoiDataChanged();
-    void UpdatePreview();
-
-    template <typename TPixel, unsigned int VImageDimension>
-    void ITKThresholding( itk::Image<TPixel, VImageDimension>* originalImage, mitk::Image* segmentation, double thresholdValue, unsigned int timeStep );
-
-    DataNode::Pointer m_ThresholdFeedbackNode;
-    DataNode::Pointer m_OriginalImageNode;
-    DataNode::Pointer m_NodeForThresholding;
-
-    double m_SensibleMinimumThresholdValue;
-    double m_SensibleMaximumThresholdValue;
-    double m_CurrentThresholdValue;
-    bool m_IsFloatImage;
-
+    virtual void runItkThreshold(Image::Pointer feedbackImage3D, Image::Pointer previewImage, unsigned int timeStep) override;
+    virtual void updateThresholdValue() override;
   };
 
 } // namespace

--- a/Modules/Segmentation/Interactions/mitkBinaryThresholdULTool.cpp
+++ b/Modules/Segmentation/Interactions/mitkBinaryThresholdULTool.cpp
@@ -85,7 +85,7 @@ void mitk::BinaryThresholdULTool::Activated()
 {
   Superclass::Activated();
 
-  m_ToolManager->RoiDataChanged += mitk::MessageDelegate<mitk::BinaryThresholdULTool>(this, &mitk::BinaryThresholdULTool::OnRoiDataChanged);
+  m_ToolManager->RoiDataChanged += mitk::MessageDelegate<std::remove_reference<decltype(*this)>::type>(this, &mitk::BinaryThresholdULTool::OnRoiDataChanged);
 
   m_OriginalImageNode = m_ToolManager->GetReferenceData(0);
   m_NodeForThresholding = m_OriginalImageNode;
@@ -102,7 +102,7 @@ void mitk::BinaryThresholdULTool::Activated()
 
 void mitk::BinaryThresholdULTool::Deactivated()
 {
-  m_ToolManager->RoiDataChanged -= mitk::MessageDelegate<mitk::BinaryThresholdULTool>(this, &mitk::BinaryThresholdULTool::OnRoiDataChanged);
+  m_ToolManager->RoiDataChanged -= mitk::MessageDelegate<std::remove_reference<decltype(*this)>::type>(this, &mitk::BinaryThresholdULTool::OnRoiDataChanged);
   m_NodeForThresholding = NULL;
   m_OriginalImageNode = NULL;
   try
@@ -163,13 +163,15 @@ void mitk::BinaryThresholdULTool::SetupPreviewNode()
 
         //Let's paint the feedback node green...
         mitk::LabelSetImage::Pointer previewImage = dynamic_cast<mitk::LabelSetImage*> (m_ThresholdFeedbackNode->GetData());
-
-        itk::RGBPixel<float> pixel;
-        pixel[0] = 0.0f;
-        pixel[1] = 1.0f;
-        pixel[2] = 0.0f;
-        previewImage->GetActiveLabel()->SetColor(pixel);
-        previewImage->GetActiveLabelSet()->UpdateLookupTable(previewImage->GetActiveLabel()->GetValue());
+        if (previewImage) 
+        {
+          itk::RGBPixel<float> pixel;
+          pixel[0] = 0.0f;
+          pixel[1] = 1.0f;
+          pixel[2] = 0.0f;
+          previewImage->GetActiveLabel()->SetColor(pixel);
+          previewImage->GetActiveLabelSet()->UpdateLookupTable(previewImage->GetActiveLabel()->GetValue());
+        }
       }
       else
         m_ThresholdFeedbackNode->SetData( mitk::Image::New() );
@@ -191,21 +193,25 @@ void mitk::BinaryThresholdULTool::SetupPreviewNode()
         m_SensibleMaximumThresholdValue = static_cast<double>( statistics->GetScalarValueMax() );
       }
 
-      double range = m_SensibleMaximumThresholdValue - m_SensibleMinimumThresholdValue;
-      m_CurrentLowerThresholdValue = m_SensibleMinimumThresholdValue + range/3.0;
-      m_CurrentUpperThresholdValue = m_SensibleMinimumThresholdValue + 2*range/3.0;
-
       bool isFloatImage = false;
       if ((originalImage->GetPixelType().GetPixelType() == itk::ImageIOBase::SCALAR)
           &&(originalImage->GetPixelType().GetComponentType() == itk::ImageIOBase::FLOAT || originalImage->GetPixelType().GetComponentType() == itk::ImageIOBase::DOUBLE))
       {
         isFloatImage = true;
       }
-
       IntervalBordersChanged.Send(m_SensibleMinimumThresholdValue, m_SensibleMaximumThresholdValue, isFloatImage);
-      ThresholdingValuesChanged.Send(m_CurrentLowerThresholdValue, m_CurrentUpperThresholdValue);
+
+      updateThresholdValue();
     }
   }
+}
+
+void mitk::BinaryThresholdULTool::updateThresholdValue()
+{
+  double range = m_SensibleMaximumThresholdValue - m_SensibleMinimumThresholdValue;
+  m_CurrentLowerThresholdValue = m_SensibleMinimumThresholdValue + range / 3.0;
+  m_CurrentUpperThresholdValue = m_SensibleMinimumThresholdValue + 2 * range / 3.0;
+  ThresholdingValuesChanged.Send(m_CurrentLowerThresholdValue, m_CurrentUpperThresholdValue);
 }
 
 template <typename TPixel, unsigned int VImageDimension>
@@ -309,7 +315,7 @@ void mitk::BinaryThresholdULTool::OnRoiDataChanged()
 }
 
 template <typename TPixel, unsigned int VImageDimension>
-static void ITKThresholding( itk::Image<TPixel, VImageDimension>* originalImage, mitk::Image* segmentation, double lower, double upper, unsigned int timeStep )
+static void mitk::BinaryThresholdULTool::ITKThresholding(itk::Image<TPixel, VImageDimension>* originalImage, mitk::Image* segmentation, double lower, double upper, unsigned int timeStep)
 {
   typedef itk::Image<TPixel, VImageDimension> ImageType;
   typedef itk::Image<mitk::Tool::DefaultSegmentationDataType, VImageDimension> SegmentationType;
@@ -340,8 +346,13 @@ void mitk::BinaryThresholdULTool::UpdatePreview()
       timeSelector->UpdateLargestPossibleRegion();
       Image::Pointer feedBackImage3D = timeSelector->GetOutput();
 
-      AccessByItk_n(feedBackImage3D, ITKThresholding, (previewImage, m_CurrentLowerThresholdValue, m_CurrentUpperThresholdValue, timeStep));
+      runItkThreshold(feedBackImage3D, previewImage, timeStep);
     }
     RenderingManager::GetInstance()->RequestUpdateAll();
   }
+}
+
+void mitk::BinaryThresholdULTool::runItkThreshold(Image::Pointer feedbackImage3D, Image::Pointer previewImage, unsigned int timeStep)
+{
+  AccessByItk_n(feedbackImage3D, ITKThresholding, (previewImage, m_CurrentLowerThresholdValue, m_CurrentUpperThresholdValue, timeStep));
 }

--- a/Modules/Segmentation/Interactions/mitkBinaryThresholdULTool.h
+++ b/Modules/Segmentation/Interactions/mitkBinaryThresholdULTool.h
@@ -91,7 +91,7 @@ namespace mitk
     void ITKThresholding(
       itk::Image<TPixel,
       VImageDimension>* originalImage,
-      mitk::Image* segmentation,
+      mitk::Image::Pointer segmentation,
       double lower,
       double upper,
       unsigned int timeStep

--- a/Modules/Segmentation/Interactions/mitkBinaryThresholdULTool.h
+++ b/Modules/Segmentation/Interactions/mitkBinaryThresholdULTool.h
@@ -21,6 +21,7 @@ See LICENSE.txt or http://www.mitk.org for details.
 #include <MitkSegmentationExports.h>
 #include "mitkAutoSegmentationTool.h"
 #include "mitkDataNode.h"
+#include <mitkImage.h>
 
 #include <itkImage.h>
 #include <itkBinaryThresholdImageFilter.h>
@@ -69,12 +70,13 @@ namespace mitk
     BinaryThresholdULTool(); // purposely hidden
     virtual ~BinaryThresholdULTool();
 
-    void SetupPreviewNode();
+    virtual void SetupPreviewNode();
+    virtual void runItkThreshold(Image::Pointer feedbackImage3D, Image::Pointer previewImage, unsigned int timeStep);
+    virtual void updateThresholdValue();
 
-    void CreateNewSegmentationFromThreshold(DataNode* node);
-
-    void OnRoiDataChanged();
     void UpdatePreview();
+    void CreateNewSegmentationFromThreshold(DataNode* node);
+    void OnRoiDataChanged();
 
     DataNode::Pointer m_ThresholdFeedbackNode;
     DataNode::Pointer m_OriginalImageNode;
@@ -85,11 +87,15 @@ namespace mitk
     mitk::ScalarType m_CurrentLowerThresholdValue;
     mitk::ScalarType m_CurrentUpperThresholdValue;
 
-    typedef itk::Image<int, 3> ImageType;
-    typedef itk::Image< Tool::DefaultSegmentationDataType, 3> SegmentationType; // this is sure for new segmentations
-    typedef itk::BinaryThresholdImageFilter<ImageType, SegmentationType> ThresholdFilterType;
-    ThresholdFilterType::Pointer m_ThresholdFilter;
-
+    template <typename TPixel, unsigned int VImageDimension>
+    void ITKThresholding(
+      itk::Image<TPixel,
+      VImageDimension>* originalImage,
+      mitk::Image* segmentation,
+      double lower,
+      double upper,
+      unsigned int timeStep
+    );
   };
 
 } // namespace


### PR DESCRIPTION
AUT-1312
AUT-1326

Исправил краш и некорректную работу Threshold-инструментов с non-multilabel сегментациями.
Провел рефакторинг, теперь обычный Threshold является частным случаем ULThreshold'а.

Тестовые шаги:
1. Загрузить данные в универсальный кейс.
2. Открыть плагин сегментации.
3. Создать сегментацию в менеджере сегментаций.
   - Проверить, что инструмент Threshold работает как ожидается.
   - Проверить, что инструмент ULThreshold работает как ожидается.
   - Проверить, что новая сегментация создается корректно при нажатии на кнопку New при подтверждении сегментации.
4. Повторить проверки из шага 3 для сегментаций, созданных в плагине.
