### PR TITLE
Slightly change render annotation conception

### DIFF
--- a/Modules/QtWidgets/include/QmitkStdMultiWidget.h
+++ b/Modules/QtWidgets/include/QmitkStdMultiWidget.h
@@ -43,7 +43,7 @@ class vtkCornerAnnotation;
 class vtkMitkRectangleProp;
 
 namespace mitk {
-class RenderingManager;
+  class RenderingManager;
 }
 
 /// \ingroup QmitkModule

--- a/Modules/QtWidgets/src/QmitkRenderWindowMenu.cpp
+++ b/Modules/QtWidgets/src/QmitkRenderWindowMenu.cpp
@@ -70,8 +70,8 @@ m_Parent(parent)
 
   //Create Menu Widget
   this->CreateMenuWidget();
-  this->setMinimumWidth(61); //DIRTY.. If you add or remove a button, you need to change the size.
-  this->setMaximumWidth(61);
+  this->setMinimumWidth(62); //DIRTY.. If you add or remove a button, you need to change the size.
+  this->setMaximumWidth(62);
   this->setAutoFillBackground( true );
 
   //Else part fixes the render window menu issue on Linux bug but caused bugs on Mac OS and Windows
@@ -119,7 +119,7 @@ QmitkRenderWindowMenu::~QmitkRenderWindowMenu()
 void QmitkRenderWindowMenu::CreateMenuWidget()
 {
   QHBoxLayout* layout = new QHBoxLayout(this);
-  layout->setAlignment( Qt::AlignRight );
+  layout->setAlignment( Qt::AlignHCenter );
   layout->setContentsMargins(1,1,1,1);
 
   QSize size( 13, 13 );
@@ -129,7 +129,7 @@ void QmitkRenderWindowMenu::CreateMenuWidget()
 
   // button for changing rotation mode
   m_CrosshairModeButton = new QToolButton(this);
-  m_CrosshairModeButton->setMaximumSize(15, 15);
+  m_CrosshairModeButton->setMaximumSize(16, 16);
   m_CrosshairModeButton->setIconSize(size);
   m_CrosshairModeButton->setMenu( m_CrosshairMenu );
   m_CrosshairModeButton->setIcon(QIcon(QPixmap(iconCrosshairMode_xpm)));
@@ -140,7 +140,7 @@ void QmitkRenderWindowMenu::CreateMenuWidget()
 
   //fullScreenButton
   m_FullScreenButton = new QToolButton(this);
-  m_FullScreenButton->setMaximumSize(15, 15);
+  m_FullScreenButton->setMaximumSize(16, 16);
   m_FullScreenButton->setIconSize(size);
   m_FullScreenButton->setIcon(QIcon(QPixmap(iconFullScreen_xpm)));
   m_FullScreenButton->setAutoRaise(true);
@@ -148,7 +148,7 @@ void QmitkRenderWindowMenu::CreateMenuWidget()
 
   //settingsButton
   m_SettingsButton = new QToolButton(this);
-  m_SettingsButton->setMaximumSize(15, 15);
+  m_SettingsButton->setMaximumSize(16, 16);
   m_SettingsButton->setIconSize(size);
   m_SettingsButton->setIcon(QIcon(QPixmap(iconSettings_xpm)));
   m_SettingsButton->setAutoRaise(true);
@@ -742,7 +742,7 @@ void QmitkRenderWindowMenu::MoveWidgetToCorrectPos(float /*opacity*/)
 #endif
 {
 #ifdef QMITK_USE_EXTERNAL_RENDERWINDOW_MENU
-  int X=floor( double(this->m_Parent->width() - this->width() - 8.0) );
+  int X=floor( double(this->m_Parent->width()/2 - this->width()/2) );
   int Y=7;
 
   QPoint pos = this->m_Parent->mapToGlobal( QPoint(0,0) );
@@ -754,7 +754,7 @@ void QmitkRenderWindowMenu::MoveWidgetToCorrectPos(float /*opacity*/)
 
   this->setWindowOpacity(opacity);
 #else
-  int moveX= floor( double(this->m_Parent->width() - this->width() - 4.0) );
+  int moveX= floor( double(this->m_Parent->width()/2 - this->width()/2) );
   this->move( moveX, 3 );
   this->show();
 #endif

--- a/Modules/QtWidgets/src/QmitkStdMultiWidget.cpp
+++ b/Modules/QtWidgets/src/QmitkStdMultiWidget.cpp
@@ -1564,7 +1564,7 @@ mitk::DataNode::Pointer QmitkStdMultiWidget::GetTopLayerNode(mitk::DataStorage::
   return node;
 }
 
-void QmitkStdMultiWidget::setCornerAnnotation(int corner, int i, const char* text) 
+void QmitkStdMultiWidget::setCornerAnnotation(int corner, int i, const char* text)
 {
   // empty or NULL string breaks renderer
   // and white square appears
@@ -1572,8 +1572,8 @@ void QmitkStdMultiWidget::setCornerAnnotation(int corner, int i, const char* tex
     text = " ";
   }
   cornerText[i]->SetText(corner, text);
-  cornerText[i]->SetMaximumFontSize(14);
-  textProp[i]->SetColor(1.0, 1.0, 1.0);
+  cornerText[i]->SetMaximumFontSize(13);
+  textProp[i]->SetColor(1.0, 1.0, 7.0);
   textProp[i]->SetFontFamilyToArial();
   cornerText[i]->SetTextProperty(textProp[i]);
 }
@@ -1622,8 +1622,16 @@ void QmitkStdMultiWidget::HandleCrosshairPositionEventDelayed()
     mitk::BoundingBox::BoundsArrayType bounds = image->GetGeometry()->GetBounds();
     std::stringstream _infoStringStream[3];
     std::string cornerimgtext[3];
+
+    imageProperties = image->GetPropertyList();
+    std::string seriesNumber;
+    imageProperties->GetStringProperty("dicom.series.SeriesNumber", seriesNumber);
+
     for(int i = 0; i < 3; i++) {
       _infoStringStream[i] << "Im: " << (p[i] + 1) << "/" << bounds[(i*2 + 1)];
+      if (seriesNumber != "") {
+        _infoStringStream[i] << "\nSe: " << seriesNumber;
+      }
       cornerimgtext[i] = _infoStringStream[i].str();
       setCornerAnnotation(2, i, cornerimgtext[i].c_str());
     }
@@ -1634,7 +1642,6 @@ void QmitkStdMultiWidget::HandleCrosshairPositionEventDelayed()
       std::string patient, patientId,
         birthday, sex, institution, studyDate, studyTime;
 
-      imageProperties = image->GetPropertyList();
       imageProperties->GetStringProperty("dicom.patient.PatientsName", patient);
       imageProperties->GetStringProperty("dicom.patient.PatientID", patientId);
       imageProperties->GetStringProperty("dicom.patient.PatientsBirthDate", birthday);
@@ -1652,13 +1659,15 @@ void QmitkStdMultiWidget::HandleCrosshairPositionEventDelayed()
       char mi[3]; mi[2] = 0;
       char ss[3]; ss[2] = 0;
 
-      if (m_displayMetaInfo && (birthday != "")) {
-        sscanf (birthday.c_str(),"%4c%2c%2c",yy,mm,dd);
-        infoStringStream[0] 
-          << "\n\n" << patient.c_str()
-          << "\n" << patientId.c_str()
-          << "\n" << dd << "." << mm << "." << yy << " " << sex.c_str()
-          << "\n" << institution.c_str();
+      if (m_displayMetaInfo) {
+        infoStringStream[0]
+          << patient.c_str()
+          << "\n" << patientId.c_str();
+        if (birthday != "") {
+          sscanf (birthday.c_str(),"%4c%2c%2c",yy,mm,dd);
+          infoStringStream[0] << "\n" << dd << "." << mm << "." << yy << " " << sex.c_str();
+        }
+        infoStringStream[0] << "\n" << institution.c_str();
       } else {
         infoStringStream[0].clear();
       }
@@ -1675,7 +1684,9 @@ void QmitkStdMultiWidget::HandleCrosshairPositionEventDelayed()
 
       auto render_annotation = [&] (int j, int corner) {
         const std::string infoString = infoStringStream[j].str();
-        setCornerAnnotation(corner, 3, infoString.c_str());
+        for(int i = 0; i < 4; i++) {
+          setCornerAnnotation(corner, i, infoString.c_str());
+        }
       };
       render_annotation(0, 3);
       render_annotation(1, 1);


### PR DESCRIPTION
http://samsmu.net:8083/browse/AUT-1944

Немного меняет концепт аннотаций в окне рендера
 - Текст стал немного меньше (мешал радиологам)
 - Добавлен номер серии (как в радианте)
 - Что бы убрать вертикальный оффсет пришлось переместить меню в центр
 - Аннотации в полной мере теперь показываются на всех окнах мультивиджета (как в радианте)

пулл реквест только частично закрывает задачу
меню в центре - это спорное решение, но лучшего я пока не придумал