### PR TITLE
Изменено поведение сохранения настроек для следующего файла. AUT-1851

### DIFF
--- a/Modules/Core/include/mitkIOUtil.h
+++ b/Modules/Core/include/mitkIOUtil.h
@@ -448,9 +448,9 @@ private:
 
   struct Impl;
 
-  static std::map<std::string, mitk::IFileIO::Options> usedOptions;
-  static std::map<std::string, FileReaderSelector::Item> usedReaderItems;
-  static std::set<SaveInfo> usedSaveInfos;
+  static std::map<std::string, mitk::IFileIO::Options> m_usedOptions;
+  static std::map<std::string, FileReaderSelector::Item> m_usedReaderItems;
+  static std::set<SaveInfo> m_usedSaveInfos;
 };
 
 }

--- a/Modules/Core/include/mitkIOUtil.h
+++ b/Modules/Core/include/mitkIOUtil.h
@@ -448,6 +448,9 @@ private:
 
   struct Impl;
 
+  static std::map<std::string, mitk::IFileIO::Options> usedOptions;
+  static std::map<std::string, FileReaderSelector::Item> usedReaderItems;
+  static std::set<SaveInfo> usedSaveInfos;
 };
 
 }

--- a/Modules/Core/src/IO/mitkIOUtil.cpp
+++ b/Modules/Core/src/IO/mitkIOUtil.cpp
@@ -659,8 +659,6 @@ std::string IOUtil::Load(std::vector<LoadInfo>& loadInfos,
 
   std::string errMsg;
 
-  std::map<std::string, FileReaderSelector::Item> usedReaderItems;
-
   for(auto & loadInfo : loadInfos)
   {
     std::vector<FileReaderSelector::Item> readers = loadInfo.m_ReaderSelector.Get();
@@ -707,7 +705,7 @@ std::string IOUtil::Load(std::vector<LoadInfo>& loadInfos,
             callOptionsCallback = false;
             loadInfo.m_ReaderSelector.Select(oldSelectedItemIter->second.GetServiceId());
             loadInfo.m_ReaderSelector.GetSelected().GetReader()->SetOptions(
-                  oldSelectedItemIter->second.GetReader()->GetOptions());
+              usedOptions.at(oldSelectedItemIter->first));
             break;
           }
         }
@@ -724,6 +722,7 @@ std::string IOUtil::Load(std::vector<LoadInfo>& loadInfos,
         FileReaderSelector::Item selectedItem = loadInfo.m_ReaderSelector.GetSelected();
         usedReaderItems.insert(std::make_pair(selectedItem.GetMimeType().GetName(),
                                               selectedItem));
+        usedOptions.insert(std::make_pair(selectedItem.GetMimeType().GetName(), selectedItem.GetReader()->GetOptions()));
       }
     }
 
@@ -954,8 +953,6 @@ std::string IOUtil::Save(std::vector<SaveInfo>& saveInfos, WriterOptionsFunctorB
 
   std::string errMsg;
 
-  std::set<SaveInfo> usedSaveInfos;
-
   for (auto & saveInfo : saveInfos)
   {
     const std::string baseDataType = saveInfo.m_BaseData->GetNameOfClass();
@@ -1123,4 +1120,7 @@ IOUtil::LoadInfo::LoadInfo(const std::string& path)
 {
 }
 
+std::map<std::string, mitk::IFileIO::Options> IOUtil::usedOptions;
+std::map<std::string, FileReaderSelector::Item> IOUtil::usedReaderItems;
+std::set<IOUtil::SaveInfo> IOUtil::usedSaveInfos;
 }


### PR DESCRIPTION
http://samsmu.net:8083/browse/AUT-1851

При выборе опции "Apply to the next files with same type", выбранный вариант будет применяться ко всем последующим файлам такого же вида.

Чтение:
1. Открыть файл с выбором способа чтения
2. Поставить "Apply to the next files with same type"
3. Открыть файл еще раз

Запись:
1. Сохранить сегментацию
2. Выбрать при сохранении "Apply to the next files with same type"
3. Сохранить сегментацию еще раз