### PR TITLE
Исправление для Region growing

### DIFF
--- a/Modules/Segmentation/Interactions/mitkRegionGrowingTool.cpp
+++ b/Modules/Segmentation/Interactions/mitkRegionGrowingTool.cpp
@@ -516,5 +516,8 @@ void mitk::RegionGrowingTool::OnMouseReleased(StateMachineAction*, InteractionEv
             this->WriteBackSegmentationResult(positionEvent, m_WorkingSlice);
             FeedbackContourTool::SetFeedbackContourVisible(false);
         }
+
+        m_ScreenXDifference = 0;
+        m_ScreenYDifference = 0;
     }
 }


### PR DESCRIPTION
http://samsmu.net:8083/browse/AUT-1587

Проблема была в том, что разница между координатами, которая вычисляется при движении мыши, не сбрасывалась после того, как кнопка мыши была отпущена.
Из-за этого эта разница всё накапливалась, что приводило к гигантским границам и неправильной работе инструмента.
Я планирую отправить этот фикс в апстрим МИТК, в последнем релизе у них эта же проблема.

Тестовые шаги:

1. Загрузить данные в универсальный кейс.
2. Создать сегментацию.
3. Включить Region Growing.
4. Отредактировать сегментацию несколько раз, всегда двигая мышку в одном и том же направлении (например, налево вверх).
   - После этого инструмент продолжает работать корректно.
