### PR TITLE
Add QmitkSynchronizeSelectedData class

### DIFF
--- a/Modules/QtWidgets/CMakeLists.txt
+++ b/Modules/QtWidgets/CMakeLists.txt
@@ -2,7 +2,7 @@ MITK_CREATE_MODULE(
   INCLUDE_DIRS PRIVATE resource # for xpm includes
   DEPENDS MitkPlanarFigure MitkOverlays MitkConfig
   PACKAGE_DEPENDS
-    PUBLIC ITK|ITKIOImageBase VTK|vtkGUISupportQt+vtkGUISupportQtOpenGL Qt5|Widgets+OpenGL+Core
+    PUBLIC ITK|ITKIOImageBase VTK|vtkGUISupportQt+vtkGUISupportQtOpenGL Qt5|Widgets+OpenGL+Core Boost
   SUBPROJECTS MITK-CoreUI
 )
 

--- a/Modules/QtWidgets/files.cmake
+++ b/Modules/QtWidgets/files.cmake
@@ -37,6 +37,7 @@ QmitkDataStorageComboBoxWithSelectNone.cpp
 QmitkPropertyItem.cpp
 QmitkPropertyItemDelegate.cpp
 QmitkPropertyItemModel.cpp
+QmitkSynchronizeSelectedData.cpp
 )
 
 set(MOC_H_FILES

--- a/Modules/QtWidgets/include/QmitkDataStorageComboBox.h
+++ b/Modules/QtWidgets/include/QmitkDataStorageComboBox.h
@@ -17,7 +17,12 @@ See LICENSE.txt or http://www.mitk.org for details.
 #ifndef QmitkDataStorageComboBox_h
 #define QmitkDataStorageComboBox_h
 
-#include <MitkQtWidgetsExports.h>
+// Toolkit Includes
+#include <map>
+
+#include <boost/signals2.hpp>
+
+#include <QComboBox>
 
 // Own Includes
 #include "mitkDataStorage.h"
@@ -25,9 +30,9 @@ See LICENSE.txt or http://www.mitk.org for details.
 #include "mitkWeakPointer.h"
 #include "mitkNodePredicateBase.h"
 
-// Toolkit Includes
-#include <QComboBox>
-#include <map>
+#include <MitkQtWidgetsExports.h>
+
+#include "QmitkSynchronizeSelectedData.h"
 
 // Forward Declartions
 
@@ -68,6 +73,9 @@ class MITKQTWIDGETS_EXPORT QmitkDataStorageComboBox : public QComboBox
     /// \brief Seaches for a given node and returns a valid index or -1 if the node was not found.
     ///
     virtual int Find( const mitk::DataNode* _DataNode ) const;
+    
+    void SubscribeToChangeData(SynchronizeEventType type);
+    void UnsubscribeToChangeData();
 
   //#PUBLIC GETTER
   public:
@@ -235,7 +243,12 @@ class MITKQTWIDGETS_EXPORT QmitkDataStorageComboBox : public QComboBox
     ///
     /// \brief If set to "true" new Nodes will be automatically selected.
     bool m_AutoSelectNewNodes;
+    
+  private:
+    
+    boost::signals2::connection m_CurrentDataChange;
 
+    void OnChangeData(const mitk::DataNode* node);
 };
 
 #endif // QmitkDataStorageComboBox_h

--- a/Modules/QtWidgets/include/QmitkSynchronizeSelectedData.h
+++ b/Modules/QtWidgets/include/QmitkSynchronizeSelectedData.h
@@ -3,6 +3,7 @@
 #include <boost/thread/recursive_mutex.hpp>
 #include <boost/function.hpp>
 #include <boost/signals2.hpp>
+#include <boost/noncopyable.hpp>
 
 #include <mitkDataNode.h>
 
@@ -16,30 +17,20 @@ enum class SynchronizeEventType
 
 typedef boost::signals2::signal<void(const mitk::DataNode*)> SlotType;
 
-class MITKQTWIDGETS_EXPORT QmitkSynchronizeSelectedData
+class MITKQTWIDGETS_EXPORT QmitkSynchronizeSelectedData : boost::noncopyable
 {
 
 public:
-
-  ~QmitkSynchronizeSelectedData();
 
   static boost::signals2::connection addObserver(SynchronizeEventType type, const SlotType::slot_type& func);
 
   static void emitImageChange(mitk::DataNode* node);
   static void emitSegmentationChange(mitk::DataNode* node);
 
-  static QmitkSynchronizeSelectedData* getInstance();
-
 private:
-
-  static QmitkSynchronizeSelectedData* m_instance;
 
   static boost::recursive_mutex m_mutex;
   
   static SlotType m_imageChange;
   static SlotType m_segmentationChange;
-
-  QmitkSynchronizeSelectedData();
-  QmitkSynchronizeSelectedData(const QmitkSynchronizeSelectedData&);
-  QmitkSynchronizeSelectedData& operator = (const QmitkSynchronizeSelectedData&);
 };

