### PR TITLE
Цвет пикселя под курсором для US изображений

### DIFF
--- a/Modules/Core/files.cmake
+++ b/Modules/Core/files.cmake
@@ -10,6 +10,7 @@ set(CPP_FILES
   Algorithms/mitkBaseDataSource.cpp
   Algorithms/mitkClippedSurfaceBoundsCalculator.cpp
   Algorithms/mitkCompareImageDataFilter.cpp
+  Algorithms/mitkCompositePixelValueToString.cpp
   Algorithms/mitkConvert2Dto3DImageFilter.cpp
   Algorithms/mitkDataNodeSource.cpp
   Algorithms/mitkExtractSliceFilter.cpp

--- a/Modules/Core/include/mitkCompositePixelValueToString.h
+++ b/Modules/Core/include/mitkCompositePixelValueToString.h
@@ -1,0 +1,33 @@
+/*===================================================================
+
+The Medical Imaging Interaction Toolkit (MITK)
+
+Copyright (c) German Cancer Research Center,
+Division of Medical and Biological Informatics.
+All rights reserved.
+
+This software is distributed WITHOUT ANY WARRANTY; without
+even the implied warranty of MERCHANTABILITY or FITNESS FOR
+A PARTICULAR PURPOSE.
+
+See LICENSE.txt or http://www.mitk.org for details.
+
+===================================================================*/
+
+#ifndef mitkCompositePixelValueToString_h
+#define mitkCompositePixelValueToString_h
+
+#include <mitkImage.h>
+#include <string>
+
+namespace mitk
+{
+  /** \brief Converts composite pixel values to a displayable string
+  *
+  * \throws mitk::Exception If the image is NULL.
+  * \throws mitk::AccessByItkException for pixel types which are not part of MITK_ACCESSBYITK_COMPOSITE_PIXEL_TYPES_SEQ
+  */
+  std::string MITKCORE_EXPORT ConvertCompositePixelValueToString(Image::Pointer image, itk::Index<3> index);
+}
+
+#endif

--- a/Modules/Core/include/mitkImage.h
+++ b/Modules/Core/include/mitkImage.h
@@ -304,6 +304,7 @@ public:
   //## @param sDim override z-space dimension in @a vtkimagedata (if >0 and <)
   //## @param pDim override y-space dimension in @a vtkimagedata (if >0 and <)
   virtual void Initialize(vtkImageData* vtkimagedata, int channels = 1, int tDim = -1, int sDim = -1, int pDim = -1);
+  virtual void Initialize(const mitk::PixelType& type, vtkImageData* vtkimagedata, int channels = 1, int tDim = -1, int sDim = -1, int pDim = -1);
 
   //##Documentation
   //## initialize new (or re-initialize) image information by @a itkimage,

--- a/Modules/Core/include/mitkStatusBar.h
+++ b/Modules/Core/include/mitkStatusBar.h
@@ -17,68 +17,80 @@ See LICENSE.txt or http://www.mitk.org for details.
 
 #ifndef MITKSTATUSBAR_H
 #define MITKSTATUSBAR_H
-#include <itkObject.h>
-#include <MitkCoreExports.h>
 #include "mitkStatusBarImplementation.h"
+#include <MitkCoreExports.h>
+#include <itkObject.h>
+#include <mitkPoint.h>
+#include <itkIndex.h>
 
-
-namespace mitk {
-//##Documentation
-//## @brief Sending a message to the applications StatusBar
-//##
-//## Holds a GUI dependent StatusBarImplementation and sends the text further.
-//## nearly equal to itk::OutputWindow,
-//## no Window, but one line of text and a delay for clear.
-//## all mitk-classes use this class to display text on GUI-StatusBar.
-//## The mainapplication has to set the internal held StatusBarImplementation with SetInstance(..).
-//## @ingroup Interaction
-class MITKCORE_EXPORT StatusBar : public itk::Object
+namespace mitk
 {
-public:
-  itkTypeMacro(StatusBar, itk::Object);
-
   //##Documentation
-  //## @brief static method to get the GUI dependent StatusBar-instance
-  //## so the methods DisplayText, etc. can be called
-  //## No reference counting, cause of decentral static use!
-  static StatusBar* GetInstance();
+  //## @brief Sending a message to the applications StatusBar
+  //##
+  //## Holds a GUI dependent StatusBarImplementation and sends the text further.
+  //## nearly equal to itk::OutputWindow,
+  //## no Window, but one line of text and a delay for clear.
+  //## all mitk-classes use this class to display text on GUI-StatusBar.
+  //## The mainapplication has to set the internal held StatusBarImplementation with SetInstance(..).
+  //## @ingroup Interaction
+  class MITKCORE_EXPORT StatusBar : public itk::Object
+  {
+  public:
+    itkTypeMacro(StatusBar, itk::Object);
 
-  //##Documentation
-  //## @brief Supply a GUI- dependent StatusBar. Has to be set by the application
-  //## to connect the application dependent subclass of mitkStatusBar
-  //## if you create an instance, then call ->Delete() on the supplied
-  //## instance after setting it.
-  static void SetImplementation(StatusBarImplementation* instance);
+    //##Documentation
+    //## @brief static method to get the GUI dependent StatusBar-instance
+    //## so the methods DisplayText, etc. can be called
+    //## No reference counting, cause of decentral static use!
+    static StatusBar *GetInstance();
 
-  //##Documentation
-  //## @brief Send a string to the applications StatusBar
-  void DisplayText(const char* t);
-  //##Documentation
-  //## @brief Send a string with a time delay to the applications StatusBar
-  void DisplayText(const char* t, int ms);
-  void DisplayErrorText(const char *t);
-  void DisplayWarningText(const char *t);
-  void DisplayWarningText(const char *t, int ms);
-  void DisplayGenericOutputText(const char *t);
-  void DisplayDebugText(const char *t);
-  void DisplayGreyValueText(const char *t);
+    //##Documentation
+    //## @brief Supply a GUI- dependent StatusBar. Has to be set by the application
+    //## to connect the application dependent subclass of mitkStatusBar
+    //## if you create an instance, then call ->Delete() on the supplied
+    //## instance after setting it.
+    static void SetImplementation(StatusBarImplementation *instance);
 
-  //##Documentation
-  //## @brief removes any temporary message being shown.
-  void Clear();
+    //##Documentation
+    //## @brief Send a string to the applications StatusBar
+    void DisplayText(const char *t);
+    //##Documentation
+    //## @brief Send a string with a time delay to the applications StatusBar
+    void DisplayText(const char *t, int ms);
+    void DisplayErrorText(const char *t);
+    void DisplayWarningText(const char *t);
+    void DisplayWarningText(const char *t, int ms);
+    void DisplayGenericOutputText(const char *t);
+    void DisplayDebugText(const char *t);
+    void DisplayGreyValueText(const char *t);
 
-  //##Documentation
-  //## @brief Set the SizeGrip of the window
-  //## (the triangle in the lower right Windowcorner for changing the size)
-  //## to enabled or disabled
-  void SetSizeGripEnabled(bool enable);
+    //##Documentation
+    //## @brief Display position, index, time and pixel value
+    void DisplayImageInfo(mitk::Point3D point, itk::Index<3> index, mitk::ScalarType time, mitk::ScalarType pixelValue);
+    //## @brief Display rotation, index, time and custom pixel value
+    void DisplayImageInfo(mitk::Point3D point, itk::Index<3> index, mitk::ScalarType time, const char *pixelValue);
+    //##Documentation
+    //## @brief Display placeholder text for invalid information
+    void DisplayImageInfoInvalid();
 
-protected:
-  StatusBar();
-  virtual ~StatusBar();
-  static StatusBarImplementation* m_Implementation;
-  static StatusBar* m_Instance;
-};
+    //##Documentation
+    //## @brief removes any temporary message being shown.
+    void Clear();
 
-}// end namespace mitk
+    //##Documentation
+    //## @brief Set the SizeGrip of the window
+    //## (the triangle in the lower right Windowcorner for changing the size)
+    //## to enabled or disabled
+    void SetSizeGripEnabled(bool enable);
+
+  protected:
+    StatusBar();
+    virtual ~StatusBar();
+
+    static StatusBarImplementation *m_Implementation;
+    static StatusBar *m_Instance;
+  };
+
+} // end namespace mitk
 #endif /* define MITKSTATUSBAR_H */

