### PR TITLE
Краш в 3Д-интерполяции

### DIFF
--- a/Modules/SegmentationUI/Qmitk/QmitkSlicesInterpolator.cpp
+++ b/Modules/SegmentationUI/Qmitk/QmitkSlicesInterpolator.cpp
@@ -218,8 +218,19 @@ QmitkSlicesInterpolator::QmitkSlicesInterpolator(QWidget* parent, const char*  /
 
 void QmitkSlicesInterpolator::SetDataStorage( mitk::DataStorage::Pointer storage )
 {
+  if (m_DataStorage)
+  {
+    m_DataStorage->RemoveNodeEvent.RemoveListener(
+      mitk::MessageDelegate1<QmitkSlicesInterpolator, const mitk::DataNode*>(this, &QmitkSlicesInterpolator::nodeRemoved)
+    );
+  }
+   
   m_DataStorage = storage;
   m_SurfaceInterpolator->SetDataStorage(storage);
+
+  m_DataStorage->RemoveNodeEvent.AddListener(
+    mitk::MessageDelegate1<QmitkSlicesInterpolator, const mitk::DataNode*>(this, &QmitkSlicesInterpolator::nodeRemoved)
+  );
 }
 
 mitk::DataStorage* QmitkSlicesInterpolator::GetDataStorage()
@@ -311,6 +322,12 @@ QmitkSlicesInterpolator::~QmitkSlicesInterpolator()
     // remove old observers
     Uninitialize();
   }
+
+  WaitForFutures();
+
+  m_DataStorage->RemoveNodeEvent.RemoveListener(
+    mitk::MessageDelegate1<QmitkSlicesInterpolator, const mitk::DataNode*>(this, &QmitkSlicesInterpolator::nodeRemoved)
+  );
 
   if (m_DataStorage.IsNotNull()) {
     if (m_DataStorage->Exists(m_3DContourNode))
@@ -1289,5 +1306,29 @@ void QmitkSlicesInterpolator::OnSliceNavigationControllerDeleted(const itk::Obje
     m_ControllerToTimeObserverTag.remove(slicer);
     m_ControllerToSliceObserverTag.remove(slicer);
     m_ControllerToDeleteObserverTag.remove(slicer);
+  }
+}
+
+void QmitkSlicesInterpolator::WaitForFutures()
+{
+  if (m_Watcher.isRunning())
+  {
+    m_Watcher.waitForFinished();
+  }
+
+  if (m_PlaneWatcher.isRunning())
+  {
+    m_PlaneWatcher.waitForFinished();
+  }
+}
+
+void QmitkSlicesInterpolator::nodeRemoved(const mitk::DataNode* node)
+{
+  if ((m_ToolManager && m_ToolManager->GetWorkingData(0) == node) ||
+      node == m_3DContourNode ||
+      node == m_FeedbackNode ||
+      node == m_InterpolatedSurfaceNode)
+  {
+    WaitForFutures();
   }
 }

--- a/Modules/SegmentationUI/Qmitk/QmitkSlicesInterpolator.h
+++ b/Modules/SegmentationUI/Qmitk/QmitkSlicesInterpolator.h
@@ -259,6 +259,8 @@ private:
     void Show2DInterpolationControls(bool show);
     void Show3DInterpolationControls(bool show);
     void CheckSupportedImageDimension();
+    void WaitForFutures();
+    void nodeRemoved(const mitk::DataNode* node);
 
     mitk::SegmentationInterpolationController::Pointer m_Interpolator;
     mitk::SurfaceInterpolationController::Pointer m_SurfaceInterpolator;


### PR DESCRIPTION
AUT-1420

Проблема была в QFuture, которые продолжали работать, когда закрывались их данные или сам плагин. Теперь виджет интерполяции будет ждать завершения фьючеров перед удалением рабочих данных и перед закрытием.

Тестовые шаги:

1. Загрузить данные в универсальный кейс.
2. Создать сегментацию, открыть плагин "Сегментация".
3. Включить 3Д-интерполяцию.
4. Нарисовать инструментом "Add" несколько областей на разных срезах.
5. Пока интерполяция в процессе, удалить рабочую сегментацию.
   - Сегментация удаляется только после того, как интерполяция построена. 
   - Краша нет.
6. Повторить шаги 2-4.
7. Нажать на кнопку "Suggest a plane" и закрыть плагин, пока идет обработка.
   - Краша нет.