### PR TITLE
Выключение 2Д-интерполяции когда надо

### DIFF
--- a/Modules/SegmentationUI/Qmitk/QmitkSlicesInterpolator.cpp
+++ b/Modules/SegmentationUI/Qmitk/QmitkSlicesInterpolator.cpp
@@ -590,6 +590,8 @@ void QmitkSlicesInterpolator::Interpolate( mitk::PlaneGeometry* plane, unsigned 
         if (interpolation) {
           m_FeedbackNode->SetData(interpolation);
           m_LastSNC = slicer;
+        } else if (m_LastSNC == slicer) {
+          m_FeedbackNode->SetData(nullptr);
         }
       }
     }


### PR DESCRIPTION
http://samsmu.net:8083/browse/AUT-2463

Теперь при скроллинге за пределы сегментации контур 2Д-интерполяции будет прятаться.

Тестовые шаги:

1. Загрузить данные в универсальный кейс.
2. Открыть плагин "Сегментация", создать сегментацию, включить 2Д-интерполяцию.
   - Интерполяция работает в пределах сегментации по скроллу и по клику.
   - При выходе активного слайса за пределы сегментации, желтый промежуточный контур 2Д-интерполяции перестает быть видимым.