### PR TITLE
Исправлен индекс в статус баре при прокрутке. AUT-1796

### DIFF
--- a/Modules/Core/src/Controllers/mitkStatusBar.cpp
+++ b/Modules/Core/src/Controllers/mitkStatusBar.cpp
@@ -79,9 +79,9 @@ namespace mitk
                             << std::fixed << point[1] << ", "
                             << std::fixed << point[2] << "> mm; ";
 
-    stream << "Index: <" << index[0] << ", "
-                         << index[1] << ", "
-                         << index[2] << "> ; ";
+    stream << "Index: <" << index[0] + 1 << ", "
+                         << index[1] + 1 << ", "
+                         << index[2] + 1 << "> ; ";
 
     stream << "Time: " << time << " ms";
   }

--- a/Modules/Core/src/Interactions/mitkDisplayInteractor.cpp
+++ b/Modules/Core/src/Interactions/mitkDisplayInteractor.cpp
@@ -583,6 +583,7 @@ void mitk::DisplayInteractor::ScrollOneDown(StateMachineAction*, InteractionEven
       stepper = sliceNaviController->GetTime();
     }
     stepper->Next();
+    interactionEvent->GetSender()->RequestUpdate();
   }
 }
 
@@ -597,6 +598,7 @@ void mitk::DisplayInteractor::ScrollOneUp(StateMachineAction*, InteractionEvent*
       stepper = sliceNaviController->GetTime();
     }
     stepper->Previous();
+    interactionEvent->GetSender()->RequestUpdate();
   }
 }
 


### PR DESCRIPTION
http://samsmu.net:8083/browse/AUT-1796

Теперь после прокрутки статус бар корректно определяет текущий срез.

1. Открыть универсальный кейс
2. Прокрутить колесиком на окне с серией
3. Проверить статус бар