### PR TITLE
Автоплан падает после повторной загрузки проекта

### DIFF
--- a/Plugins/org.mitk.gui.qt.common/src/internal/QmitkViewCoordinator.cpp
+++ b/Plugins/org.mitk.gui.qt.common/src/internal/QmitkViewCoordinator.cpp
@@ -106,6 +106,16 @@ void QmitkViewCoordinator::PartDeactivated(const berry::IWorkbenchPartReference:
   //MITK_INFO << "*** PartDeactivated (" << partRef->GetPart(false)->GetPartName() << ")";
   berry::IWorkbenchPart* part = partRef->GetPart(false).GetPointer();
 
+  // Check for a render window part and if it is the currently active on.
+  // Inform IRenderWindowPartListener views that it has been deactivated.
+  if (mitk::IRenderWindowPart* renderPart = dynamic_cast<mitk::IRenderWindowPart*>(part)) {
+    if (m_VisibleRenderWindowPart == renderPart) {
+      RenderWindowPartDeactivated(renderPart);
+      m_VisibleRenderWindowPart = nullptr;
+      m_ActiveRenderWindowPart = nullptr;
+    }
+  }
+
   if (mitk::ILifecycleAwarePart* lifecycleAwarePart = dynamic_cast<mitk::ILifecycleAwarePart*>(part))
   {
     lifecycleAwarePart->Deactivated();


### PR DESCRIPTION
Исправлено падение.
Для воспроизведения необходим открытый Навигатор изображений и кликнуть в Segmentation Manager перед закрытием.
Фикс покрывает оба кейса из комментариев Галины и Владимира.

http://samsmu.net:8083/browse/AUT-1783