### PR TITLE
Don't save/restore perspective on startup

### DIFF
--- a/Plugins/org.blueberry.ui.qt/src/internal/berryWorkbenchConstants.cpp
+++ b/Plugins/org.blueberry.ui.qt/src/internal/berryWorkbenchConstants.cpp
@@ -172,9 +172,6 @@ const QString WorkbenchConstants::TAG_PERSPECTIVES = "perspectives";
 
 const QString WorkbenchConstants::TAG_PERSPECTIVE = "perspective";
 
-const QString WorkbenchConstants::TAG_ACTIVE_PERSPECTIVE =
-    "activePerspective";
-
 const QString WorkbenchConstants::TAG_ACTIVE_PART = "activePart";
 
 const QString WorkbenchConstants::TAG_ACTION_SET = "actionSet";

--- a/Plugins/org.blueberry.ui.qt/src/internal/berryWorkbenchConstants.h
+++ b/Plugins/org.blueberry.ui.qt/src/internal/berryWorkbenchConstants.h
@@ -170,8 +170,6 @@ struct BERRY_UI_QT WorkbenchConstants
 
   static const QString TAG_PERSPECTIVE; // = "perspective";
 
-  static const QString TAG_ACTIVE_PERSPECTIVE; // = "activePerspective";
-
   static const QString TAG_ACTIVE_PART; // = "activePart";
 
   static const QString TAG_ACTION_SET; // = "actionSet";

--- a/Plugins/org.blueberry.ui.qt/src/internal/berryWorkbenchPage.cpp
+++ b/Plugins/org.blueberry.ui.qt/src/internal/berryWorkbenchPage.cpp
@@ -3002,9 +3002,6 @@ bool WorkbenchPage::RestoreState(IMemento::Pointer memento,
           activePartID = ViewFactory::ExtractPrimaryId(activePartID);
         }
       }
-      QString activePerspectiveID;
-      childMem->GetString(WorkbenchConstants::TAG_ACTIVE_PERSPECTIVE,
-          activePerspectiveID);
 
       // Restore perspectives.
       QList<IMemento::Pointer> perspMems(childMem->GetChildren(
@@ -3030,11 +3027,7 @@ bool WorkbenchPage::RestoreState(IMemento::Pointer memento,
         {
           activePerspective = persp;
         }
-        else if ((activePerspective == 0) && desc->GetId()
-            == activePerspectiveID)
-        {
-          activePerspective = persp;
-        }
+
         perspList.Add(persp);
         window->FirePerspectiveOpened(WorkbenchPage::Pointer(this), desc);
         //                }
@@ -3253,11 +3246,6 @@ bool WorkbenchPage::SaveState(IMemento::Pointer memento)
 
   // Create persp block.
   childMem = memento->CreateChild(WorkbenchConstants::TAG_PERSPECTIVES);
-  if (this->GetPerspective())
-  {
-    childMem->PutString(WorkbenchConstants::TAG_ACTIVE_PERSPECTIVE,
-        this->GetPerspective()->GetId());
-  }
   if (this->GetActivePart() != 0)
   {
     if (this->GetActivePart().Cast<IViewPart> ())


### PR DESCRIPTION
Load perspective (perspective action) and perspective plugins (CreateQtPart) on demand only

исправляет костыль, который аффектил время загрузки