### PR TITLE
Исправление скролла с Ctrl

### DIFF
--- a/Modules/Core/resource/Interactions/DisplayConfigMITK.xml
+++ b/Modules/Core/resource/Interactions/DisplayConfigMITK.xml
@@ -71,6 +71,9 @@
     <attribute name="Modifiers" value="ctrl"/>
     <attribute name="EventButton" value="LeftMouseButton"/>
   </event_variant>
+  <event_variant class="MouseReleaseEvent" name="EndScrolling">
+    <attribute name="EventButton" value="LeftMouseButton"/>
+  </event_variant>
   <event_variant class="MouseMoveEvent" name="Scrolling">
     <attribute name="Modifiers" value="ctrl"/>
     <attribute name="ButtonState" value="LeftMouseButton"/>


### PR DESCRIPTION
http://samsmu.net:8083/browse/AUT-1548

В интеракторе была неправильная карта переходов: выход из ctrl-скроллинга осуществлялся только если нажат Ctrl и отпущена левая кнопка мыши. 
Если Ctrl отпускался раньше кнопки мыши, система оставалась в Ctrl-скроллинге.

Тестовые шаги:

1. Загрузить данные во вьювер.
2. Прокрутить срезы колесиком.
   - Скролл работает.
3. Зажать Ctrl и прокрутить срезы движением мыши.
   - Скролл работает.
4. Отпустить сначала Ctrl, потом кнопку мыши.
5. Прокрутить срезы колесиком.
   - Скролл работает.
6. Зажать Ctrl и прокрутить срезы движением мыши.
   - Скролл работает.
7. Отпустить сначала кнопку мыши, потом Ctrl.
8. Прокрутить срезы колесиком.
   - Скролл работает.