### PR TITLE
Исправлена позиция открепленных контролов. AUT-1294

### DIFF
--- a/Plugins/org.blueberry.ui.qt/src/internal/berryQtShell.cpp
+++ b/Plugins/org.blueberry.ui.qt/src/internal/berryQtShell.cpp
@@ -65,7 +65,7 @@ void QtShell::SetBounds(const QRect& bounds)
 
 QRect QtShell::GetBounds() const
 {
-  return widget->frameGeometry();
+  return widget->geometry();
 }
 
 void QtShell::SetLocation(int x, int y)


### PR DESCRIPTION
http://samsmu.net:8083/browse/AUT-1294

Контролы больше не увеличиваются в размере при переключением между кейсами.

1. Перейти на универсальный кейс.
2. Открепить какой-нибудь контрол.
3. Перейти на вьювер и вернуться на универсальный кейс.