### PR TITLE
Исправлено падение при закрытии плагина Volume Visualization. AUT-1946

### DIFF
--- a/Plugins/org.mitk.gui.qt.volumevisualization/src/internal/QmitkVolumeVisualizationView.h
+++ b/Plugins/org.mitk.gui.qt.volumevisualization/src/internal/QmitkVolumeVisualizationView.h
@@ -75,6 +75,7 @@ private:
 
   mitk::WeakPointer<mitk::DataNode> m_SelectedNode;
   unsigned long m_NodeListenerTag;
+  bool m_ListeningNode;
   itk::MemberCommand<QmitkVolumeVisualizationView>::Pointer m_ModifiedCommand;
 
   void UpdateInterface();


### PR DESCRIPTION
http://samsmu.net:8083/browse/AUT-1946

Исправлена ошибка с падением автоплана при закрытии плагина Volume Visualization.

1. Сохранить состояние камеры
2. Включить Volume Rendering
3. Вернуть сохраненное состояние камеры
ОР: В плагине отображается корректоное значение для Volume Rendering