### PR TITLE
Порядок временных срезов

### DIFF
--- a/Modules/Core/include/mitkDicomSeriesReader.h
+++ b/Modules/Core/include/mitkDicomSeriesReader.h
@@ -490,22 +490,7 @@ public:
 
    Find all series (and sub-series -- see details) in a particular directory.
   */
-  static FileNamesGrouping GetSeries(const std::string &dir,
-                                   bool groupImagesWithGantryTilt,
-                                   const StringContainer &restrictions = StringContainer());
-
-  /**
-   \brief see other GetSeries().
-
-   \warning Untested, could or could not work.
-
-   This differs only by having an additional restriction to a single known DICOM series.
-   Internally, it uses the other GetSeries() method.
-  */
-  static StringContainer GetSeries(const std::string &dir,
-                                   const std::string &series_uid,
-                                   bool groupImagesWithGantryTilt,
-                                   const StringContainer &restrictions = StringContainer());
+  static FileNamesGrouping GetSeries(const std::string &dir);
 
   /**
    \brief PREFERRED version of this method - scan and sort DICOM files.
@@ -530,22 +515,8 @@ public:
    \warning Adding restrictions is not yet implemented!
    */
   static
-  FileNamesGrouping
-  GetSeries(const StringContainer& files,
-            bool sortTo3DPlust,
-            bool groupImagesWithGantryTilt,
-            const StringContainer &restrictions = StringContainer());
-
-  /**
-    \brief See other GetSeries().
-
-    Use GetSeries(const StringContainer& files, bool sortTo3DPlust, const StringContainer &restrictions) instead.
-  */
-  static
-  FileNamesGrouping
-  GetSeries(const StringContainer& files,
-            bool groupImagesWithGantryTilt,
-            const StringContainer &restrictions = StringContainer());
+    FileNamesGrouping
+    GetSeries(const StringContainer& files, bool unused = true /* for backward compatibility */);
 
   /**
    Loads a DICOM series composed by the file names enumerated in the file names container.
@@ -796,7 +767,7 @@ protected:
   */
   static
   SliceGroupingAnalysisResult
-  AnalyzeFileForITKImageSeriesReaderSpacingAssumption(const StringContainer& files, bool groupsOfSimilarImages, const gdcm::Scanner::MappingType& tagValueMappings_);
+  AnalyzeFileForITKImageSeriesReaderSpacingAssumption(const StringContainer& files, const gdcm::Scanner::MappingType& tagValueMappings_);
 
   /**
     \brief Safely convert const char* to std::string.

--- a/Modules/Core/src/IO/mitkDicomSeriesReaderService.cpp
+++ b/Modules/Core/src/IO/mitkDicomSeriesReaderService.cpp
@@ -61,8 +61,7 @@ std::vector<itk::SmartPointer<BaseData> > DicomSeriesReaderService::Read()
 
   }
 
-  DicomSeriesReader::FileNamesGrouping imageBlocks = DicomSeriesReader::GetSeries(itksys::SystemTools::GetFilenamePath(fileName),
-                                                                                  true); // true = group gantry tilt images
+  DicomSeriesReader::FileNamesGrouping imageBlocks = DicomSeriesReader::GetSeries(itksys::SystemTools::GetFilenamePath(fileName));
   const unsigned int size = imageBlocks.size();
 
   ProgressBar::GetInstance()->AddStepsToDo(size);

--- a/Modules/Core/test/mitkDicomSeriesReaderTest.cpp
+++ b/Modules/Core/test/mitkDicomSeriesReaderTest.cpp
@@ -71,7 +71,7 @@ int mitkDicomSeriesReaderTest(int argc, char* argv[])
   dir = argv[1];
 
   //check if DICOMTags have been set as property for mitk::Image
-  mitk::DicomSeriesReader::FileNamesGrouping seriesInFiles = mitk::DicomSeriesReader::GetSeries( dir, true );
+  mitk::DicomSeriesReader::FileNamesGrouping seriesInFiles = mitk::DicomSeriesReader::GetSeries(dir);
   std::list<mitk::Image::Pointer> images;
   std::map<mitk::Image::Pointer, mitk::DicomSeriesReader::StringContainer> fileMap;
 

--- a/Modules/DCMTesting/src/mitkTestDCMLoading.cpp
+++ b/Modules/DCMTesting/src/mitkTestDCMLoading.cpp
@@ -69,7 +69,7 @@ mitk::TestDCMLoading::ImageList mitk::TestDCMLoading::LoadFiles( const StringCon
 
   ImageList result;
 
-  DicomSeriesReader::FileNamesGrouping seriesInFiles = DicomSeriesReader::GetSeries( files, true );
+  DicomSeriesReader::FileNamesGrouping seriesInFiles = DicomSeriesReader::GetSeries( files);
 
   // TODO sort series UIDs, implementation of map iterator might differ on different platforms (or verify this is a standard topic??)
   for (DicomSeriesReader::FileNamesGrouping::const_iterator seriesIter = seriesInFiles.begin();

--- a/Modules/DiffusionImaging/MiniApps/Dicom2Nrrd.cpp
+++ b/Modules/DiffusionImaging/MiniApps/Dicom2Nrrd.cpp
@@ -54,7 +54,7 @@ int main(int argc, char* argv[])
   std::string outFileName = us::any_cast<string>(parsedArgs["output"]);
 
   //check if DICOMTags have been set as property for mitk::Image
-  mitk::DicomSeriesReader::FileNamesGrouping seriesInFiles = mitk::DicomSeriesReader::GetSeries( inputFolder, true );
+  mitk::DicomSeriesReader::FileNamesGrouping seriesInFiles = mitk::DicomSeriesReader::GetSeries( inputFolder);
   std::list<mitk::Image::Pointer> images;
   std::map<mitk::Image::Pointer, mitk::DicomSeriesReader::StringContainer> fileMap;
 

--- a/Modules/LegacyIO/mitkDataNodeFactory.cpp
+++ b/Modules/LegacyIO/mitkDataNodeFactory.cpp
@@ -251,7 +251,7 @@ void mitk::DataNodeFactory::ReadFileSeriesTypeDCM()
 
   }
 
-  DicomSeriesReader::FileNamesGrouping imageBlocks = DicomSeriesReader::GetSeries(this->GetDirectory(), true, this->m_SeriesRestrictions); // true = group gantry tilt images
+  DicomSeriesReader::FileNamesGrouping imageBlocks = DicomSeriesReader::GetSeries(this->GetDirectory());
   const unsigned int size = imageBlocks.size();
 
   this->ResizeOutputs(size);


### PR DESCRIPTION
http://samsmu.net:8083/browse/AUT-2246

Теперь срезы правильно расположены в 4Д-изображениях.

Тестовые шаги:

1. Убедиться, что все дайкомы из http://85.236.191.80:8084/wiki/doku.php?id=autoplan:dev:dicoms грузятся как надо.
2. К сожалению, правильность сортировки по времени не видно "на глаз". Так что после пункта 1 задача должна уйти на тестирование к Прилепину, который считает метрики по срезам.