--- a/Modules/Core/src/Algorithms/mitkCompositePixelValueToString.cpp
+++ b/Modules/Core/src/Algorithms/mitkCompositePixelValueToString.cpp
@@ -1,0 +1,78 @@
+/*===================================================================
+
+The Medical Imaging Interaction Toolkit (MITK)
+
+Copyright (c) German Cancer Research Center,
+Division of Medical and Biological Informatics.
+All rights reserved.
+
+This software is distributed WITHOUT ANY WARRANTY; without
+even the implied warranty of MERCHANTABILITY or FITNESS FOR
+A PARTICULAR PURPOSE.
+
+See LICENSE.txt or http://www.mitk.org for details.
+
+===================================================================*/
+
+#include <mitkCompositePixelValueToString.h>
+#include <mitkImageAccessByItk.h>
+#include <sstream>
+
+namespace mitk
+{
+  // The output operator for RGBA in ITK does not properly cast to printable type,
+  // like the RGB pixel output operator. This here is an indirection to fix this until
+  // ITK-3501 is fixed.
+  template <typename TComponent>
+  std::ostream &operator<<(std::ostream &os, const itk::RGBPixel<TComponent> &c)
+  {
+    return itk::operator<<(os, c);
+  }
+
+  template <typename TComponent>
+  std::ostream &operator<<(std::ostream &os, const itk::RGBAPixel<TComponent> &c)
+  {
+    os << static_cast<typename itk::NumericTraits<TComponent>::PrintType>(c[0]) << "  ";
+    os << static_cast<typename itk::NumericTraits<TComponent>::PrintType>(c[1]) << "  ";
+    os << static_cast<typename itk::NumericTraits<TComponent>::PrintType>(c[2]) << "  ";
+    os << static_cast<typename itk::NumericTraits<TComponent>::PrintType>(c[3]);
+    return os;
+  }
+
+  template <typename TPixel, unsigned int VImageDimension>
+  static void ConvertCompositePixelValueToString(itk::Image<TPixel, VImageDimension> *image,
+                                                 itk::Index<3> index3,
+                                                 std::string &string)
+  {
+    itk::Index<VImageDimension> index;
+    for (unsigned int i = 0; i < VImageDimension; ++i)
+      index[i] = index3[i];
+
+    if (image->GetLargestPossibleRegion().IsInside(index))
+    {
+      std::ostringstream stream;
+      mitk::operator<<(stream, image->GetPixel(index));
+
+      string = stream.str();
+    }
+    else
+    {
+      string = "Out of bounds";
+    }
+  }
+}
+
+std::string mitk::ConvertCompositePixelValueToString(Image::Pointer image, itk::Index<3> index)
+{
+  std::string string;
+
+  if (image.IsNull())
+  {
+    mitkThrow() << "Image is null.";
+  }
+
+  AccessFixedPixelTypeByItk_n(
+    image, ConvertCompositePixelValueToString, MITK_ACCESSBYITK_COMPOSITE_PIXEL_TYPES_SEQ, (index, string));
+
+  return string;
+}

