### PR TITLE
Исправление поведения при переключении режимов вращения в мультивиджете

### DIFF
--- a/Modules/Core/resource/Interactions/DisplayInteraction.xml
+++ b/Modules/Core/resource/Interactions/DisplayInteraction.xml
@@ -186,6 +186,10 @@ TODO Std move to abort interaction of scroll/pan/zoom
         <condition name="check_position_event"/>
         <action name="init"/>
       </transition>
+      <transition event_class="InternalEvent" event_variant="RotationModeChanged" target="start">
+        <action name="rotationModeChanged"/>
+      </transition>
+
     </state>
     <state name="rotation">
       <transition event_class="InteractionPositionEvent" event_variant="Rotate" target="rotation">

--- a/Modules/Core/src/Interactions/mitkDisplayInteractor.cpp
+++ b/Modules/Core/src/Interactions/mitkDisplayInteractor.cpp
@@ -78,6 +78,7 @@ void mitk::DisplayInteractor::ConnectActionsAndFunctions()
   CONNECT_FUNCTION ("updateStatusbar", UpdateStatusbar)
   CONNECT_FUNCTION("startRotation", StartRotation);
   CONNECT_FUNCTION("endRotation", EndRotation);
+  CONNECT_FUNCTION("rotationModeChanged", EndRotation);
   CONNECT_FUNCTION("rotate", Rotate);
   CONNECT_FUNCTION("rotateBack", RotateBack);
 

--- a/Modules/QtWidgets/src/QmitkRenderWindow.cpp
+++ b/Modules/QtWidgets/src/QmitkRenderWindow.cpp
@@ -304,6 +304,9 @@ void QmitkRenderWindow::OnChangeLayoutDesign(int layoutDesignIndex)
 
 void QmitkRenderWindow::OnWidgetPlaneModeChanged(int mode)
 {
+  mitk::InternalEvent::Pointer internalEvent = mitk::InternalEvent::New(m_Renderer, nullptr, "RotationModeChanged");
+  this->HandleEvent(internalEvent.GetPointer());
+
   if (m_MenuWidget)
     m_MenuWidget->NotifyNewWidgetPlanesMode(mode);
 }


### PR DESCRIPTION
http://samsmu.net:8083/browse/AUT-2373

При переключении режима вращения в мультивиджете интерактор не выходит из предыдущего режима. Из-за этого мы можем застрять в режиме готовности к вращению.
Теперь режим должен сбрасываться.

Тестовые шаги:

1. Загрузить данные в универсальный кейс.
2. Включить режим вращения в мультивиджете.
3. Повернуть ось так, чтобы она упиралась в всплывающее меню.
4. Пока курсор показывает возможность вращения, довести его по оси до меню и выключить режим вращения.
   - Курсор сбросился в стандартный.
   - Можно двигать геометрию, щелкая по аксиальному срезу.