### PR TITLE
Краш в калькуляторе статистики

### DIFF
--- a/Modules/ImageStatistics/mitkImageStatisticsCalculator.h
+++ b/Modules/ImageStatistics/mitkImageStatisticsCalculator.h
@@ -396,7 +396,12 @@ namespace mitk
     * corresponding to the PlanarFigure will be extracted from the original
     * image. If masking is disabled, the original image is simply passed
     * through. */
-    void ExtractImageAndMask( unsigned int timeStep = 0 );
+    void ExtractImageAndMask(
+      unsigned int timeStep, 
+      mitk::Image::ConstPointer& internalImage,
+      MaskImage3DType::Pointer& internalImageMask3D,
+      MaskImage2DType::Pointer& internalImageMask2D
+    );
 
     /*calculate the min and max value, this is done because we need the min and max value before execution the statistics filter to have the wright range for the histogramm*/
     template < typename TPixel, unsigned int VImageDimension >
@@ -424,7 +429,7 @@ namespace mitk
 
     template < typename TPixel, unsigned int VImageDimension >
     void InternalCalculateMaskFromPlanarFigure(
-      const itk::Image< TPixel, VImageDimension > *image, unsigned int axis );
+      const itk::Image< TPixel, VImageDimension > *image, unsigned int axis, MaskImage2DType::Pointer& internalImageMask2D);
 
     template < typename TPixel, unsigned int VImageDimension >
     void InternalMaskIgnoredPixels(
@@ -565,11 +570,6 @@ namespace mitk
 
     unsigned int m_MaskingMode;
     bool m_MaskingModeChanged;
-
-    /** m_InternalImage contains a image volume at one time step (e.g. 2D, 3D)*/
-    mitk::Image::ConstPointer m_InternalImage;
-    MaskImage3DType::Pointer m_InternalImageMask3D;
-    MaskImage2DType::Pointer m_InternalImageMask2D;
 
     TimeStampVectorType m_ImageStatisticsTimeStampVector;
     TimeStampVectorType m_MaskedImageStatisticsTimeStampVector;


### PR DESCRIPTION
AUT-1279

Проблема была в умных указателях внутри калькулятора и в исключении.
Калькулятор держит внутри себя два умных указателя: на изображение целиком (m_Image) и на его отдельный слайс (m_InternalImage). 
В теории отдельный слайс должен быть проинициализирован в начале функции ImageStatisticsCalculator::ComputeStatistics() (внутри ExtractImageAndMask()) и очищен в конце.
Но если в процессе работы ExtractImageAndMask() возникает исключение, код никогда не дойдет до конца ComputeStatistics() и m_InternalImage будет по-прежнему указывать на какой-то слайс из изображения.
Дальше, при попытке установить новое изображение в калькулятор m_Image будет переписано, старое изображение будет удалено (потому что на него больше ничего не указывает), но m_InternalImage, которое указывает на один из его слайсов, все еще будет существовать. 
Дальше, при попытке перезаписать m_InternalImage, оно наконец-то будет удалено, вызовет деструктор объекта ImageVtkWriteAccessor, которым владеет, и ImageVtkWriteAccessor обратится к m_Image, которое уже было удалено раньше. И будет краш.

Я заменил указатель-член класса m_InternalImage на обычную локальную переменную. И теперь указатель корректно очищается при размотке стека даже в случае исключений.

Тестовые шаги:

1. Загрузить данные в дентальный кейс.
2. На втором шаге нарисовать круг, который выходит за пределы изображения (и статистика для него не считается).
3. Перейти на третий шаг и вернуться на второй.
4. Вернуться на экран выбора кейса и запустить дентальный кейс с тем же изображением.
5. Перейти на второй шаг.
   - Краша нет, круг нарисован, как и прежде.