### PR TITLE
Краш при нажатии "Закрыть проект", шаги прогресс-бара

### DIFF
--- a/Modules/SegmentationUI/Qmitk/QmitkSlicesInterpolator.cpp
+++ b/Modules/SegmentationUI/Qmitk/QmitkSlicesInterpolator.cpp
@@ -218,7 +218,12 @@ QmitkSlicesInterpolator::QmitkSlicesInterpolator(QWidget* parent, const char*  /
 
 void QmitkSlicesInterpolator::SetDataStorage( mitk::DataStorage::Pointer storage )
 {
-  if (m_DataStorage)
+  if (m_DataStorage == storage)
+  {
+    return;
+  }
+
+  if (m_DataStorage.IsNotNull())
   {
     m_DataStorage->RemoveNodeEvent.RemoveListener(
       mitk::MessageDelegate1<QmitkSlicesInterpolator, const mitk::DataNode*>(this, &QmitkSlicesInterpolator::nodeRemoved)
@@ -228,9 +233,12 @@ void QmitkSlicesInterpolator::SetDataStorage( mitk::DataStorage::Pointer storage
   m_DataStorage = storage;
   m_SurfaceInterpolator->SetDataStorage(storage);
 
-  m_DataStorage->RemoveNodeEvent.AddListener(
-    mitk::MessageDelegate1<QmitkSlicesInterpolator, const mitk::DataNode*>(this, &QmitkSlicesInterpolator::nodeRemoved)
-  );
+  if (m_DataStorage.IsNotNull())
+  {
+    m_DataStorage->RemoveNodeEvent.AddListener(
+      mitk::MessageDelegate1<QmitkSlicesInterpolator, const mitk::DataNode*>(this, &QmitkSlicesInterpolator::nodeRemoved)
+    );
+  }
 }
 
 mitk::DataStorage* QmitkSlicesInterpolator::GetDataStorage()
@@ -325,11 +333,11 @@ QmitkSlicesInterpolator::~QmitkSlicesInterpolator()
 
   WaitForFutures();
 
-  m_DataStorage->RemoveNodeEvent.RemoveListener(
-    mitk::MessageDelegate1<QmitkSlicesInterpolator, const mitk::DataNode*>(this, &QmitkSlicesInterpolator::nodeRemoved)
-  );
-
-  if (m_DataStorage.IsNotNull()) {
+  if (m_DataStorage.IsNotNull()) 
+  {
+    m_DataStorage->RemoveNodeEvent.RemoveListener(
+      mitk::MessageDelegate1<QmitkSlicesInterpolator, const mitk::DataNode*>(this, &QmitkSlicesInterpolator::nodeRemoved)
+    );
     if (m_DataStorage->Exists(m_3DContourNode))
       m_DataStorage->Remove(m_3DContourNode);
     if (m_DataStorage->Exists(m_InterpolatedSurfaceNode))

--- a/Modules/SegmentationUI/Qmitk/QmitkSlicesInterpolator.cpp
+++ b/Modules/SegmentationUI/Qmitk/QmitkSlicesInterpolator.cpp
@@ -884,7 +884,7 @@ void::QmitkSlicesInterpolator::OnSuggestPlaneClicked()
 void::QmitkSlicesInterpolator::RunPlaneSuggestion()
 {
   if(m_FirstRun)
-    mitk::ProgressBar::GetInstance()->AddStepsToDo(8);
+    mitk::ProgressBar::GetInstance()->AddStepsToDo(7);
   else
     mitk::ProgressBar::GetInstance()->AddStepsToDo(3);
 


### PR DESCRIPTION
AUT-1449
AUT-1421

Проблема была в том, что при обработке NodeRemoved обработчик этого события удалялся из хранилища. Но в цикле обработки уже использовался свой список, где этот обработчик уже был сохранен. В итоге обработчик становился невалидным и при обращении к нему происходил краш.

Проблема с прогресс-баром была просто в неправильном количестве шагов при определении плоскости: 8 шагов, но всего 7 обновлений.

Тестовые шаги:

1. Загрузить данные в универсальный кейс.
2. Нажать "Закрыть проект".
   - Проект закрылся, краша нет.