--- a/Modules/QtWidgets/include/QmitkSynchronizeSelectedData.h
+++ b/Modules/QtWidgets/include/QmitkSynchronizeSelectedData.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <boost/thread/recursive_mutex.hpp>
+#include <boost/function.hpp>
+#include <boost/signals2.hpp>
+
+#include <mitkDataNode.h>
+
+#include <MitkQtWidgetsExports.h>
+
+enum class SynchronizeEventType
+{
+  IMAGE_CHANGE,
+  SEGMENTATION_CHANGE
+};
+
+typedef boost::signals2::signal<void(const mitk::DataNode*)> SlotType;
+
+class MITKQTWIDGETS_EXPORT QmitkSynchronizeSelectedData
+{
+
+public:
+
+  ~QmitkSynchronizeSelectedData();
+
+  static boost::signals2::connection addObserver(SynchronizeEventType type, const SlotType::slot_type& func);
+
+  static void emitImageChange(mitk::DataNode* node);
+  static void emitSegmentationChange(mitk::DataNode* node);
+
+  static QmitkSynchronizeSelectedData* getInstance();
+
+private:
+
+  static QmitkSynchronizeSelectedData* m_instance;
+
+  static boost::recursive_mutex m_mutex;
+  
+  static SlotType m_imageChange;
+  static SlotType m_segmentationChange;
+
+  QmitkSynchronizeSelectedData();
+  QmitkSynchronizeSelectedData(const QmitkSynchronizeSelectedData&);
+  QmitkSynchronizeSelectedData& operator = (const QmitkSynchronizeSelectedData&);
+};

