### PR TITLE
Исправлено падение Автоплана

### DIFF
--- a/Modules/Config/src/ConfigManager.cpp
+++ b/Modules/Config/src/ConfigManager.cpp
@@ -15,7 +15,7 @@ namespace config
     void Add(const char* key, TValue&& value);
 
     template <typename TValue>
-    TValue Get(const char* key, TValue&& value) const;
+    const TValue& Get(const char* key, const TValue& value) const;
 
     void Delete(const char* key);
 
@@ -67,7 +67,7 @@ namespace config
   }
 
   template <typename TValue>
-  TValue ConfigManager::Impl::Get(const char* key, TValue&& value) const
+  const TValue& ConfigManager::Impl::Get(const char* key, const TValue& value) const
   {
     if (!key || m_deleted.end() != m_deleted.find(key)) {
       return value;


### PR DESCRIPTION
Падение/не работа функционала вызвана не правильным типом в boost::get который вызывал исключение

http://samsmu.net:8083/browse/AUT-1879