### PR TITLE
Ложные multiframe исследования

### DIFF
--- a/Modules/Core/src/IO/mitkDicomSR_ImageBlockDescriptor.cpp
+++ b/Modules/Core/src/IO/mitkDicomSR_ImageBlockDescriptor.cpp
@@ -222,7 +222,13 @@ void DicomSeriesReader::ImageBlockDescriptor::SetModality(const std::string& mod
 
 void DicomSeriesReader::ImageBlockDescriptor::SetNumberOfFrames(const std::string& numberOfFrames)
 {
-  m_IsMultiFrameImage = !numberOfFrames.empty();
+  int numberOfFramesInt = 0;
+  try {
+    numberOfFramesInt = numberOfFrames.empty() ? 0 : std::stoi(numberOfFrames);
+  } catch (...) {
+  }
+
+  m_IsMultiFrameImage = (numberOfFramesInt > 1);
 }
 
 void DicomSeriesReader::ImageBlockDescriptor::SetSOPClassUID(const std::string& sopClassUID)


### PR DESCRIPTION
http://samsmu.net:8083/browse/AUT-2087

Проблема была в коде, который устанавливает multiframe флаг.
Он проверял только наличие тэга, но не его значение, поэтому исследования, где тэг NumberOfFrame был равен 1, тоже считались multiframe.

Тестовые шаги:

1. Открыть 0117 исследование.
    - Там больше нет плеера.