### PR TITLE
Доработки для задачи логирования

### DIFF
--- a/Modules/Logging/include/AutoplanLogging.h
+++ b/Modules/Logging/include/AutoplanLogging.h
@@ -51,7 +51,7 @@
   #define AUTOPLAN_WARNING BOOST_LOG_STREAM_SEV(Logger::Log::get().lg, boost::log::trivial::warning) << "Warning: "
   #define AUTOPLAN_FATAL BOOST_LOG_STREAM_SEV(Logger::Log::get().lg, boost::log::trivial::fatal) << "Fatal Error: "
 #else
-  #define AUTOPLAN_LOG_CALLER_NAME << "From: " << Logger::details::formatCallerName(BOOST_CURRENT_FUNCTION) 
+  #define AUTOPLAN_LOG_CALLER_NAME << '(' << Logger::details::formatCallerName(BOOST_CURRENT_FUNCTION) <<") "
   #define AUTOPLAN_INFO BOOST_LOG_STREAM_SEV(Logger::Log::get().lg, boost::log::trivial::info) AUTOPLAN_LOG_CALLER_NAME
   #define AUTOPLAN_ERROR BOOST_LOG_STREAM_SEV(Logger::Log::get().lg, boost::log::trivial::error) AUTOPLAN_LOG_CALLER_NAME << "Error: "
   #define AUTOPLAN_TRACE BOOST_LOG_STREAM_SEV(Logger::Log::get().lg, boost::log::trivial::trace) AUTOPLAN_LOG_CALLER_NAME
@@ -69,7 +69,11 @@ ThrowAwayPattern & operator<<(ThrowAwayPattern&__, T)
 }
 
 #ifdef DEBUG_INFO
-  #define AUTOPLAN_DEBUG BOOST_LOG_STREAM_SEV(Logger::Log::get().lg, boost::log::trivial::debug) << "Debug: "
+  #ifdef __APPLE__
+    #define AUTOPLAN_DEBUG BOOST_LOG_STREAM_SEV(Logger::Log::get().lg, boost::log::trivial::debug) << "Debug: "
+  #else
+    #define AUTOPLAN_DEBUG BOOST_LOG_STREAM_SEV(Logger::Log::get().lg, boost::log::trivial::debug) AUTOPLAN_LOG_CALLER_NAME << "Debug: "
+  #endif // __APPLE__
 #else
   #define AUTOPLAN_DEBUG _
 #endif
@@ -162,8 +166,7 @@ namespace Logger
       xp::smatch searchResult;
       if (xp::regex_search(formatedTypeName, searchResult, classNameRegex)) {
         formatedTypeName.assign(searchResult[0].first + 1, searchResult[0].second);
-      }
-      else {
+      } else {
         formatedTypeName.resize(std::min(formatedTypeName.size(), formatedTypeName.find(':')));
       }
       std::reverse(formatedTypeName.begin(), formatedTypeName.end());

--- a/Modules/Logging/src/AutoplanLogging.cpp
+++ b/Modules/Logging/src/AutoplanLogging.cpp
@@ -9,6 +9,11 @@
 
 struct ThrowAwayPattern _ = {};
 
+namespace
+{
+  const char TIME_STAMP_FORMAT[] = "%Y-%m-%d %H:%M:%S";
+}
+
 namespace Logger {
 
   Options::Options()
@@ -105,7 +110,7 @@ namespace Logger {
       sink->set_formatter(
         boost::log::expressions::format("\t<record id=\"%1%\" timestamp=\"%2%\">%3%</record>")
         % boost::log::expressions::attr< unsigned int >("RecordID")
-        % boost::log::expressions::attr< boost::posix_time::ptime >("TimeStamp")
+        % boost::log::expressions::attr< boost::posix_time::ptime >("TimeStamp", TIME_STAMP_FORMAT))
         % boost::log::expressions::xml_decor[boost::log::expressions::stream << boost::log::expressions::smessage]
         );
 
@@ -145,7 +150,7 @@ namespace Logger {
       boost::shared_ptr< ostream_sink > sink3(new ostream_sink(dataBackend));
       sink3->set_formatter(
         boost::log::expressions::format("%1% > %2%")
-        % boost::log::expressions::attr< boost::posix_time::ptime >("TimeStamp")
+        % boost::log::expressions::attr< boost::posix_time::ptime >("TimeStamp", TIME_STAMP_FORMAT))
         % boost::log::expressions::xml_decor[boost::log::expressions::stream << boost::log::expressions::smessage]
         );
 

--- a/Modules/Logging/src/AutoplanLogging.cpp
+++ b/Modules/Logging/src/AutoplanLogging.cpp
@@ -6,6 +6,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/join.hpp>
 #include <boost/date_time.hpp>
+#include <boost/log/support/date_time.hpp>
 
 struct ThrowAwayPattern _ = {};
 
@@ -110,7 +111,7 @@ namespace Logger {
       sink->set_formatter(
         boost::log::expressions::format("\t<record id=\"%1%\" timestamp=\"%2%\">%3%</record>")
         % boost::log::expressions::attr< unsigned int >("RecordID")
-        % boost::log::expressions::attr< boost::posix_time::ptime >("TimeStamp", TIME_STAMP_FORMAT))
+        % boost::log::expressions::format_date_time< boost::posix_time::ptime >("TimeStamp", TIME_STAMP_FORMAT)
         % boost::log::expressions::xml_decor[boost::log::expressions::stream << boost::log::expressions::smessage]
         );
 
@@ -150,7 +151,7 @@ namespace Logger {
       boost::shared_ptr< ostream_sink > sink3(new ostream_sink(dataBackend));
       sink3->set_formatter(
         boost::log::expressions::format("%1% > %2%")
-        % boost::log::expressions::attr< boost::posix_time::ptime >("TimeStamp", TIME_STAMP_FORMAT))
+        % boost::log::expressions::format_date_time< boost::posix_time::ptime >("TimeStamp", TIME_STAMP_FORMAT)
         % boost::log::expressions::xml_decor[boost::log::expressions::stream << boost::log::expressions::smessage]
         );
 


### PR DESCRIPTION
Убраны миллисекунды из выводимого в лог времени
Название вызывающего класса/функции взять в круглые скобки вместо слова From
Добавлен пробел после вызывающего класса, чтоб не сливался с сообщением
Поправлено логирование для уровня Debug
Исправлена ошибка форматирования в соответствии с CS

http://samsmu.net:8083/browse/AUT-1682