### PR TITLE
Fixed console flag reading as file. AUT-2037 [skip ci]

### DIFF
--- a/Plugins/org.mitk.gui.qt.ext/src/internal/QmitkCommonExtPlugin.cpp
+++ b/Plugins/org.mitk.gui.qt.ext/src/internal/QmitkCommonExtPlugin.cpp
@@ -61,9 +61,6 @@ void QmitkCommonExtPlugin::start(ctkPluginContext* context)
   {
     connect(qApp, SIGNAL(messageReceived(QByteArray)), this, SLOT(handleIPCMessage(QByteArray)));
   }
-
-  // This is a potentially long running operation.
-  loadDataFromDisk(berry::Platform::GetApplicationArgs(), true);
 }
 
 void QmitkCommonExtPlugin::stop(ctkPluginContext* context)


### PR DESCRIPTION
http://samsmu.net:8083/browse/AUT-2037

Исправлено чтение флага консоли как файла.

1. Открыть авптолан с флагом --console

ОР: В консоли нету предупреждений о неужачной попытке прочитать файл --console