### PR TITLE
Исправление загрузки DWI от GE

### DIFF
--- a/Modules/DiffusionImaging/DiffusionCore/src/DicomImport/mitkDiffusionHeaderGEDICOMFileReader.cpp
+++ b/Modules/DiffusionImaging/DiffusionCore/src/DicomImport/mitkDiffusionHeaderGEDICOMFileReader.cpp
@@ -38,9 +38,9 @@ bool mitk::DiffusionHeaderGEDICOMFileReader
   // b value stored in the first bytes
   // typical example:  "1000\8\0\0" for bvalue=1000
   //                   "40\8\0\0" for bvalue=40
-  // so we need to cut off the last 6 elements
-  const char* bval_string = ge_tagvalue_string.substr(0,ge_tagvalue_string.length()-6).c_str();
-  header_info.b_value = static_cast<unsigned int>(strtod( bval_string, &pEnd ));
+  int slashPos = ge_tagvalue_string.find('\\');
+  std::string bval_string = ge_tagvalue_string.substr(0, slashPos);
+  header_info.b_value = std::stoi(bval_string);
 
   // now retrieve the gradient direction
   if(success &&


### PR DESCRIPTION
http://samsmu.net:8083/browse/AUT-2857

МИТК неправильно парсило строку с B-value.

Тестовые шаги:

1. Загрузить исследования 0619-0622.
   - Они содержат DWI серию.