### PR TITLE
Отключение интерполяции по щелчку

### DIFF
--- a/Modules/SegmentationUI/Qmitk/QmitkSlicesInterpolator.cpp
+++ b/Modules/SegmentationUI/Qmitk/QmitkSlicesInterpolator.cpp
@@ -589,9 +589,7 @@ void QmitkSlicesInterpolator::Interpolate( mitk::PlaneGeometry* plane, unsigned 
         mitk::SegTool2D::DetermineAffectedImageSlice( m_Segmentation, plane, clickedSliceDimension, clickedSliceIndex );
 
         mitk::Image::Pointer interpolation = m_Interpolator->Interpolate( clickedSliceDimension, clickedSliceIndex, plane, timeStep );
-        if (interpolation.IsNotNull()) {
-          m_FeedbackNode->SetData(interpolation);
-        }
+        m_FeedbackNode->SetData(interpolation);
 
         m_LastSNC = slicer;
         m_LastSliceIndex = clickedSliceIndex;


### PR DESCRIPTION
http://samsmu.net:8083/browse/AUT-1927

Проблема в том, что МИТК в принципе плохо работает с интерполяцией по щелчку мыши.
Мы пытались обойти эту проблему, но это привело к багам.
Так что я вернул код, как он был, теперь интерполяция будет появляться только при использовании скролла.

Так же я создам задачу для нормального улучшения интерполяции.

Тестовые шаги:

1. Загрузить дайком в универсальный кейс.
2. Создать сегментацию.
3. С помощью инструмента Add нарисовать два контура на двух разных срезах аксиальной проекции.
4. Включить 3Д-интерполяцию.
5. Прокрутить срезы аксиальной проекции колесиком мыши.
   - Желтый контур интерполяции создается.
6. Изменить позицию щелчком мыши в разных окнах.
   - Желтый контур интерполяции пропал, при подтверждении интерполяции на одном срезе ничего не происходит.