### PR TITLE
Новая функция MessageBase::AddFirstListener

### DIFF
--- a/Modules/Core/include/mitkMessage.h
+++ b/Modules/Core/include/mitkMessage.h
@@ -391,6 +391,27 @@ public:
     m_Mutex.Unlock();
   }
 
+  /**
+  * \brief AddFirstListener
+  *
+  * New listener will be first receiver.
+  * Note: The use of both AddListener and AddFirstListener for the same (object, member function) pair in callback can give an unexpected result.
+  */
+  void AddFirstListener(const AbstractDelegate& delegate) const
+  {
+    AbstractDelegatePtr msgCmd(delegate.Clone());
+
+    m_Mutex.Lock();
+    const auto iter = std::find_if(m_Listeners.begin(), m_Listeners.end(),
+      [msgCmd](AbstractDelegatePtr item) { return *item == msgCmd.get(); });
+    if (m_Listeners.end() == iter) {
+      m_Listeners.push_front(msgCmd);
+    } else {
+      m_ListenerToRemove.erase(iter->get());
+    }
+    m_Mutex.Unlock();
+  }
+
   void operator += (const AbstractDelegate& delegate) const
   {
     this->AddListener(delegate);

--- a/Modules/QtWidgets/src/QmitkDataStorageTreeModel.cpp
+++ b/Modules/QtWidgets/src/QmitkDataStorageTreeModel.cpp
@@ -559,7 +559,7 @@ void QmitkDataStorageTreeModel::SetDataStorage( mitk::DataStorage* _DataStorage 
       m_DataStorage->ChangedNodeEvent.AddListener( mitk::MessageDelegate1<QmitkDataStorageTreeModel
         , const mitk::DataNode*>( this, &QmitkDataStorageTreeModel::SetNodeModified ) );
 
-      m_DataStorage->RemoveNodeEvent.AddListener( mitk::MessageDelegate1<QmitkDataStorageTreeModel
+      m_DataStorage->RemoveNodeEvent.AddFirstListener( mitk::MessageDelegate1<QmitkDataStorageTreeModel
         , const mitk::DataNode*>( this, &QmitkDataStorageTreeModel::RemoveNode ) );
 
       mitk::DataStorage::SetOfObjects::ConstPointer _NodeSet = m_DataStorage->GetSubset(m_Predicate);


### PR DESCRIPTION
Позволяет влиять на порядок вызова  слушателей событий, добавляя слушателя перед всеми другими. Новая функция использована в QmitkDataStorageTreeModel, чтобы предотвратить влияние на LevelWindowManager при удалении вспомогательных узлов.
[AUT-2178](http://samsmu.net:8083/browse/AUT-2178)