### PR TITLE
Выключение драг-анд-дропа в менеджере данных

### DIFF
--- a/Plugins/org.mitk.gui.qt.datamanager/src/QmitkDataManagerView.cpp
+++ b/Plugins/org.mitk.gui.qt.datamanager/src/QmitkDataManagerView.cpp
@@ -37,7 +37,6 @@ See LICENSE.txt or http://www.mitk.org for details.
 #include <mitkIRenderingManager.h>
 #include <mitkImageCast.h>
 //## Qmitk
-#include <QmitkDnDFrameWidget.h>
 #include <QmitkIOUtil.h>
 #include <QmitkDataStorageTreeModel.h>
 #include <QmitkCustomVariants.h>
@@ -438,15 +437,8 @@ void QmitkDataManagerView::CreateQtPartControl(QWidget* parent)
   unknownDataNodeDescriptor->AddAction(actionShowInfoDialog);
   m_DescriptorActionList.push_back(std::pair<QmitkNodeDescriptor*, QAction*>(unknownDataNodeDescriptor,actionShowInfoDialog));
 
-  QGridLayout* _DndFrameWidgetLayout = new QGridLayout;
-  _DndFrameWidgetLayout->addWidget(m_NodeTreeView, 0, 0);
-  _DndFrameWidgetLayout->setContentsMargins(0,0,0,0);
-
-  m_DndFrameWidget = new QmitkDnDFrameWidget(m_Parent);
-  m_DndFrameWidget->setLayout(_DndFrameWidgetLayout);
-
   QVBoxLayout* layout = new QVBoxLayout(parent);
-  layout->addWidget(m_DndFrameWidget);
+  layout->addWidget(m_NodeTreeView);
   layout->setContentsMargins(0,0,0,0);
 
   m_Parent->setLayout(layout);

--- a/Plugins/org.mitk.gui.qt.datamanager/src/QmitkDataManagerView.h
+++ b/Plugins/org.mitk.gui.qt.datamanager/src/QmitkDataManagerView.h
@@ -42,7 +42,6 @@ class QToolBar;
 class QMenu;
 class QSignalMapper;
 
-class QmitkDnDFrameWidget;
 class QmitkDataStorageTreeModel;
 class QmitkDataManagerItemDelegate;
 class QmitkNumberPropertySlider;
@@ -212,7 +211,6 @@ protected:
 protected:
 
   QWidget* m_Parent;
-  QmitkDnDFrameWidget* m_DndFrameWidget;
 
   ///
   /// \brief A plain widget as the base pane.


### PR DESCRIPTION
http://192.168.3.243:8083/browse/AUT-1510

Так как стандартный драг&дроп в МИТК работает по-другому, нежели в Автоплане, я выключил его поддержку в менеджере данных.

Тестовые шаги:

1. Загрузить данные в универсальный кейс.
2. Перетащить данные на менеджер данных.
   - Он их не принимает.