--- a/Modules/Core/src/Controllers/mitkStatusBar.cpp
+++ b/Modules/Core/src/Controllers/mitkStatusBar.cpp
@@ -14,108 +14,155 @@ See LICENSE.txt or http://www.mitk.org for details.
 
 ===================================================================*/
 
-
 #include "mitkStatusBar.h"
 #include <itkObjectFactory.h>
 #include <itkOutputWindow.h>
 
-
-namespace mitk {
-
-StatusBarImplementation* StatusBar::m_Implementation = nullptr;
-StatusBar* StatusBar::m_Instance = nullptr;
-
-/**
- * Display the text in the statusbar of the applikation
- */
-void StatusBar::DisplayText(const char* t)
+namespace mitk
 {
+  StatusBarImplementation *StatusBar::m_Implementation = nullptr;
+  StatusBar *StatusBar::m_Instance = nullptr;
+
+  /**
+   * Display the text in the statusbar of the applikation
+   */
+  void StatusBar::DisplayText(const char *t)
+  {
     if (m_Implementation != nullptr)
-        m_Implementation->DisplayText(t);
-}
-
-/**
- * Display the text in the statusbar of the applikation for ms seconds
- */
-void StatusBar::DisplayText(const char* t, int ms)
-{
-  if (m_Implementation != nullptr)
-    m_Implementation->DisplayText(t, ms);
-}
-
-void StatusBar::DisplayErrorText(const char *t)
-{
-  if (m_Implementation != nullptr)
-    m_Implementation->DisplayErrorText(t);
-}
-void StatusBar::DisplayWarningText(const char *t)
-{
-  if (m_Implementation != nullptr)
-    m_Implementation->DisplayWarningText(t);
-}
-void StatusBar::DisplayWarningText(const char *t, int ms)
-{
-  if (m_Implementation != nullptr)
-    m_Implementation->DisplayWarningText(t, ms);
-}
-void StatusBar::DisplayGenericOutputText(const char *t)
-{
-  if (m_Implementation != nullptr)
-    m_Implementation->DisplayGenericOutputText(t);
-}
-void StatusBar::DisplayDebugText(const char *t)
-{
-  if (m_Implementation != nullptr)
-    m_Implementation->DisplayDebugText(t);
-}
-void StatusBar::DisplayGreyValueText(const char *t)
-{
-  if (m_Implementation != nullptr)
-    m_Implementation->DisplayGreyValueText(t);
-}
-void StatusBar::Clear()
-{
-  if ( m_Implementation != nullptr)
-    m_Implementation->Clear();
-}
-void StatusBar::SetSizeGripEnabled(bool enable)
-{
-  if (m_Implementation != nullptr)
-  {
-    m_Implementation->SetSizeGripEnabled(enable);
-  }
-}
-/**
- * Get the instance of this StatusBar
- */
-StatusBar* StatusBar::GetInstance()
-{
-  if (m_Instance == nullptr)//if not set, then send a errormessage on OutputWindow
-  {
-    m_Instance = new StatusBar();
+      m_Implementation->DisplayText(t);
   }
 
-  return m_Instance;
-}
-
-/**
- * Set an instance of this; application must do this!See Header!
- */
-void StatusBar::SetImplementation(StatusBarImplementation* implementation)
-{
-  if ( m_Implementation == implementation )
+  /**
+   * Display the text in the statusbar of the applikation for ms seconds
+   */
+  void StatusBar::DisplayText(const char *t, int ms)
   {
-    return;
+    if (m_Implementation != nullptr)
+      m_Implementation->DisplayText(t, ms);
   }
-  m_Implementation = implementation;
-}
 
-StatusBar::StatusBar()
-{
-}
+  void StatusBar::DisplayErrorText(const char *t)
+  {
+    if (m_Implementation != nullptr)
+      m_Implementation->DisplayErrorText(t);
+  }
+  void StatusBar::DisplayWarningText(const char *t)
+  {
+    if (m_Implementation != nullptr)
+      m_Implementation->DisplayWarningText(t);
+  }
+  void StatusBar::DisplayWarningText(const char *t, int ms)
+  {
+    if (m_Implementation != nullptr)
+      m_Implementation->DisplayWarningText(t, ms);
+  }
+  void StatusBar::DisplayGenericOutputText(const char *t)
+  {
+    if (m_Implementation != nullptr)
+      m_Implementation->DisplayGenericOutputText(t);
+  }
+  void StatusBar::DisplayDebugText(const char *t)
+  {
+    if (m_Implementation != nullptr)
+      m_Implementation->DisplayDebugText(t);
+  }
+  void StatusBar::DisplayGreyValueText(const char *t)
+  {
+    if (m_Implementation != nullptr)
+      m_Implementation->DisplayGreyValueText(t);
+  }
 
-StatusBar::~StatusBar()
-{
-}
+  static void WriteCommonImageInfo(
+    std::ostringstream &stream, Point3D point, itk::Index<3> index, ScalarType time)
+  {
+    stream << "Position: <" << std::fixed << point[0] << ", "
+                            << std::fixed << point[1] << ", "
+                            << std::fixed << point[2] << "> mm; ";
 
-}//end namespace mitk
+    stream << "Index: <" << index[0] << ", "
+                         << index[1] << ", "
+                         << index[2] << "> ; ";
+
+    stream << "Time: " << time << " ms";
+  }
+
+  void StatusBar::DisplayImageInfo(Point3D point, itk::Index<3> index, ScalarType time, ScalarType pixelValue)
+  {
+    if (m_Implementation == nullptr)
+      return;
+
+    std::ostringstream stream;
+    stream.imbue(std::locale::classic());
+    stream.precision(2);
+
+    WriteCommonImageInfo(stream, point, index, time);
+    stream << "; Pixel value: ";
+
+    if (fabs(pixelValue) > 1000000 || fabs(pixelValue) < 0.01)
+      stream << std::scientific;
+
+    stream << pixelValue;
+
+    m_Implementation->DisplayGreyValueText(stream.str().c_str());
+  }
+
+  void StatusBar::DisplayImageInfo(Point3D point, itk::Index<3> index, ScalarType time, const char *pixelValue)
+  {
+    if (m_Implementation == nullptr)
+      return;
+
+    std::ostringstream stream;
+    stream.imbue(std::locale::classic());
+    stream.precision(2);
+
+    WriteCommonImageInfo(stream, point, index, time);
+    stream << "; " << pixelValue;
+
+    m_Implementation->DisplayGreyValueText(stream.str().c_str());
+  }
+
+  void StatusBar::DisplayImageInfoInvalid()
+  {
+    if (m_Implementation != nullptr)
+      m_Implementation->DisplayGreyValueText("No image information at this position!");
+  }
+  void StatusBar::Clear()
+  {
+    if (m_Implementation != nullptr)
+      m_Implementation->Clear();
+  }
+  void StatusBar::SetSizeGripEnabled(bool enable)
+  {
+    if (m_Implementation != nullptr)
+    {
+      m_Implementation->SetSizeGripEnabled(enable);
+    }
+  }
+  /**
+   * Get the instance of this StatusBar
+   */
+  StatusBar *StatusBar::GetInstance()
+  {
+    if (m_Instance == nullptr) // if not set, then send a errormessage on OutputWindow
+    {
+      m_Instance = new StatusBar();
+    }
+
+    return m_Instance;
+  }
+
+  /**
+   * Set an instance of this; application must do this!See Header!
+   */
+  void StatusBar::SetImplementation(StatusBarImplementation *implementation)
+  {
+    if (m_Implementation == implementation)
+    {
+      return;
+    }
+    m_Implementation = implementation;
+  }
+
+  StatusBar::StatusBar() {}
+  StatusBar::~StatusBar() {}
+} // end namespace mitk

