### PR TITLE
Краш в плагине Basic Image Processing

### DIFF
--- a/Plugins/org.mitk.gui.qt.basicimageprocessing/src/internal/QmitkBasicImageProcessingView.cpp
+++ b/Plugins/org.mitk.gui.qt.basicimageprocessing/src/internal/QmitkBasicImageProcessingView.cpp
@@ -174,6 +174,9 @@ QmitkBasicImageProcessing::QmitkBasicImageProcessing()
 
 QmitkBasicImageProcessing::~QmitkBasicImageProcessing()
 {
+  if (m_TimeStepperAdapter) {
+    delete m_TimeStepperAdapter;
+  }
   //berry::ISelectionService* s = GetSite()->GetWorkbenchWindow()->GetSelectionService();
   //if(s)
   //  s->RemoveSelectionListener(m_SelectionListener);
@@ -272,6 +275,10 @@ void QmitkBasicImageProcessing::InternalGetTimeNavigationController()
     auto tnc = renwin_part->GetTimeNavigationController();
     if( tnc != nullptr )
     {
+      if (m_TimeStepperAdapter) {
+        delete m_TimeStepperAdapter;
+      }
+
       m_TimeStepperAdapter = new QmitkStepperAdapter((QObject*) m_Controls->sliceNavigatorTime, tnc->GetTime(), "sliceNavigatorTimeFromBIP");
     }
   }

--- a/Plugins/org.mitk.gui.qt.basicimageprocessing/src/internal/QmitkBasicImageProcessingView.cpp
+++ b/Plugins/org.mitk.gui.qt.basicimageprocessing/src/internal/QmitkBasicImageProcessingView.cpp
@@ -303,6 +303,7 @@ void QmitkBasicImageProcessing::OnSelectionChanged(berry::IWorkbenchPart::Pointe
   *m_SelectedImageNode = _DataNode;
   //try to cast to image
   mitk::Image::Pointer tempImage = dynamic_cast<mitk::Image*>(m_SelectedImageNode->GetNode()->GetData());
+  this->InternalGetTimeNavigationController();
 
     //no image
     if( tempImage.IsNull() || (tempImage->IsInitialized() == false) )
@@ -325,8 +326,6 @@ void QmitkBasicImageProcessing::OnSelectionChanged(berry::IWorkbenchPart::Pointe
     if ( tempImage->GetDimension() > 3 )
     {
       // try to retrieve the TNC (for 4-D Processing )
-      this->InternalGetTimeNavigationController();
-
       m_Controls->sliceNavigatorTime->setEnabled(true);
       m_Controls->tlTime->setEnabled(true);
     }


### PR DESCRIPTION
http://samsmu.net:8083/browse/AUT-1531

Проблема в том, что объект QmitkStepperAdapter создается только для 4D изображений, но этот объект требуется для корректной работы mitk::Stepper, который, в свою очередь, используется и для 3D изображений.
Теперь QmitkStepperAdapter инициализируется всегда и удаляется в деструкторе.

Тестовые шаги в http://samsmu.net:8083/browse/AUT-1531.