--- a/Modules/QtWidgets/src/QmitkDataStorageComboBox.cpp
+++ b/Modules/QtWidgets/src/QmitkDataStorageComboBox.cpp
@@ -29,8 +29,6 @@ QmitkDataStorageComboBox::QmitkDataStorageComboBox( QWidget* parent, bool _AutoS
 , m_AutoSelectNewNodes(_AutoSelectNewNodes)
 {
   this->Init();
-  
-  QmitkSynchronizeSelectedData::getInstance();
 }
 
 QmitkDataStorageComboBox::QmitkDataStorageComboBox( mitk::DataStorage* _DataStorage, const mitk::NodePredicateBase* _Predicate,

--- a/Modules/QtWidgets/src/QmitkDataStorageComboBox.cpp
+++ b/Modules/QtWidgets/src/QmitkDataStorageComboBox.cpp
@@ -13,6 +13,7 @@ A PARTICULAR PURPOSE.
 See LICENSE.txt or http://www.mitk.org for details.
 
 ===================================================================*/
+#include <boost/bind.hpp>
 
 #include "QmitkDataStorageComboBox.h"
 
@@ -28,6 +29,8 @@ QmitkDataStorageComboBox::QmitkDataStorageComboBox( QWidget* parent, bool _AutoS
 , m_AutoSelectNewNodes(_AutoSelectNewNodes)
 {
   this->Init();
+  
+  QmitkSynchronizeSelectedData::getInstance();
 }
 
 QmitkDataStorageComboBox::QmitkDataStorageComboBox( mitk::DataStorage* _DataStorage, const mitk::NodePredicateBase* _Predicate,
@@ -45,6 +48,8 @@ QmitkDataStorageComboBox::QmitkDataStorageComboBox( mitk::DataStorage* _DataStor
 
 QmitkDataStorageComboBox::~QmitkDataStorageComboBox()
 {
+  UnsubscribeToChangeData();
+
   // if there was an old storage, remove listeners
   if(m_DataStorage.IsNotNull())
   {
@@ -57,6 +62,29 @@ QmitkDataStorageComboBox::~QmitkDataStorageComboBox()
   //we have lots of observers to nodes and their name properties, this get's ugly if nodes live longer than the box
   while(m_Nodes.size() > 0)
     RemoveNode(0);
+}
+
+void QmitkDataStorageComboBox::OnChangeData(const mitk::DataNode* node)
+{
+  const int index = Find(node);
+  if (index == -1)
+  {
+    AddNode(node);
+    return;
+  }
+  
+  SetSelectedNode(const_cast<mitk::DataNode*>(node));
+}
+
+void QmitkDataStorageComboBox::SubscribeToChangeData(SynchronizeEventType type)
+{
+  SlotType::slot_type slot = boost::bind(&QmitkDataStorageComboBox::OnChangeData, this, _1);
+  m_CurrentDataChange = QmitkSynchronizeSelectedData::addObserver(type, slot);
+}
+
+void QmitkDataStorageComboBox::UnsubscribeToChangeData()
+{
+  m_CurrentDataChange.disconnect();
 }
 
 //#PUBLIC GETTER

--- a/Modules/QtWidgets/src/QmitkSynchronizeSelectedData.cpp
+++ b/Modules/QtWidgets/src/QmitkSynchronizeSelectedData.cpp
@@ -1,0 +1,58 @@
+#include <boost/thread/locks.hpp>
+
+#include "../include/QmitkSynchronizeSelectedData.h"
+
+QmitkSynchronizeSelectedData* QmitkSynchronizeSelectedData::m_instance = nullptr;
+boost::recursive_mutex QmitkSynchronizeSelectedData::m_mutex;
+SlotType QmitkSynchronizeSelectedData::m_imageChange;
+SlotType QmitkSynchronizeSelectedData::m_segmentationChange;
+
+QmitkSynchronizeSelectedData::QmitkSynchronizeSelectedData()
+{
+}
+
+QmitkSynchronizeSelectedData::~QmitkSynchronizeSelectedData()
+{
+  m_imageChange.disconnect_all_slots();
+  m_segmentationChange.disconnect_all_slots();
+}
+
+QmitkSynchronizeSelectedData* QmitkSynchronizeSelectedData::getInstance()
+{
+  if (m_instance == nullptr)
+  {
+    m_instance = new QmitkSynchronizeSelectedData();
+  }
+
+  return m_instance;
+}
+
+boost::signals2::connection QmitkSynchronizeSelectedData::addObserver(SynchronizeEventType type, const SlotType::slot_type& func)
+{
+  boost::unique_lock<boost::recursive_mutex> lock(m_mutex);
+
+  boost::signals2::connection currentConnect;
+  
+  if (type == SynchronizeEventType::IMAGE_CHANGE)
+  {
+    currentConnect = getInstance()->m_imageChange.connect(func);
+  }
+  else if (type == SynchronizeEventType::SEGMENTATION_CHANGE)
+  {
+    currentConnect = getInstance()->m_segmentationChange.connect(func);
+  }
+  
+  return currentConnect;
+}
+
+void QmitkSynchronizeSelectedData::emitImageChange(mitk::DataNode* node)
+{
+  boost::unique_lock<boost::recursive_mutex> lock(m_mutex);
+  getInstance()->m_imageChange(node);
+}
+
+void QmitkSynchronizeSelectedData::emitSegmentationChange(mitk::DataNode* node)
+{
+  boost::unique_lock<boost::recursive_mutex> lock(m_mutex);
+  getInstance()->m_segmentationChange(node);
+}

--- a/Modules/QtWidgets/src/QmitkSynchronizeSelectedData.cpp
+++ b/Modules/QtWidgets/src/QmitkSynchronizeSelectedData.cpp
@@ -2,30 +2,9 @@
 
 #include "../include/QmitkSynchronizeSelectedData.h"
 
-QmitkSynchronizeSelectedData* QmitkSynchronizeSelectedData::m_instance = nullptr;
 boost::recursive_mutex QmitkSynchronizeSelectedData::m_mutex;
 SlotType QmitkSynchronizeSelectedData::m_imageChange;
 SlotType QmitkSynchronizeSelectedData::m_segmentationChange;
-
-QmitkSynchronizeSelectedData::QmitkSynchronizeSelectedData()
-{
-}
-
-QmitkSynchronizeSelectedData::~QmitkSynchronizeSelectedData()
-{
-  m_imageChange.disconnect_all_slots();
-  m_segmentationChange.disconnect_all_slots();
-}
-
-QmitkSynchronizeSelectedData* QmitkSynchronizeSelectedData::getInstance()
-{
-  if (m_instance == nullptr)
-  {
-    m_instance = new QmitkSynchronizeSelectedData();
-  }
-
-  return m_instance;
-}
 
 boost::signals2::connection QmitkSynchronizeSelectedData::addObserver(SynchronizeEventType type, const SlotType::slot_type& func)
 {
@@ -35,11 +14,11 @@ boost::signals2::connection QmitkSynchronizeSelectedData::addObserver(Synchroniz
   
   if (type == SynchronizeEventType::IMAGE_CHANGE)
   {
-    currentConnect = getInstance()->m_imageChange.connect(func);
+    currentConnect = m_imageChange.connect(func);
   }
   else if (type == SynchronizeEventType::SEGMENTATION_CHANGE)
   {
-    currentConnect = getInstance()->m_segmentationChange.connect(func);
+    currentConnect = m_segmentationChange.connect(func);
   }
   
   return currentConnect;
@@ -48,11 +27,11 @@ boost::signals2::connection QmitkSynchronizeSelectedData::addObserver(Synchroniz
 void QmitkSynchronizeSelectedData::emitImageChange(mitk::DataNode* node)
 {
   boost::unique_lock<boost::recursive_mutex> lock(m_mutex);
-  getInstance()->m_imageChange(node);
+  m_imageChange(node);
 }
 
 void QmitkSynchronizeSelectedData::emitSegmentationChange(mitk::DataNode* node)
 {
   boost::unique_lock<boost::recursive_mutex> lock(m_mutex);
-  getInstance()->m_segmentationChange(node);
+  m_segmentationChange(node);
 }


### PR DESCRIPTION
  Добавляет класс QmitkSynchronizeSelectedData, который позволяет синхронизировать выбор сегментации и изображения, между плагинами. Нужен для того, что бы SegManager в Автоплане мог синхронизировать свои выбранные данные с плагином LiverSegmentation.

http://samsmu.net:8083/browse/AUT-2364