### PR TITLE
Краш в деструкторе интерактора

### DIFF
--- a/Modules/Core/src/Interactions/mitkDataInteractor.cpp
+++ b/Modules/Core/src/Interactions/mitkDataInteractor.cpp
@@ -29,11 +29,6 @@ mitk::DataInteractor::DataInteractor()
 
 mitk::DataInteractor::~DataInteractor()
 {
-  if (m_DataNode.IsNotNull())
-  {
-    if (m_DataNode->GetDataInteractor() == this)
-      m_DataNode->SetDataInteractor(nullptr);
-  }
 }
 
 mitk::DataNode* mitk::DataInteractor::GetDataNode() const


### PR DESCRIPTION
AUT-1471

Если не отсоединить интерактор от ноды, при удалении этой ноды будет краш.
Это происходит потому, что интерактор пытается отсоединить себя от ноды в деструкторе, что при водит к вызову этого деструктора снова и снова.

В то же время, надо держит умный указатель на интерактор. Если вызван деструктор интерактора, значит, нода уже уничтожена (иначе интерактор бы жил из-за умного указателя). Таким образом, в деструкторе интерактора делать ничего не надо.