### PR TITLE
Краш в 3Д-интерполяции

### DIFF
--- a/Modules/ContourModel/DataManagement/mitkContourElement.cpp
+++ b/Modules/ContourModel/DataManagement/mitkContourElement.cpp
@@ -266,7 +266,10 @@ bool mitk::ContourElement::IsNearContour(const mitk::Point3D &point, float eps)
 {
     ConstVertexIterator it1 = this->m_Vertices->begin();
     ConstVertexIterator it2 = this->m_Vertices->begin();
-    it2 ++; // it2 runs one position ahead
+    if (it2 != this->m_Vertices->end())
+    {
+      it2++; // it2 runs one position ahead
+    }
 
     ConstVertexIterator end = this->m_Vertices->end();
 

--- a/Modules/Core/src/DataManagement/mitkSurface.cpp
+++ b/Modules/Core/src/DataManagement/mitkSurface.cpp
@@ -151,13 +151,14 @@ vtkPolyData* mitk::Surface::GetVtkPolyData(unsigned int t) const
 {
   if (t < m_PolyDatas.size())
   {
-    if(m_PolyDatas[t] == nullptr && this->GetSource().IsNotNull())
+    auto source = GetSource();
+    if (m_PolyDatas[t] == nullptr && source)
     {
       RegionType requestedRegion;
       requestedRegion.SetIndex(3, t);
       requestedRegion.SetSize(3, 1);
       this->m_RequestedRegion = requestedRegion;
-      this->GetSource()->Update();
+      source->Update();
     }
 
     return m_PolyDatas[t].GetPointer();
@@ -168,8 +169,9 @@ vtkPolyData* mitk::Surface::GetVtkPolyData(unsigned int t) const
 
 void mitk::Surface::UpdateOutputInformation()
 {
-  if (this->GetSource().IsNotNull())
-    this->GetSource()->UpdateOutputInformation();
+  auto source = GetSource();
+  if (source)
+    source->UpdateOutputInformation();
 
   if (m_CalculateBoundingBox == true && !m_PolyDatas.empty())
     this->CalculateBoundingBox();


### PR DESCRIPTION
AUT-1410

Один очень странный краш в mitkSurface - проверка на 0, которая проходила, но переменная все равно было 0.
И еще один краш в петле: если итератор пустой, его нельзя увеличивать.

Тестовые шаги на видео в AUT-1410.