### PR TITLE
Краш в CPU режимах Volume Rendering

### DIFF
--- a/Modules/MapperExt/src/mitkGPUVolumeMapper3D.cpp
+++ b/Modules/MapperExt/src/mitkGPUVolumeMapper3D.cpp
@@ -19,6 +19,7 @@ See LICENSE.txt or http://www.mitk.org for details.
 #define GPU_ERROR MITK_ERROR("mapper.vr")
 
 #include "mitkGPUVolumeMapper3D.h"
+VTK_MODULE_INIT(vtkRenderingVolumeOpenGL);
 
 #include "mitkDataNode.h"
 


### PR DESCRIPTION
http://samsmu.net:8083/browse/AUT-1642

В нашей версии МИТК не хватало инициализации одной из vtk фабрик.

Тестовые шаги:

1. Загрузить данные в универсальный кейс.
2. Открыть плагин Volume Rendering.
3. Выбрать изображение, включить Volume Rendering, выбрать CPU режим.
   - Volume Rendering работает, Автоплан не падает.