### PR TITLE
GUI для инструмента Region Growing 2D

### DIFF
--- a/Modules/Segmentation/Interactions/mitkRegionGrowingTool.cpp
+++ b/Modules/Segmentation/Interactions/mitkRegionGrowingTool.cpp
@@ -42,8 +42,6 @@ namespace mitk {
 MITK_TOOL_MACRO(MITKSEGMENTATION_EXPORT, RegionGrowingTool, "Region growing tool");
 }
 
-#define ROUND(a)     ((a)>0 ? (int)((a)+0.5) : -(int)(0.5-(a)))
-
 mitk::RegionGrowingTool::RegionGrowingTool()
     :FeedbackContourTool("PressMoveRelease"),
       m_SeedValue(0),
@@ -461,6 +459,8 @@ void mitk::RegionGrowingTool::OnMouseMoved(StateMachineAction*, InteractionEvent
         m_Thresholds[0] = std::min<ScalarType>(m_SeedValue, m_InitialThresholds[0] - (m_ScreenYDifference - m_ScreenXDifference) * m_MouseDistanceScaleFactor);
         m_Thresholds[1] = std::max<ScalarType>(m_SeedValue, m_InitialThresholds[1] + (m_ScreenYDifference + m_ScreenXDifference) * m_MouseDistanceScaleFactor);
         MITK_DEBUG << "Screen difference X: " << m_ScreenXDifference;
+
+        thresholdsChanged.Send(m_Thresholds[0], m_Thresholds[1]);
 
         // Perform region growing again and show the result
         mitk::Image::Pointer resultImage = mitk::Image::New();

--- a/Modules/Segmentation/Interactions/mitkRegionGrowingTool.h
+++ b/Modules/Segmentation/Interactions/mitkRegionGrowingTool.h
@@ -68,6 +68,8 @@ class MITKSEGMENTATION_EXPORT RegionGrowingTool : public FeedbackContourTool
 
     virtual const char* GetName() const override;
 
+    Message2<double, double> thresholdsChanged;
+
   protected:
 
     RegionGrowingTool(); // purposely hidden

--- a/Modules/SegmentationUI/Qmitk/QmitkRegionGrowingToolGUI.cpp
+++ b/Modules/SegmentationUI/Qmitk/QmitkRegionGrowingToolGUI.cpp
@@ -1,0 +1,44 @@
+#include "QmitkRegionGrowingToolGUI.h"
+
+
+MITK_TOOL_GUI_MACRO(MITKSEGMENTATIONUI_EXPORT, QmitkRegionGrowingToolGUI, "")
+
+QmitkRegionGrowingToolGUI::QmitkRegionGrowingToolGUI()
+  : QmitkToolGUI()
+{
+  m_Controls.setupUi(this);
+
+  connect(this, SIGNAL(NewToolAssociated(mitk::Tool*)), this, SLOT(OnNewToolAssociated(mitk::Tool*)));
+}
+
+QmitkRegionGrowingToolGUI::~QmitkRegionGrowingToolGUI()
+{
+  if (m_RegionGrowingTool.IsNotNull())
+  {
+    m_RegionGrowingTool->thresholdsChanged -=
+      mitk::MessageDelegate2<QmitkRegionGrowingToolGUI, double, double>(this, &QmitkRegionGrowingToolGUI::onThresholdsChanged);
+  }
+}
+
+void QmitkRegionGrowingToolGUI::OnNewToolAssociated(mitk::Tool* tool)
+{
+  if (m_RegionGrowingTool.IsNotNull())
+  {
+    m_RegionGrowingTool->thresholdsChanged -=
+      mitk::MessageDelegate2<QmitkRegionGrowingToolGUI, double, double>(this, &QmitkRegionGrowingToolGUI::onThresholdsChanged);
+  }
+
+  m_RegionGrowingTool = dynamic_cast<mitk::RegionGrowingTool*>(m_Tool.GetPointer());
+
+  if (m_RegionGrowingTool.IsNotNull())
+  {
+    m_RegionGrowingTool->thresholdsChanged +=
+      mitk::MessageDelegate2<QmitkRegionGrowingToolGUI, double, double>(this, &QmitkRegionGrowingToolGUI::onThresholdsChanged);
+  }
+}
+
+void QmitkRegionGrowingToolGUI::onThresholdsChanged(double lowThreshold, double highThreshold)
+{
+  m_Controls.lowThresholdValue->setText(QString::number(lowThreshold));
+  m_Controls.highThresholdValue->setText(QString::number(highThreshold));
+}

--- a/Modules/SegmentationUI/Qmitk/QmitkRegionGrowingToolGUI.h
+++ b/Modules/SegmentationUI/Qmitk/QmitkRegionGrowingToolGUI.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <mitkRegionGrowingTool.h>
+
+#include "QmitkToolGUI.h"
+#include "ui_QmitkRegionGrowingToolGUIControls.h"
+
+class RegionGrowingTool;
+
+class MITKSEGMENTATIONUI_EXPORT QmitkRegionGrowingToolGUI : public QmitkToolGUI
+{
+  Q_OBJECT
+
+public:
+  mitkClassMacro(QmitkRegionGrowingToolGUI, QmitkToolGUI);
+  itkFactorylessNewMacro(Self)
+  itkCloneMacro(Self)
+
+protected slots:
+  void OnNewToolAssociated(mitk::Tool* tool);
+
+protected:
+
+  QmitkRegionGrowingToolGUI();
+  virtual ~QmitkRegionGrowingToolGUI();
+
+  void onThresholdsChanged(double lowThreshold, double highThreshold);
+
+  mitk::RegionGrowingTool::Pointer m_RegionGrowingTool;
+  Ui::QmitkRegionGrowingToolGUIControls m_Controls;
+};

--- a/Modules/SegmentationUI/Qmitk/QmitkRegionGrowingToolGUIControls.ui
+++ b/Modules/SegmentationUI/Qmitk/QmitkRegionGrowingToolGUIControls.ui
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QmitkRegionGrowingToolGUIControls</class>
+ <widget class="QWidget" name="QmitkRegionGrowingToolGUIControls">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>295</width>
+    <height>55</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Ignored" vsizetype="Minimum">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>QmitkLiveWireTool2DGUIControls</string>
+  </property>
+  <property name="toolTip">
+   <string>Confirm all previous contour.</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="1" column="0">
+      <widget class="QLabel" name="highThresholdLabel">
+       <property name="text">
+        <string>High Threshold:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="lowThresholdLabel">
+       <property name="text">
+        <string>Low Threshold:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLabel" name="lowThresholdValue">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLabel" name="highThresholdValue">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <layoutdefault spacing="6" margin="11"/>
+ <resources/>
+ <connections/>
+</ui>

--- a/Modules/SegmentationUI/files.cmake
+++ b/Modules/SegmentationUI/files.cmake
@@ -24,6 +24,7 @@ Qmitk/QmitkToolRoiDataSelectionBox.cpp
 Qmitk/QmitkToolSelectionBox.cpp
 Qmitk/QmitkToolWorkingDataSelectionBox.cpp
 Qmitk/QmitkWatershedToolGUI.cpp
+Qmitk/QmitkRegionGrowingToolGUI.cpp
 )
 
 set(MOC_H_FILES
@@ -51,6 +52,7 @@ Qmitk/QmitkToolRoiDataSelectionBox.h
 Qmitk/QmitkToolSelectionBox.h
 Qmitk/QmitkToolWorkingDataSelectionBox.h
 Qmitk/QmitkWatershedToolGUI.h
+Qmitk/QmitkRegionGrowingToolGUI.h
 )
 
 set(UI_FILES
@@ -59,4 +61,5 @@ Qmitk/QmitkConfirmSegmentationDialog.ui
 Qmitk/QmitkOtsuToolWidgetControls.ui
 Qmitk/QmitkPickingToolGUIControls.ui
 Qmitk/QmitkLiveWireTool2DGUIControls.ui
+Qmitk/QmitkRegionGrowingToolGUIControls.ui
 )


### PR DESCRIPTION
http://samsmu.net:8083/browse/AUT-1518

Я не смог воспроизвести проблему, но изменение лимитов в Region Growing совсем не очевидно.
Так что я добавил отображение этих лимитов в плагине в реальном времени.

Посмотрим, поможет ли это рентгенологам.
В любом случае, это поможет нам найти, в чем проблема при следующем ее появлении.

Тестовые шаги:

1. Загрузить данные в универсальный кейс.
2. Создать сегментацию, включить Region Growing 2D.
   - При использовании этого инструмента в плагине Сегментация сверху от панели инструментов отображаются нижняя и верхняя границы.