--- a/Modules/Core/src/DataManagement/mitkImage.cpp
+++ b/Modules/Core/src/DataManagement/mitkImage.cpp
@@ -941,57 +941,62 @@ void mitk::Image::Initialize(const mitk::Image* image)
 
 void mitk::Image::Initialize(vtkImageData* vtkimagedata, int channels, int tDim, int sDim, int pDim)
 {
-  if(vtkimagedata==nullptr) return;
+  mitk::PixelType pixelType(MakePixelType(vtkimagedata));
+  Initialize(pixelType, vtkimagedata, channels, tDim, sDim, pDim);
+}
 
-  m_Dimension=vtkimagedata->GetDataDimension();
-  unsigned int i, *tmpDimensions=new unsigned int[m_Dimension>4?m_Dimension:4];
-  for(i=0;i<m_Dimension;++i) tmpDimensions[i]=vtkimagedata->GetDimensions()[i];
-  if(m_Dimension<4)
+void mitk::Image::Initialize(const mitk::PixelType& type, vtkImageData* vtkimagedata, int channels, int tDim, int sDim, int pDim)
+{
+  if (vtkimagedata == nullptr) return;
+
+  m_Dimension = vtkimagedata->GetDataDimension();
+  unsigned int i, *tmpDimensions = new unsigned int[m_Dimension>4 ? m_Dimension : 4];
+  for (i = 0; i<m_Dimension; ++i) tmpDimensions[i] = vtkimagedata->GetDimensions()[i];
+  if (m_Dimension<4)
   {
     unsigned int *p;
-    for(i=0,p=tmpDimensions+m_Dimension;i<4-m_Dimension;++i, ++p)
-      *p=1;
+    for (i = 0, p = tmpDimensions + m_Dimension; i<4 - m_Dimension; ++i, ++p)
+      *p = 1;
   }
 
-  if(pDim>=0)
+  if (pDim >= 0)
   {
-    tmpDimensions[1]=pDim;
-    if(m_Dimension < 2)
+    tmpDimensions[1] = pDim;
+    if (m_Dimension < 2)
       m_Dimension = 2;
   }
-  if(sDim>=0)
+  if (sDim >= 0)
   {
-    tmpDimensions[2]=sDim;
-    if(m_Dimension < 3)
+    tmpDimensions[2] = sDim;
+    if (m_Dimension < 3)
       m_Dimension = 3;
   }
-  if(tDim>=0)
+  if (tDim >= 0)
   {
-    tmpDimensions[3]=tDim;
-    if(m_Dimension < 4)
+    tmpDimensions[3] = tDim;
+    if (m_Dimension < 4)
       m_Dimension = 4;
   }
 
-  mitk::PixelType pixelType(MakePixelType(vtkimagedata));
-  Initialize(pixelType, m_Dimension, tmpDimensions, channels);
+  Initialize(type, m_Dimension, tmpDimensions, channels);
 
   const double *spacinglist = vtkimagedata->GetSpacing();
   Vector3D spacing;
   FillVector3D(spacing, spacinglist[0], 1.0, 1.0);
-  if(m_Dimension>=2)
-    spacing[1]=spacinglist[1];
-  if(m_Dimension>=3)
-    spacing[2]=spacinglist[2];
+  if (m_Dimension >= 2)
+    spacing[1] = spacinglist[1];
+  if (m_Dimension >= 3)
+    spacing[2] = spacinglist[2];
 
   // access origin of vtkImage
   Point3D origin;
   double vtkorigin[3];
   vtkimagedata->GetOrigin(vtkorigin);
   FillVector3D(origin, vtkorigin[0], 0.0, 0.0);
-  if(m_Dimension>=2)
-    origin[1]=vtkorigin[1];
-  if(m_Dimension>=3)
-    origin[2]=vtkorigin[2];
+  if (m_Dimension >= 2)
+    origin[1] = vtkorigin[1];
+  if (m_Dimension >= 3)
+    origin[2] = vtkorigin[2];
 
   SlicedGeometry3D* slicedGeometry = GetSlicedGeometry(0);
 
@@ -1007,7 +1012,7 @@ void mitk::Image::Initialize(vtkImageData* vtkimagedata, int channels, int tDim,
   timeGeometry->Initialize(slicedGeometry, m_Dimensions[3]);
   SetTimeGeometry(timeGeometry);
 
-  delete [] tmpDimensions;
+  delete[] tmpDimensions;
 }
 
 bool mitk::Image::IsValidSlice(int s, int t, int n) const

--- a/Plugins/org.mitk.gui.qt.imagenavigator/src/internal/QmitkImageNavigatorView.cpp
+++ b/Plugins/org.mitk.gui.qt.imagenavigator/src/internal/QmitkImageNavigatorView.cpp
@@ -23,9 +23,46 @@ See LICENSE.txt or http://www.mitk.org for details.
 
 #include <berryConstants.h>
 #include <mitkPlaneGeometry.h>
+#include <mitkNodePredicateDataType.h>
+#include <mitkStatusBar.h>
+#include <mitkPixelTypeMultiplex.h>
+#include <mitkImagePixelReadAccessor.h>
+#include <mitkNodePredicateProperty.h>
+
+#include <mitkCompositePixelValueToString.h>
 
 const std::string QmitkImageNavigatorView::VIEW_ID = "org.mitk.views.imagenavigator";
 
+
+static mitk::DataNode::Pointer GetTopLayerNode(const mitk::DataStorage::SetOfObjects::ConstPointer nodes, const mitk::Point3D &position, mitk::BaseRenderer* renderer)
+{
+    mitk::DataNode::Pointer node;
+    int  maxlayer = -32768;
+
+    if(nodes.IsNotNull())
+    {
+        // find node with largest layer, that is the node shown on top in the render window
+        for (unsigned int x = 0; x < nodes->size(); x++)
+        {
+            if ( (nodes->at(x)->GetData()->GetGeometry() != NULL) &&
+                 nodes->at(x)->GetData()->GetGeometry()->IsInside(position) )
+            {
+                int layer = 0;
+                if(!(nodes->at(x)->GetIntProperty("layer", layer))) continue;
+                if(layer > maxlayer)
+                {
+                    if( static_cast<mitk::DataNode::Pointer>(nodes->at(x))->IsVisible(renderer) )
+                    {
+                        node = nodes->at(x);
+                        maxlayer = layer;
+                    }
+                }
+            }
+        }
+    }
+
+    return node;
+}
 
 QmitkImageNavigatorView::QmitkImageNavigatorView()
   : m_AxialStepper(0)
@@ -81,6 +118,7 @@ void QmitkImageNavigatorView::RenderWindowPartActivated(mitk::IRenderWindowPart*
       m_Controls.m_AxialLabel->setEnabled(true);
       m_Controls.m_ZWorldCoordinateSpinBox->setEnabled(true);
       connect(m_AxialStepper, SIGNAL(Refetch()), this, SLOT(OnRefetch()));
+      connect(m_AxialStepper, SIGNAL(Refetch()), this, SLOT(UpdateStatusBar()));
     }
     else
     {
@@ -100,6 +138,7 @@ void QmitkImageNavigatorView::RenderWindowPartActivated(mitk::IRenderWindowPart*
       m_Controls.m_SagittalLabel->setEnabled(true);
       m_Controls.m_YWorldCoordinateSpinBox->setEnabled(true);
       connect(m_SagittalStepper, SIGNAL(Refetch()), this, SLOT(OnRefetch()));
+      connect(m_SagittalStepper, SIGNAL(Refetch()), this, SLOT(UpdateStatusBar()));
     }
     else
     {
@@ -119,6 +158,7 @@ void QmitkImageNavigatorView::RenderWindowPartActivated(mitk::IRenderWindowPart*
       m_Controls.m_CoronalLabel->setEnabled(true);
       m_Controls.m_XWorldCoordinateSpinBox->setEnabled(true);
       connect(m_FrontalStepper, SIGNAL(Refetch()), this, SLOT(OnRefetch()));
+      connect(m_FrontalStepper, SIGNAL(Refetch()), this, SLOT(UpdateStatusBar()));
     }
     else
     {
@@ -136,11 +176,104 @@ void QmitkImageNavigatorView::RenderWindowPartActivated(mitk::IRenderWindowPart*
                                               "sliceNavigatorTimeFromSimpleExample");
       m_Controls.m_SliceNavigatorTime->setEnabled(true);
       m_Controls.m_TimeLabel->setEnabled(true);
+      connect(m_TimeStepper, SIGNAL(Refetch()), this, SLOT(UpdateStatusBar()));
     }
     else
     {
       m_Controls.m_SliceNavigatorTime->setEnabled(false);
       m_Controls.m_TimeLabel->setEnabled(false);
+    }
+
+    this->OnRefetch();
+    this->UpdateStatusBar();
+  }
+}
+
+void QmitkImageNavigatorView::UpdateStatusBar()
+{
+  if (m_IRenderWindowPart != nullptr)
+  {
+    mitk::Point3D position = m_IRenderWindowPart->GetSelectedPosition();
+    mitk::BaseRenderer::Pointer renderer = mitk::BaseRenderer::GetInstance(m_IRenderWindowPart->GetActiveQmitkRenderWindow()->GetVtkRenderWindow());
+    mitk::TNodePredicateDataType<mitk::Image>::Pointer isImageData = mitk::TNodePredicateDataType<mitk::Image>::New();
+
+    mitk::DataStorage::SetOfObjects::ConstPointer nodes = this->GetDataStorage()->GetSubset(isImageData).GetPointer();
+
+    if (nodes.IsNotNull())
+    {
+      mitk::Image::Pointer image3D;
+      mitk::DataNode::Pointer node;
+      mitk::DataNode::Pointer topSourceNode;
+
+      int component = 0;
+
+      node = GetTopLayerNode(nodes, position, renderer);
+
+      if (node.IsNotNull())
+      {
+        bool isBinary(false);
+        node->GetBoolProperty("binary", isBinary);
+        if (isBinary)
+        {
+          mitk::DataStorage::SetOfObjects::ConstPointer sourcenodes = this->GetDataStorage()->GetSources(node, NULL, true);
+          if (!sourcenodes->empty())
+          {
+            topSourceNode = GetTopLayerNode(sourcenodes, position, renderer);
+          }
+          if (topSourceNode.IsNotNull())
+          {
+            image3D = dynamic_cast<mitk::Image*>(topSourceNode->GetData());
+            topSourceNode->GetIntProperty("Image.Displayed Component", component);
+          }
+          else
+          {
+            image3D = dynamic_cast<mitk::Image*>(node->GetData());
+            node->GetIntProperty("Image.Displayed Component", component);
+          }
+        }
+        else
+        {
+          image3D = dynamic_cast<mitk::Image*>(node->GetData());
+          node->GetIntProperty("Image.Displayed Component", component);
+        }
+      }
+
+      // get the position and pixel value from the image and build up status bar text
+      auto statusBar = mitk::StatusBar::GetInstance();
+
+      if (image3D.IsNotNull() && statusBar != nullptr)
+      {
+        itk::Index<3> p;
+        image3D->GetGeometry()->WorldToIndex(position, p);
+
+        auto pixelType = image3D->GetChannelDescriptor().GetPixelType().GetPixelType();
+
+        if (pixelType == itk::ImageIOBase::RGB || pixelType == itk::ImageIOBase::RGBA)
+        {
+          std::string pixelValue = "Pixel RGB(A) value: ";
+          pixelValue.append(ConvertCompositePixelValueToString(image3D, p));
+          statusBar->DisplayImageInfo(position, p, renderer->GetTime(), pixelValue.c_str());
+        }
+        else
+        {
+          itk::Index<3> p;
+          image3D->GetGeometry()->WorldToIndex(position, p);
+          mitk::ScalarType pixelValue;
+          mitkPixelTypeMultiplex5(
+            mitk::FastSinglePixelAccess,
+            image3D->GetChannelDescriptor().GetPixelType(),
+            image3D,
+            image3D->GetVolumeData(renderer->GetTimeStep()),
+            p,
+            pixelValue,
+            component);
+          statusBar->DisplayImageInfo(position, p, renderer->GetTime(), pixelValue);
+        }
+      }
+      else
+      {
+        statusBar->DisplayImageInfoInvalid();
+      }
     }
   }
 }

--- a/Plugins/org.mitk.gui.qt.imagenavigator/src/internal/QmitkImageNavigatorView.h
+++ b/Plugins/org.mitk.gui.qt.imagenavigator/src/internal/QmitkImageNavigatorView.h
@@ -65,6 +65,7 @@ protected slots:
 
   void OnMillimetreCoordinateValueChanged();
   void OnRefetch();
+  void UpdateStatusBar();
 
 protected:
 


### PR DESCRIPTION
http://samsmu.net:8083/browse/AUT-1777

Это бэкпорт фикса https://phabricator.mitk.org/T20223.
Он позволяет смотреть цвет пикселя под курсором в универсальном кейсе для US изображений.

Тестовые шаги:

1. Загрузить 0342 пациента, перейти в универсальный кейс.
2. Подвигать перекрестие.
   - Статус-бар показывает значение пикселя под курсором.