### PR TITLE
Исправление скролла с Ctrl (попытка номер 2)

### DIFF
--- a/Modules/Core/resource/Interactions/DisplayInteraction.xml
+++ b/Modules/Core/resource/Interactions/DisplayInteraction.xml
@@ -129,6 +129,7 @@ TODO Std move to abort interaction of scroll/pan/zoom
       </transition>
       <transition event_class="InteractionPositionEvent" event_variant="EndScrolling" target="start"/>
       <transition event_class="InteractionPositionEvent" event_variant="EndScrollingVar" target="start"/>
+      <transition event_class="InteractionPositionEvent" event_variant="EndMoveCrosshair" target="start"/>
     </state>
     <state name="adjustlevelwindow">
       <transition event_class="InteractionPositionEvent" event_variant="adjustlevelwindow" target="adjustlevelwindow">

--- a/Modules/Core/resource/Interactions/DisplayInteraction.xml
+++ b/Modules/Core/resource/Interactions/DisplayInteraction.xml
@@ -87,6 +87,9 @@ TODO Std move to abort interaction of scroll/pan/zoom
         <action name="updateStatusbar"/>
       </transition>
       <transition event_class="InteractionPositionEvent" event_variant="EndMoveCrosshair" target="start"/>
+      <transition event_class="InteractionPositionEvent" event_variant="EndMoving" target="start"/>
+      <transition event_class="InteractionPositionEvent" event_variant="EndScrolling" target="start"/>
+      <transition event_class="InteractionPositionEvent" event_variant="EndLevelWindow" target="start"/>
 
       <!-- Case when we jumped in from rotation (wanted to rotate, but not possible, so alternative action is to set crosshair) -->
       <transition event_class="InteractionPositionEvent"  event_variant="Rotate" target="crosshair">
@@ -114,6 +117,9 @@ TODO Std move to abort interaction of scroll/pan/zoom
         <action name="move"/>
       </transition>
       <transition event_class="InteractionPositionEvent" event_variant="EndMoving" target="start"/>
+      <transition event_class="InteractionPositionEvent" event_variant="EndScrolling" target="start"/>
+      <transition event_class="InteractionPositionEvent" event_variant="EndMoveCrosshair" target="start"/>
+      <transition event_class="InteractionPositionEvent" event_variant="EndLevelWindow" target="start"/>
     </state>
     <state name="zoom">
       <transition event_class="InteractionPositionEvent" event_variant="Zooming" target="zoom">
@@ -130,6 +136,8 @@ TODO Std move to abort interaction of scroll/pan/zoom
       <transition event_class="InteractionPositionEvent" event_variant="EndScrolling" target="start"/>
       <transition event_class="InteractionPositionEvent" event_variant="EndScrollingVar" target="start"/>
       <transition event_class="InteractionPositionEvent" event_variant="EndMoveCrosshair" target="start"/>
+      <transition event_class="InteractionPositionEvent" event_variant="EndMoving" target="start"/>
+      <transition event_class="InteractionPositionEvent" event_variant="EndLevelWindow" target="start"/>      
     </state>
     <state name="adjustlevelwindow">
       <transition event_class="InteractionPositionEvent" event_variant="adjustlevelwindow" target="adjustlevelwindow">
@@ -137,6 +145,9 @@ TODO Std move to abort interaction of scroll/pan/zoom
         <action name="levelWindow"/>
       </transition>
       <transition event_class="InteractionPositionEvent" event_variant="EndLevelWindow" target="start"/>
+      <transition event_class="InteractionPositionEvent" event_variant="EndScrolling" target="start"/>
+      <transition event_class="InteractionPositionEvent" event_variant="EndMoveCrosshair" target="start"/>
+      <transition event_class="InteractionPositionEvent" event_variant="EndMoving" target="start"/>
     </state>
     <state name="rotationPossible">
       <transition event_class="InteractionPositionEvent" event_variant="StartRotate" target="rotation">


### PR DESCRIPTION
http://samsmu.net:8083/browse/AUT-1548

В интеракторе была неправильная карта переходов: выход из ctrl-скроллинга осуществлялся только если нажат Ctrl и отпущена левая кнопка мыши. 
Если Ctrl отпускался раньше кнопки мыши, система оставалась в Ctrl-скроллинге.
В отличии от предыдущего исправления, теперь я не добавил новое событие, а изменил саму карту переходов так, чтобы отпускание левой кнопки мыши даже без нажатого Ctrl переводило нас в стартовое состояние.

Тестовые шаги:

1. Загрузить данные во вьювер.
2. Прокрутить срезы колесиком.
   - Скролл работает.
3. Зажать Ctrl и прокрутить срезы движением мыши.
   - Скролл работает.
4. Отпустить сначала Ctrl, потом кнопку мыши.
5. Прокрутить срезы колесиком.
   - Скролл работает.
6. Зажать Ctrl и прокрутить срезы движением мыши.
   - Скролл работает.
7. Отпустить сначала кнопку мыши, потом Ctrl.
8. Прокрутить срезы колесиком.
   - Скролл работает.
9. Просто нажать и отпустить левую кнопку мыши.
   - Скролл работает.