### PR TITLE
Сегментации отображаются с контуром. AUT-1658

### DIFF
--- a/Modules/Core/include/mitkImageVtkMapper2D.h
+++ b/Modules/Core/include/mitkImageVtkMapper2D.h
@@ -180,6 +180,12 @@ public:
           This container is used to save a computed contour for the next rendering execution.
           For instance, if you zoom or pann, there is no need to recompute the contour. */
     vtkSmartPointer<vtkPolyData> m_OutlinePolyData;
+    /** \brief An actor for the outline */
+    vtkSmartPointer<vtkActor> m_OutlineActor;
+    /** \brief An actor for the outline shadow*/
+    vtkSmartPointer<vtkActor> m_OutlineShadowActor;
+    /** \brief A mapper for the outline */
+    vtkSmartPointer<vtkPolyDataMapper> m_OutlineMapper;
 
     /** \brief Timestamp of last update of stored data. */
     itk::TimeStamp m_LastUpdateTime;


### PR DESCRIPTION
http://samsmu.net:8083/browse/AUT-1658

Сегментация теперь всегда отображается с контуром, и заливка сегментации теперь прозрачная, как у multilabel сегментаций.

1. Создать сегментацию
2. Добавить область в сегментацию
3. Переключить заливку

ОР: Сегментация отображается, как описано выше