### PR TITLE
Прозрачность по умолчанию для полигональных моделей [skip-CI]

### DIFF
--- a/Modules/Segmentation/Algorithms/mitkShowSegmentationAsSurface.cpp
+++ b/Modules/Segmentation/Algorithms/mitkShowSegmentationAsSurface.cpp
@@ -177,7 +177,7 @@ void ShowSegmentationAsSurface::ThreadedUpdateSuccessful()
       np->SetRepresentationToWireframe();
   }
 
-  m_Node->SetProperty("opacity", FloatProperty::New(0.3) );
+  m_Node->SetProperty("opacity", FloatProperty::New(1.0) );
   m_Node->SetProperty("line width", IntProperty::New(1) );
   m_Node->SetProperty("scalar visibility", BoolProperty::New(false) );
 


### PR DESCRIPTION
http://samsmu.net:8083/browse/AUT-2614

Теперь полигональные модели, созданные с помощью алгоритмов из МИТК, по умолчанию полностью непрозрачны.

Тестовые шаги в AUT-2614.