### PR TITLE
Краш при перетаскивании сегментации в менеджер данных

### DIFF
--- a/Modules/QtWidgets/src/QmitkDataStorageTreeModel.cpp
+++ b/Modules/QtWidgets/src/QmitkDataStorageTreeModel.cpp
@@ -164,6 +164,10 @@ bool QmitkDataStorageTreeModel::dropMimeData(const QMimeData *data,
 
     // First we extract a Qlist of TreeItem* pointers.
     QList<TreeItem*> listOfItemsToDrop = ToTreeItemPtrList(data);
+    if (listOfItemsToDrop.size() == 0)
+    {
+      return false;
+    }
 
     // Retrieve the TreeItem* where we are dropping stuff, and its parent.
     TreeItem* dropItem = this->TreeItemFromIndex(parent);


### PR DESCRIPTION
AUT-1357

Менеджер данных принимает данные общего типа application/x-qabstractitemmodeldatalist, но при этом не производит проверки на их валидность. Из-за этого получается пустой список, при обращении к элементам которого и происходит краш.
Теперь список проверяется перед использованием.

Тестовые шаги на видео в AUT-1357
