### PR TITLE
Fix. Автоплан падает при повторном открытии файла, если закрыть datamanager

### DIFF
--- a/Modules/Core/include/mitkPlaneGeometry.h
+++ b/Modules/Core/include/mitkPlaneGeometry.h
@@ -551,7 +551,7 @@ namespace mitk {
 
     virtual void PrintSelf(std::ostream &os, itk::Indent indent) const override;
 
-    mitk::BaseGeometry *m_ReferenceGeometry;
+    mitk::BaseGeometry::Pointer m_ReferenceGeometry;
 
     //##Documentation
     //## @brief PreSetSpacing


### PR DESCRIPTION
Исправлено падение, вызванное тем, что PlaneGeometry не владел ReferenceGeometry

http://samsmu.net:8083/browse/AUT-1667