### PR TITLE
Обновление позиции на статус-баре в универсальном кейсе

### DIFF
--- a/Modules/Core/resource/Interactions/DisplayInteraction.xml
+++ b/Modules/Core/resource/Interactions/DisplayInteraction.xml
@@ -32,9 +32,11 @@ TODO Std move to abort interaction of scroll/pan/zoom
         <!-- mitkDispplayInteractor.cpp implements this for all events -->
         <transition event_class="InteractionEvent" event_variant="PlaneUP" target="start">
             <action name="ScrollOneUp"/>
+            <action name="updateStatusbar"/>
         </transition>
         <transition event_class="InteractionEvent" event_variant="PlaneDown" target="start">
             <action name="ScrollOneDown"/>
+            <action name="updateStatusbar"/>
         </transition>
         <transition event_class="MousePressEvent"  event_variant="StartScroll" target="scroll">
             <action name="init"/>
@@ -132,6 +134,7 @@ TODO Std move to abort interaction of scroll/pan/zoom
       <transition event_class="InteractionPositionEvent" event_variant="Scrolling" target="scroll">
         <condition name="check_position_event"/>
         <action name="scroll"/>
+        <action name="updateStatusbar"/>
       </transition>
       <transition event_class="InteractionPositionEvent" event_variant="EndScrolling" target="start"/>
       <transition event_class="InteractionPositionEvent" event_variant="EndScrollingVar" target="start"/>
@@ -159,9 +162,11 @@ TODO Std move to abort interaction of scroll/pan/zoom
       </transition>
       <transition event_class="InteractionEvent" event_variant="PlaneUP" target="rotationPossible">
         <action name="ScrollOneUp"/>
+        <action name="updateStatusbar"/>
       </transition>
       <transition event_class="InteractionEvent" event_variant="PlaneDown" target="rotationPossible">
         <action name="ScrollOneDown"/>
+        <action name="updateStatusbar"/>
       </transition>
       <transition event_class="InteractionPositionEvent" event_variant="StartMove" target="move">
         <condition name="check_position_event"/>


### PR DESCRIPTION
http://samsmu.net:8083/browse/AUT-1795

Теперь статус-бар обновляется при прокрутке срезов колесом и с помощью Ctrl.
Но есть проблема из МИТК, что статус-бар показывает предыдущую позицию курсора (до перемотки). На это будет создана отдельная задача.