### PR TITLE
Краш при повторном открытии

### DIFF
--- a/Plugins/org.mitk.gui.qt.common/src/internal/QmitkViewCoordinator.cpp
+++ b/Plugins/org.mitk.gui.qt.common/src/internal/QmitkViewCoordinator.cpp
@@ -25,9 +25,7 @@ See LICENSE.txt or http://www.mitk.org for details.
 #include <berryIWorkbenchPage.h>
 
 QmitkViewCoordinator::QmitkViewCoordinator()
-  : m_ActiveZombieView(nullptr)
-  , m_ActiveRenderWindowPart(nullptr)
-  , m_VisibleRenderWindowPart(nullptr)
+  : m_ActiveRenderWindowPart(nullptr)
 {
 }
 
@@ -66,53 +64,6 @@ berry::IPartListener::Events::Types QmitkViewCoordinator::GetPartEventTypes() co
     | berry::IPartListener::Events::VISIBLE | berry::IPartListener::Events::OPENED;
 }
 
-void QmitkViewCoordinator::PartActivated(const berry::IWorkbenchPartReference::Pointer& partRef )
-{
-  //MITK_INFO << "*** PartActivated (" << partRef->GetPart(false)->GetPartName() << ")";
-  berry::IWorkbenchPart* part = partRef->GetPart(false).GetPointer();
-
-  // Check for a render window part and inform IRenderWindowPartListener views
-  // that it was activated
-  if ( mitk::IRenderWindowPart* renderPart = dynamic_cast<mitk::IRenderWindowPart*>(part) )
-  {
-    m_ActiveRenderWindowPart = renderPart;
-  }
-
-  // Check if the activated part wants to be notified
-  if (mitk::ILifecycleAwarePart* lifecycleAwarePart = dynamic_cast<mitk::ILifecycleAwarePart*>(part))
-  {
-    lifecycleAwarePart->Activated();
-  }
-
-  // Check if a zombie view has been activated.
-  if (mitk::IZombieViewPart* zombieView = dynamic_cast<mitk::IZombieViewPart*>(part))
-  {
-    if (m_ActiveZombieView && (m_ActiveZombieView != zombieView))
-    {
-      // Another zombie view has been activated. Tell the old one about it.
-      m_ActiveZombieView->ActivatedZombieView(partRef);
-      m_ActiveZombieView = zombieView;
-    }
-  }
-}
-
-void QmitkViewCoordinator::PartDeactivated(const berry::IWorkbenchPartReference::Pointer& partRef )
-{
-  //MITK_INFO << "*** PartDeactivated (" << partRef->GetPart(false)->GetPartName() << ")";
-  berry::IWorkbenchPart* part = partRef->GetPart(false).GetPointer();
-  
-  // Check for a render window part and if it is the currently active on.
-  // Inform IRenderWindowPartListener views that it has been deactivated.
-  if (dynamic_cast<mitk::IRenderWindowPart*>(part)) {
-    m_ActiveRenderWindowPart = nullptr;
-  }
-
-  if (mitk::ILifecycleAwarePart* lifecycleAwarePart = dynamic_cast<mitk::ILifecycleAwarePart*>(part))
-  {
-    lifecycleAwarePart->Deactivated();
-  }
-}
-
 void QmitkViewCoordinator::PartOpened(const berry::IWorkbenchPartReference::Pointer& partRef )
 {
   //MITK_INFO << "*** PartOpened (" << partRef->GetPart(false)->GetPartName() << ")";
@@ -144,10 +95,9 @@ void QmitkViewCoordinator::PartHidden(const berry::IWorkbenchPartReference::Poin
   // Inform IRenderWindowPartListener views that it has been hidden.
   if ( mitk::IRenderWindowPart* renderPart = dynamic_cast<mitk::IRenderWindowPart*>(part) )
   {
-    if (!m_ActiveRenderWindowPart && m_VisibleRenderWindowPart == renderPart)
-    {
+    if (m_ActiveRenderWindowPart == renderPart) {
       RenderWindowPartDeactivated(renderPart);
-      m_VisibleRenderWindowPart = nullptr;
+      m_ActiveRenderWindowPart = nullptr;
     }
   }
 
@@ -166,10 +116,9 @@ void QmitkViewCoordinator::PartVisible(const berry::IWorkbenchPartReference::Poi
   // that it was activated
   if ( mitk::IRenderWindowPart* renderPart = dynamic_cast<mitk::IRenderWindowPart*>(part) )
   {
-    if (!m_ActiveRenderWindowPart)
-    {
+    if (!m_ActiveRenderWindowPart) {
       RenderWindowPartActivated(renderPart);
-      m_VisibleRenderWindowPart = renderPart;
+      m_ActiveRenderWindowPart = renderPart;
     }
   }
 

--- a/Plugins/org.mitk.gui.qt.common/src/internal/QmitkViewCoordinator.h
+++ b/Plugins/org.mitk.gui.qt.common/src/internal/QmitkViewCoordinator.h
@@ -65,16 +65,6 @@ public:
   berry::IPartListener::Events::Types GetPartEventTypes() const override;
 
   /**
-   * \see IPartListener::PartActivated()
-   */
-  virtual void PartActivated (const berry::IWorkbenchPartReference::Pointer& partRef) override;
-
-  /**
-   * \see IPartListener::PartDeactivated()
-   */
-  virtual void PartDeactivated(const berry::IWorkbenchPartReference::Pointer& /*partRef*/) override;
-
-  /**
    * \see IPartListener::PartOpened()
    */
   virtual void PartOpened(const berry::IWorkbenchPartReference::Pointer& partRef) override;
@@ -111,9 +101,7 @@ private:
 
 private:
 
-  mitk::IZombieViewPart* m_ActiveZombieView;
   mitk::IRenderWindowPart* m_ActiveRenderWindowPart;
-  mitk::IRenderWindowPart* m_VisibleRenderWindowPart;
 
   QSet<mitk::IRenderWindowPartListener*> m_RenderWindowListeners;
 


### PR DESCRIPTION
http://samsmu.net:8083/browse/AUT-1948

Проблема в классе, который координирует состоянии открытого мультивиджета, там сломана логика.
Так как у нас всегда только один открытый мультивиджет, код этого класса можно заметно упростить, что я и сделал.

Кроме краша, есть связанная проблема с тем, что плагины становятся выключенными.
Этот фикс решает обе проблемы.

Тестовые шаги:

1. Загрузить картинку или модель в универсальный кейс.
2. Убедиться, что навигатор изображений видим и активен.
3. Закрыть картинку, загрузить ее снова.
   - Автоплан не падает.
4. Открыть плагин сегментации, переключиться на него, обратно на мультивиджет, перейти на вкладку просмотра, вернуться на универсальный кейс, поработать с сегментациями.
   - Плагин активен и не выключается без повода.
