### PR TITLE
Исправлено обновление плагина объемной визуализации. AUT-1946

### DIFF
--- a/Plugins/org.mitk.gui.qt.volumevisualization/src/internal/QmitkVolumeVisualizationView.h
+++ b/Plugins/org.mitk.gui.qt.volumevisualization/src/internal/QmitkVolumeVisualizationView.h
@@ -74,9 +74,12 @@ protected:
 private:
 
   mitk::WeakPointer<mitk::DataNode> m_SelectedNode;
+  unsigned long m_NodeListenerTag;
+  itk::MemberCommand<QmitkVolumeVisualizationView>::Pointer m_ModifiedCommand;
 
   void UpdateInterface();
   void NodeRemoved(const mitk::DataNode* node) override;
+  void onPropertyChanged(const itk::Object* caller, const itk::EventObject& event);
 
 };
 


### PR DESCRIPTION
http://samsmu.net:8083/browse/AUT-1946

Плагин объемной визуализации теперь обновляет интерфейс если у выбраного нода был изменен параметр "volumerendering". Это необходимо, например, для корректного воставноления вью из вьюпорт тулбокса.

1. Сохранить состояние камеры
2. Включить Volume Rendering
3. Вернуть сохраненное состояние камеры

ОР: В плагине отображается корректоное значение для Volume Rendering