### PR TITLE
Исправление осей в мультивиджете

### DIFF
--- a/Modules/Core/include/mitkPlaneGeometry.h
+++ b/Modules/Core/include/mitkPlaneGeometry.h
@@ -140,9 +140,12 @@ namespace mitk {
     *   thisgeometry->SetExtentInMM(2, 1.0);
     * \endcode
     */
-    virtual void InitializeStandardPlane(const BaseGeometry* geometry3D,
-      PlaneOrientation planeorientation = Axial, ScalarType zPosition = 0,
-      bool frontside = true, bool rotated = false);
+    virtual void InitializeStandardPlane(const BaseGeometry *geometry3D,
+                                         PlaneOrientation planeorientation = Axial,
+                                         ScalarType zPosition = 0,
+                                         bool frontside = true,
+                                         bool rotated = false,
+                                         bool top = true);
 
     /**
     * \brief Initialize a plane with orientation \a planeorientation
@@ -174,19 +177,28 @@ namespace mitk {
     * \a Cave/Caution: Currently only RPI, LAI, LPS and RAS in the three standard planes are covered,
     * i.e. 12 cases of 144:  3 standard planes * 48 coordinate orientations = 144 cases.
     */
-    virtual void InitializeStandardPlane(ScalarType width, ScalarType height,
-                                         const AffineTransform3D* transform = nullptr,
+    virtual void InitializeStandardPlane(ScalarType width,
+                                         ScalarType height,
+                                         const AffineTransform3D *transform = nullptr,
                                          PlaneOrientation planeorientation = Axial,
-                                         ScalarType zPosition = 0, bool frontside = true, bool rotated = false);
+                                         ScalarType zPosition = 0,
+                                         bool frontside = true,
+                                         bool rotated = false,
+                                         bool top = true);
 
     /**
     * \brief Initialize plane with orientation \a planeorientation
     * (default: axial) given width, height and spacing.
     *
     */
-    virtual void InitializeStandardPlane(ScalarType width, ScalarType height,
-      const Vector3D & spacing, PlaneOrientation planeorientation = Axial,
-      ScalarType zPosition = 0, bool frontside = true, bool rotated = false);
+    virtual void InitializeStandardPlane(ScalarType width,
+                                         ScalarType height,
+                                         const Vector3D &spacing,
+                                         PlaneOrientation planeorientation = Axial,
+                                         ScalarType zPosition = 0,
+                                         bool frontside = true,
+                                         bool rotated = false,
+                                         bool top = true);
 
     /**
     * \brief Initialize plane by width and height in pixels, right-/down-vector

--- a/Modules/Core/include/mitkSlicedGeometry3D.h
+++ b/Modules/Core/include/mitkSlicedGeometry3D.h
@@ -191,8 +191,7 @@ namespace mitk {
     * Initializes the bounding box according to the width/height of the
     * PlaneGeometry and \a slices. The spacing is calculated from the PlaneGeometry.
     */
-    virtual void InitializeEvenlySpaced(mitk::PlaneGeometry *geometry2D,
-      unsigned int slices, bool flipped = false);
+    virtual void InitializeEvenlySpaced(mitk::PlaneGeometry *geometry2D, unsigned int slices);
 
     /**
     * \brief Completely initialize this instance as evenly-spaced with slices
@@ -204,7 +203,8 @@ namespace mitk {
     * PlaneGeometry.
     */
     virtual void InitializeEvenlySpaced(mitk::PlaneGeometry *geometry2D,
-      mitk::ScalarType zSpacing, unsigned int slices, bool flipped = false);
+                                        mitk::ScalarType zSpacing,
+                                        unsigned int slices);
 
     /**
     * \brief Completely initialize this instance as evenly-spaced plane slices

--- a/Modules/Core/src/Controllers/mitkSliceNavigationController.cpp
+++ b/Modules/Core/src/Controllers/mitkSliceNavigationController.cpp
@@ -191,20 +191,28 @@ const char* SliceNavigationController::GetViewDirectionAsString() const
     return viewDirectionString;
 }
 
-void SliceNavigationController::Update()
-{
-  if ( !m_BlockUpdate )
+  void SliceNavigationController::Update()
   {
-    if ( m_ViewDirection == Axial )
+    if (!m_BlockUpdate)
     {
-      this->Update( Axial, m_Top, false, true );
-    }
-    else
-    {
-      this->Update( m_ViewDirection );
+      if (m_ViewDirection == Sagittal)
+      {
+        this->Update(Sagittal, true, true, false);
+      }
+      else if (m_ViewDirection == Frontal)
+      {
+        this->Update(Frontal, false, true, false);
+      }
+      else if (m_ViewDirection == Axial)
+      {
+        this->Update(Axial, false, false, true);
+      }
+      else
+      {
+        this->Update(m_ViewDirection);
+      }
     }
   }
-}
 
 
 void

--- a/Modules/Core/src/DataManagement/mitkDataStorage.cpp
+++ b/Modules/Core/src/DataManagement/mitkDataStorage.cpp
@@ -319,10 +319,20 @@ mitk::TimeGeometry::Pointer mitk::DataStorage::ComputeBoundingGeometry3D( const 
           // Attention: Objects with zero bounding box are not respected in time bound calculation
           for (TimeStepType i=0; i<timeGeometry->CountTimeSteps(); i++)
           {
-            Vector3D spacing = node->GetData()->GetGeometry(i)->GetSpacing();
+            // We must not use 'node->GetData()->GetGeometry(i)->GetSpacing()' here, as it returns the spacing
+            // in its original space, which, in case of an image geometry, can have the values in different
+            // order than in world space. For the further calculations, we need to have the spacing values
+            // in world coordinate order (sag-cor-ax).
+            Vector3D spacing;
+            spacing.Fill(1.0);
+            node->GetData()->GetGeometry(i)->IndexToWorld(spacing, spacing);
             for (int axis = 0; axis < 3; ++ axis)
             {
-              if (spacing[axis] < minSpacing[axis]) minSpacing[axis] = spacing[axis];
+              ScalarType space = std::abs(spacing[axis]);
+              if (space < minSpacing[axis])
+              {
+                minSpacing[axis] = space;
+              }
             }
 
             const TimeBounds & curTimeBounds = node->GetData()->GetTimeGeometry()->GetTimeBounds(i);
@@ -374,11 +384,14 @@ mitk::TimeGeometry::Pointer mitk::DataStorage::ComputeBoundingGeometry3D( const 
     // correct bounding-box (is now in mm, should be in index-coordinates)
     // according to spacing
     BoundingBox::BoundsArrayType bounds = result->GetBounds();
-    int i;
-    for(i = 0; i < 6; ++i)
+    AffineTransform3D::OutputVectorType offset;
+    for (int i = 0; i < 3; ++i)
     {
-      bounds[i] /= minSpacing[i/2];
+      offset[i] = bounds[i * 2];
+      bounds[i * 2] = 0.0;
+      bounds[i * 2 + 1] = (bounds[i * 2 + 1] - offset[i]) / minSpacing[i];
     }
+    geometry->GetIndexToWorldTransform()->SetOffset(offset);
     geometry->SetBounds(bounds);
     geometry->SetSpacing(minSpacing);
     // Initialize the time sliced geometry

--- a/Modules/Core/src/DataManagement/mitkImage.cpp
+++ b/Modules/Core/src/DataManagement/mitkImage.cpp
@@ -51,9 +51,7 @@ mitk::ReaderType::DictionaryArrayType mitk::Image::GetMetaDataDictionaryArray()
     return m_MetaDataDictionaryArray;
   }
 
-  mitk::IntProperty* prop = dynamic_cast<mitk::IntProperty*>(GetProperty("autoplan.mainAxisIndex").GetPointer());
-  int mainAxisIndex = prop ? prop->GetValue() : 2;
-  int numberSlices = GetLargestPossibleRegion().GetSize()[mainAxisIndex];
+  int numberSlices = GetLargestPossibleRegion().GetSize()[2];
   
   //mitk::ReaderType::DictionaryArrayType outputArray;
   m_MetaDataDictionaryArray.resize(numberSlices);
@@ -151,9 +149,7 @@ mitk::ReaderType::DictionaryArrayType mitk::Image::GetMetaDataDictionaryArray()
 
 void  mitk::Image::SetMetaDataDictionary(ReaderType::DictionaryArrayType metaData)
 {
-  mitk::IntProperty* prop = dynamic_cast<mitk::IntProperty*>(static_cast<mitk::BaseProperty*>(GetProperty("autoplan.mainAxisIndex")));
-  int mainAxisIndex = prop ? prop->GetValue() : 2;
-  int numberSlices = GetLargestPossibleRegion().GetSize()[mainAxisIndex];
+  int numberSlices = GetLargestPossibleRegion().GetSize()[2];
   
   // Setup slices
   mitk::SlicedGeometry3D* slicedGeometry = GetSlicedGeometry(0);

--- a/Modules/Core/src/DataManagement/mitkSlicedGeometry3D.cpp
+++ b/Modules/Core/src/DataManagement/mitkSlicedGeometry3D.cpp
@@ -14,6 +14,8 @@ See LICENSE.txt or http://www.mitk.org for details.
 
 ===================================================================*/
 
+#include <itkSpatialOrientationAdapter.h>
+
 #include "mitkSlicedGeometry3D.h"
 #include "mitkPlaneGeometry.h"
 #include "mitkRotationOperation.h"
@@ -162,20 +164,15 @@ void
   m_DirectionVector.Fill( 0 );
 }
 
-void
-  mitk::SlicedGeometry3D::InitializeEvenlySpaced(
-  mitk::PlaneGeometry* geometry2D, unsigned int slices, bool flipped )
+void mitk::SlicedGeometry3D::InitializeEvenlySpaced(mitk::PlaneGeometry *geometry2D, unsigned int slices)
 {
-  assert( geometry2D != nullptr );
-  this->InitializeEvenlySpaced(
-    geometry2D, geometry2D->GetExtentInMM(2)/geometry2D->GetExtent(2),
-    slices, flipped );
+  assert(geometry2D != nullptr);
+  this->InitializeEvenlySpaced(geometry2D, geometry2D->GetExtentInMM(2) / geometry2D->GetExtent(2), slices);
 }
 
-void
-  mitk::SlicedGeometry3D::InitializeEvenlySpaced(
-  mitk::PlaneGeometry* geometry2D, mitk::ScalarType zSpacing,
-  unsigned int slices, bool flipped )
+void mitk::SlicedGeometry3D::InitializeEvenlySpaced(mitk::PlaneGeometry *geometry2D,
+                                                    mitk::ScalarType zSpacing,
+                                                    unsigned int slices)
 {
   assert( geometry2D != nullptr );
   assert( geometry2D->GetExtent(0) > 0 );
@@ -198,35 +195,18 @@ void
   directionVector.Normalize();
   directionVector *= zSpacing;
 
-  if ( flipped == false )
-  {
-    // Normally we should use the following four lines to create a copy of
-    // the transform contrained in geometry2D, because it may not be changed
-    // by us. But we know that SetSpacing creates a new transform without
-    // changing the old (coming from geometry2D), so we can use the fifth
-    // line instead. We check this at (**).
-    //
-    // AffineTransform3D::Pointer transform = AffineTransform3D::New();
-    // transform->SetMatrix(geometry2D->GetIndexToWorldTransform()->GetMatrix());
-    // transform->SetOffset(geometry2D->GetIndexToWorldTransform()->GetOffset());
-    // SetIndexToWorldTransform(transform);
+  // Normally we should use the following four lines to create a copy of
+  // the transform contrained in geometry2D, because it may not be changed
+  // by us. But we know that SetSpacing creates a new transform without
+  // changing the old (coming from geometry2D), so we can use the fifth
+  // line instead. We check this at (**).
+  //
+  // AffineTransform3D::Pointer transform = AffineTransform3D::New();
+  // transform->SetMatrix(geometry2D->GetIndexToWorldTransform()->GetMatrix());
+  // transform->SetOffset(geometry2D->GetIndexToWorldTransform()->GetOffset());
+  // SetIndexToWorldTransform(transform);
 
-    this->SetIndexToWorldTransform( const_cast< AffineTransform3D * >(
-      geometry2D->GetIndexToWorldTransform() ));
-  }
-  else
-  {
-    directionVector *= -1.0;
-    this->SetIndexToWorldTransform( AffineTransform3D::New());
-    this->GetIndexToWorldTransform()->SetMatrix(
-      geometry2D->GetIndexToWorldTransform()->GetMatrix() );
-
-    AffineTransform3D::OutputVectorType scaleVector;
-    FillVector3D(scaleVector, 1.0, 1.0, -1.0);
-    this->GetIndexToWorldTransform()->Scale(scaleVector, true);
-    this->GetIndexToWorldTransform()->SetOffset(
-      geometry2D->GetIndexToWorldTransform()->GetOffset() );
-  }
+  this->SetIndexToWorldTransform(const_cast<AffineTransform3D *>(geometry2D->GetIndexToWorldTransform()));
 
   mitk::Vector3D spacing;
   FillVector3D( spacing,
@@ -251,11 +231,11 @@ void
   geometry2D->UnRegister();
 }
 
-void
-  mitk::SlicedGeometry3D::InitializePlanes(
-  const mitk::BaseGeometry *geometry3D,
-  mitk::PlaneGeometry::PlaneOrientation planeorientation,
-  bool top, bool frontside, bool rotated )
+void mitk::SlicedGeometry3D::InitializePlanes(const mitk::BaseGeometry *geometry3D,
+                                              mitk::PlaneGeometry::PlaneOrientation planeorientation,
+                                              bool top,
+                                              bool frontside,
+                                              bool rotated)
 {
   m_ReferenceGeometry = const_cast< BaseGeometry * >( geometry3D );
 
@@ -263,61 +243,63 @@ void
   planeGeometry->InitializeStandardPlane(
     geometry3D, top, planeorientation, frontside, rotated );
 
-  ScalarType viewSpacing = 1;
-  unsigned int slices = 1;
+  int worldAxis =
+      planeorientation == PlaneGeometry::Sagittal ? 0 :
+      planeorientation == PlaneGeometry::Frontal  ? 1 : 2;
 
-  switch ( planeorientation )
-  {
-  case PlaneGeometry::None:
-    break;
+  // Inspired by:
+  // http://www.na-mic.org/Wiki/index.php/Coordinate_System_Conversion_Between_ITK_and_Slicer3
 
-  case PlaneGeometry::Axial:
-    viewSpacing = geometry3D->GetSpacing()[2];
-    slices = (unsigned int) geometry3D->GetExtent( 2 );
-    break;
+  mitk::AffineTransform3D::MatrixType matrix = geometry3D->GetIndexToWorldTransform()->GetMatrix();
+  matrix.GetVnlMatrix().normalize_columns();
+  mitk::AffineTransform3D::MatrixType::InternalMatrixType inverseMatrix = matrix.GetInverse();
 
-  case PlaneGeometry::Frontal:
-    viewSpacing = geometry3D->GetSpacing()[1];
-    slices = (unsigned int) geometry3D->GetExtent( 1 );
-    break;
+  int dominantAxis = itk::Function::Max3(
+      inverseMatrix[0][worldAxis],
+      inverseMatrix[1][worldAxis],
+      inverseMatrix[2][worldAxis]);
 
-  case PlaneGeometry::Sagittal:
-    viewSpacing = geometry3D->GetSpacing()[0];
-    slices = (unsigned int) geometry3D->GetExtent( 0 );
-    break;
+  ScalarType viewSpacing = geometry3D->GetSpacing()[dominantAxis];
 
-  default:
-    itkExceptionMacro("unknown PlaneOrientation");
-  }
+  /// Although the double value returned by GetExtent() holds a round number,
+  /// you need to add 0.5 to safely convert it to unsigned it. I have seen a
+  /// case when the result was less by one without this.
+  unsigned int slices = static_cast<unsigned int>(geometry3D->GetExtent(dominantAxis) + 0.5);
 
-  mitk::Vector3D normal = this->AdjustNormal( planeGeometry->GetNormal() );
+#ifndef NDEBUG
+  int upDirection = itk::Function::Sign(inverseMatrix[dominantAxis][worldAxis]);
 
-  ScalarType directedExtent =
-    std::abs( m_ReferenceGeometry->GetExtentInMM( 0 ) * normal[0] )
-    + std::abs( m_ReferenceGeometry->GetExtentInMM( 1 ) * normal[1] )
-    + std::abs( m_ReferenceGeometry->GetExtentInMM( 2 ) * normal[2] );
+  /// The normal vector of an imaginary plane that points from the world origin (bottom left back
+  /// corner or the world, with the lowest physical coordinates) towards the inside of the volume,
+  /// along the renderer axis. Length is the slice thickness.
+  Vector3D worldPlaneNormal = inverseMatrix.get_row(dominantAxis) * (upDirection * viewSpacing);
 
-  if ( directedExtent >= viewSpacing )
-  {
-    slices = static_cast< int >(directedExtent / viewSpacing + 0.5);
-  }
-  else
-  {
-    slices = 1;
-  }
+  /// The normal of the standard plane geometry just created.
+  Vector3D standardPlaneNormal = planeGeometry->GetNormal();
 
-  bool flipped = (top == false);
+  /// The standard plane must be parallel to the 'world plane'. The normal of the standard plane
+  /// must point against the world plane if and only if 'top' is 'false'. The length of the
+  /// standard plane normal must be equal to the slice thickness.
+  assert((standardPlaneNormal - (top ? 1.0 : -1.0) * worldPlaneNormal).GetSquaredNorm() < 0.000001);
+#endif
 
-  if ( frontside == false )
-  {
-    flipped = !flipped;
-  }
-  if ( planeorientation == PlaneGeometry::Frontal )
-  {
-    flipped = !flipped;
-  }
+  this->InitializeEvenlySpaced(planeGeometry, viewSpacing, slices);
 
-  this->InitializeEvenlySpaced( planeGeometry, viewSpacing, slices, flipped );
+#ifndef NDEBUG
+  /// The standard plane normal and the z axis vector of the sliced geometry must point in
+  /// the same direction.
+  Vector3D zAxisVector = this->GetAxisVector(2);
+  Vector3D upscaledStandardPlaneNormal = standardPlaneNormal;
+  upscaledStandardPlaneNormal *= slices;
+  assert((zAxisVector - upscaledStandardPlaneNormal).GetSquaredNorm() < 0.000001);
+
+  /// You can use this test is to check the handedness of the coordinate system of the current
+  /// geometry. In principle, you can use either left- or right-handed coordinate systems, but
+  /// you normally want it to be consistent, that is the handedness should be the same across
+  /// the renderers of the same viewer.
+//  ScalarType det = vnl_det(this->GetIndexToWorldTransform()->GetMatrix().GetVnlMatrix());
+//  MITK_DEBUG << "world axis: " << worldAxis << (det > 0 ? " ; right-handed" : " ; left-handed");
+#endif
 }
 
 void

--- a/Modules/Core/test/mitkSliceNavigationControllerTest.cpp
+++ b/Modules/Core/test/mitkSliceNavigationControllerTest.cpp
@@ -14,559 +14,158 @@ See LICENSE.txt or http://www.mitk.org for details.
 
 ===================================================================*/
 
-#include "mitkSliceNavigationController.h"
-#include "mitkPlaneGeometry.h"
-#include "mitkSlicedGeometry3D.h"
-#include "mitkRotationOperation.h"
-#include "mitkInteractionConst.h"
-#include "mitkPlanePositionManager.h"
-#include "mitkTestingMacros.h"
+#include <mitkGeometry3D.h>
+#include <mitkPlaneGeometry.h>
+#include <mitkSlicedGeometry3D.h>
+#include <mitkSliceNavigationController.h>
 
-#include "usGetModuleContext.h"
-#include "usModuleContext.h"
-#include "usServiceReference.h"
+#include <mitkTestFixture.h>
+#include <mitkTestingMacros.h>
 
-#include <vnl/vnl_quaternion.h>
-#include <vnl/vnl_quaternion.txx>
+// T22254
 
-#include <fstream>
-
-bool operator==(const mitk::Geometry3D & left, const mitk::Geometry3D & right)
+class mitkSliceNavigationControllerTestSuite : public mitk::TestFixture
 {
-   mitk::BoundingBox::BoundsArrayType leftbounds, rightbounds;
-   leftbounds =left.GetBounds();
-   rightbounds=right.GetBounds();
-
-   unsigned int i;
-   for(i=0;i<6;++i)
-      if(mitk::Equal(leftbounds[i],rightbounds[i])==false) return false;
-
-   const mitk::Geometry3D::TransformType::MatrixType & leftmatrix  = left.GetIndexToWorldTransform()->GetMatrix();
-   const mitk::Geometry3D::TransformType::MatrixType & rightmatrix = right.GetIndexToWorldTransform()->GetMatrix();
-
-   unsigned int j;
-   for(i=0;i<3;++i)
-   {
-      const mitk::Geometry3D::TransformType::MatrixType::ValueType* leftvector  = leftmatrix[i];
-      const mitk::Geometry3D::TransformType::MatrixType::ValueType* rightvector = rightmatrix[i];
-      for(j=0;j<3;++j)
-         if(mitk::Equal(leftvector[i],rightvector[i])==false) return false;
-   }
-
-   const mitk::Geometry3D::TransformType::OffsetType & leftoffset  = left.GetIndexToWorldTransform()->GetOffset();
-   const mitk::Geometry3D::TransformType::OffsetType & rightoffset = right.GetIndexToWorldTransform()->GetOffset();
-   for(i=0;i<3;++i)
-      if(mitk::Equal(leftoffset[i],rightoffset[i])==false) return false;
-
-   return true;
-}
-
-int compareGeometry(const mitk::TimeGeometry & timeGeometry,
-                    const mitk::ScalarType& width, const mitk::ScalarType& height, const mitk::ScalarType& numSlices,
-                    const mitk::ScalarType& widthInMM, const mitk::ScalarType& heightInMM, const mitk::ScalarType& thicknessInMM,
-                    const mitk::Point3D& cornerpoint0, const mitk::Vector3D& right, const mitk::Vector3D& bottom, const mitk::Vector3D& normal)
-{
-   //Probleme durch umstellung von Time-SlicedGeometry auf  TimeGeometry?
-   //Eventuell gibt es keine Entsprechung mehr.
-   const mitk::BaseGeometry::Pointer geometry= timeGeometry.GetGeometryForTimeStep(0);
-   std::cout << "Testing width, height and thickness (in units): ";
-   if((mitk::Equal(geometry->GetExtent(0),width)==false) ||
-      (mitk::Equal(geometry->GetExtent(1),height)==false) ||
-      (mitk::Equal(geometry->GetExtent(2),numSlices)==false)
-      )
-   {
-      std::cout<<"[FAILED]"<<std::endl;
-      return EXIT_FAILURE;
-   }
-   std::cout<<"[PASSED]"<<std::endl;
-
-   std::cout << "Testing width, height and thickness (in mm): ";
-   if((mitk::Equal(geometry->GetExtentInMM(0),widthInMM)==false) ||
-      (mitk::Equal(geometry->GetExtentInMM(1),heightInMM)==false) ||
-      (mitk::Equal(geometry->GetExtentInMM(2),thicknessInMM)==false)
-      )
-   {
-      std::cout<<"[FAILED]"<<std::endl;
-      return EXIT_FAILURE;
-   }
-   std::cout<<"[PASSED]"<<std::endl;
-
-   std::cout << "Testing GetAxisVector(): ";
-   std::cout << "dir=0 ";
-   mitk::Vector3D dv;
-   dv=right; dv.Normalize(); dv*=widthInMM;
-   if((mitk::Equal(geometry->GetAxisVector(0), dv)==false))
-   {
-      std::cout<<"[FAILED]"<<std::endl;
-      return EXIT_FAILURE;
-   }
-   std::cout<<"[PASSED]";
-   std::cout << ", dir=1 ";
-   dv=bottom; dv.Normalize(); dv*=heightInMM;
-   if((mitk::Equal(geometry->GetAxisVector(1), dv)==false))
-   {
-      std::cout<<"[FAILED]"<<std::endl;
-      return EXIT_FAILURE;
-   }
-   std::cout<<"[PASSED]";
-   std::cout << ", dir=2 ";
-   dv=normal; dv.Normalize(); dv*=thicknessInMM;
-   if((mitk::Equal(geometry->GetAxisVector(2), dv)==false))
-   {
-      std::cout<<"[FAILED]"<<std::endl;
-      return EXIT_FAILURE;
-   }
-   std::cout<<"[PASSED]"<<std::endl;
-
-   std::cout << "Testing offset: ";
-   if((mitk::Equal(geometry->GetCornerPoint(0),cornerpoint0, (double) vnl_math::float_eps)==false))
-   {
-      std::cout<<"[FAILED]"<<std::endl;
-      return EXIT_FAILURE;
-   }
-   std::cout<<"[PASSED]"<<std::endl;
-   return EXIT_SUCCESS;
-}
-
-int testGeometry(const mitk::Geometry3D * geometry,
-                 const mitk::ScalarType& width, const mitk::ScalarType& height, const mitk::ScalarType& numSlices,
-                 const mitk::ScalarType& widthInMM, const mitk::ScalarType& heightInMM, const mitk::ScalarType& thicknessInMM,
-                 const mitk::Point3D& cornerpoint0, const mitk::Vector3D& right, const mitk::Vector3D& bottom, const mitk::Vector3D& normal)
-{
-   int result=EXIT_FAILURE;
-
-   std::cout << "Comparing GetCornerPoint(0) of Geometry3D with provided cornerpoint0: ";
-   if(mitk::Equal(geometry->GetCornerPoint(0), cornerpoint0)==false)
-   {
-      std::cout<<"[FAILED]"<<std::endl;
-      return EXIT_FAILURE;
-   }
-   std::cout<<"[PASSED]"<<std::endl;
-
-   std::cout << "Creating and initializing a SliceNavigationController with the Geometry3D: ";
-   mitk::SliceNavigationController::Pointer sliceCtrl = mitk::SliceNavigationController::New();
-   sliceCtrl->SetInputWorldGeometry3D(geometry);
-   std::cout<<"[PASSED]"<<std::endl;
-
-   std::cout << "Testing SetViewDirection(mitk::SliceNavigationController::Axial): ";
-   sliceCtrl->SetViewDirection(mitk::SliceNavigationController::Axial);
-   std::cout<<"[PASSED]"<<std::endl;
-
-   std::cout << "Testing Update(): ";
-   sliceCtrl->Update();
-   std::cout<<"[PASSED]"<<std::endl;
-
-   std::cout << "Testing result of CreatedWorldGeometry(): ";
-   mitk::Point3D axialcornerpoint0;
-   axialcornerpoint0 = cornerpoint0+bottom+normal*(numSlices-1+0.5); //really -1?
-   result = compareGeometry(*sliceCtrl->GetCreatedWorldGeometry(), width, height, numSlices, widthInMM, heightInMM, thicknessInMM*numSlices, axialcornerpoint0, right, bottom*(-1.0), normal*(-1.0));
-   if(result!=EXIT_SUCCESS)
-   {
-      std::cout<<"[FAILED]"<<std::endl;
-      return result;
-   }
-   std::cout<<"[PASSED]"<<std::endl;
-
-   std::cout << "Testing SetViewDirection(mitk::SliceNavigationController::Frontal): ";
-   sliceCtrl->SetViewDirection(mitk::SliceNavigationController::Frontal);
-   std::cout<<"[PASSED]"<<std::endl;
-
-   std::cout << "Testing Update(): ";
-   sliceCtrl->Update();
-   std::cout<<"[PASSED]"<<std::endl;
-
-   std::cout << "Testing result of CreatedWorldGeometry(): ";
-   mitk::Point3D frontalcornerpoint0;
-   frontalcornerpoint0 = cornerpoint0+geometry->GetAxisVector(1)*(+0.5/geometry->GetExtent(1));
-   result = compareGeometry(*sliceCtrl->GetCreatedWorldGeometry(), width, numSlices, height, widthInMM, thicknessInMM*numSlices, heightInMM, frontalcornerpoint0, right, normal, bottom);
-   if(result!=EXIT_SUCCESS)
-   {
-      std::cout<<"[FAILED]"<<std::endl;
-      return result;
-   }
-   std::cout<<"[PASSED]"<<std::endl;
-
-   std::cout << "Testing SetViewDirection(mitk::SliceNavigationController::Sagittal): ";
-   sliceCtrl->SetViewDirection(mitk::SliceNavigationController::Sagittal);
-   std::cout<<"[PASSED]"<<std::endl;
-
-   std::cout << "Testing Update(): "<<std::endl;
-   sliceCtrl->Update();
-   std::cout<<"[PASSED]"<<std::endl;
-
-   std::cout << "Testing result of CreatedWorldGeometry(): ";
-   mitk::Point3D sagittalcornerpoint0;
-   sagittalcornerpoint0 = cornerpoint0+geometry->GetAxisVector(0)*(+0.5/geometry->GetExtent(0));
-   result = compareGeometry(*sliceCtrl->GetCreatedWorldGeometry(), height, numSlices, width, heightInMM, thicknessInMM*numSlices, widthInMM, sagittalcornerpoint0, bottom, normal, right);
-   if(result!=EXIT_SUCCESS)
-   {
-      std::cout<<"[FAILED]"<<std::endl;
-      return result;
-   }
-   std::cout<<"[PASSED]"<<std::endl;
-
-   return EXIT_SUCCESS;
-}
-
-int testReorientPlanes ()
-{
-   //Create PlaneGeometry
-   mitk::PlaneGeometry::Pointer planegeometry = mitk::PlaneGeometry::New();
-
-   mitk::Point3D origin;
-   mitk::Vector3D right, bottom, normal;
-   mitk::ScalarType width, height;
-   mitk::ScalarType widthInMM, heightInMM, thicknessInMM;
-
-   width  = 100;    widthInMM  = width;
-   height = 200;    heightInMM = height;
-   thicknessInMM = 1.5;
-
-   mitk::FillVector3D(origin, 4.5,              7.3, 11.2);
-   mitk::FillVector3D(right,  widthInMM,          0, 0);
-   mitk::FillVector3D(bottom,         0, heightInMM, 0);
-   mitk::FillVector3D(normal,         0,          0, thicknessInMM);
-
-   mitk::Vector3D spacing;
-   normal.Normalize(); normal *= thicknessInMM;
-   mitk::FillVector3D(spacing, 1.0, 1.0, thicknessInMM);
-   planegeometry->InitializeStandardPlane(right.GetVnlVector(), bottom.GetVnlVector(), &spacing);
-   planegeometry->SetOrigin(origin);
-
-   //Create SlicedGeometry3D out of planeGeometry
-   mitk::SlicedGeometry3D::Pointer slicedgeometry1 = mitk::SlicedGeometry3D::New();
-   unsigned int numSlices = 20;
-   slicedgeometry1->InitializeEvenlySpaced(planegeometry, thicknessInMM, numSlices, false);
-
-   //Create another slicedgeo which will be rotated
-   mitk::SlicedGeometry3D::Pointer slicedgeometry2 = mitk::SlicedGeometry3D::New();
-   slicedgeometry2->InitializeEvenlySpaced(planegeometry, thicknessInMM, numSlices, false);
-
-   //Create  geo3D as reference
-   mitk::Geometry3D::Pointer geometry = mitk::Geometry3D::New();
-   geometry->SetBounds(slicedgeometry1->GetBounds());
-   geometry->SetIndexToWorldTransform(slicedgeometry1->GetIndexToWorldTransform());
-
-   //Initialize planes
-   for (int i=0; i < (int)numSlices; i++)
-   {
-      mitk::PlaneGeometry::Pointer geo2d = mitk::PlaneGeometry::New();
-      geo2d->Initialize();
-      geo2d->SetReferenceGeometry(geometry);
-      slicedgeometry1->SetPlaneGeometry(geo2d,i);
-   }
-
-   for (int i=0; i < (int)numSlices; i++)
-   {
-      mitk::PlaneGeometry::Pointer geo2d = mitk::PlaneGeometry::New();
-      geo2d->Initialize();
-      geo2d->SetReferenceGeometry(geometry);
-      slicedgeometry2->SetPlaneGeometry(geo2d,i);
-   }
-
-   slicedgeometry1->SetReferenceGeometry(geometry);
-   slicedgeometry2->SetReferenceGeometry(geometry);
-
-   //Create SNC
-   mitk::SliceNavigationController::Pointer sliceCtrl1 = mitk::SliceNavigationController::New();
-   sliceCtrl1->SetInputWorldGeometry3D(slicedgeometry1);
-   sliceCtrl1->Update();
-
-   mitk::SliceNavigationController::Pointer sliceCtrl2 = mitk::SliceNavigationController::New();
-   sliceCtrl2->SetInputWorldGeometry3D(slicedgeometry2);
-   sliceCtrl2->Update();
-
-   slicedgeometry1->SetSliceNavigationController(sliceCtrl1);
-   slicedgeometry2->SetSliceNavigationController(sliceCtrl2);
-
-   // Whats current geometry?
-   MITK_INFO << "center: " << sliceCtrl1->GetCurrentPlaneGeometry()->GetCenter();
-   MITK_INFO << "normal: " << sliceCtrl1->GetCurrentPlaneGeometry()->GetNormal();
-   MITK_INFO << "origin: " << sliceCtrl1->GetCurrentPlaneGeometry()->GetOrigin();
-   MITK_INFO << "axis0 : " << sliceCtrl1->GetCurrentPlaneGeometry()->GetAxisVector(0);
-   MITK_INFO << "aixs1 : " << sliceCtrl1->GetCurrentPlaneGeometry()->GetAxisVector(1);
-
-   //
-   // Now reorient slices (ONE POINT, ONE NORMAL)
-   mitk::Point3D oldCenter, oldOrigin;
-   mitk::Vector3D oldAxis0, oldAxis1;
-   oldCenter = sliceCtrl1->GetCurrentPlaneGeometry()->GetCenter();
-   oldOrigin = sliceCtrl1->GetCurrentPlaneGeometry()->GetOrigin();
-   oldAxis0 = sliceCtrl1->GetCurrentPlaneGeometry()->GetAxisVector(0);
-   oldAxis1 = sliceCtrl1->GetCurrentPlaneGeometry()->GetAxisVector(1);
-
-   mitk::Point3D orientCenter;
-   mitk::Vector3D orientNormal;
-   orientCenter = oldCenter;
-   mitk::FillVector3D(orientNormal, 0.3, 0.1, 0.8);
-   orientNormal.Normalize();
-   sliceCtrl1->ReorientSlices(orientCenter,orientNormal);
-
-   mitk::Point3D newCenter, newOrigin;
-   mitk::Vector3D newNormal;
-   newCenter = sliceCtrl1->GetCurrentPlaneGeometry()->GetCenter();
-   newOrigin = sliceCtrl1->GetCurrentPlaneGeometry()->GetOrigin();
-   newNormal = sliceCtrl1->GetCurrentPlaneGeometry()->GetNormal();
-   newNormal.Normalize();
-
-   itk::Index<3> orientCenterIdx;
-   itk::Index<3> newCenterIdx;
-   sliceCtrl1->GetCurrentGeometry3D()->WorldToIndex(orientCenter, orientCenterIdx);
-   sliceCtrl1->GetCurrentGeometry3D()->WorldToIndex(newCenter, newCenterIdx);
-
-   if (
-      (newCenterIdx != orientCenterIdx)  ||
-      ( !mitk::Equal(orientNormal, newNormal) )
-      )
-   {
-      MITK_INFO << "Reorient Planes (1 point, 1 vector) not working as it should";
-      MITK_INFO << "orientCenterIdx: " << orientCenterIdx;
-      MITK_INFO << "newCenterIdx: " << newCenterIdx;
-      MITK_INFO << "orientNormal: " << orientNormal;
-      MITK_INFO << "newNormal: " << newNormal;
-      return EXIT_FAILURE;
-   }
-
-   //
-   // Now reorient slices (center, vec0, vec1 )
-   mitk::Vector3D orientAxis0, orientAxis1, newAxis0, newAxis1;
-   mitk::FillVector3D(orientAxis0, 1.0, 0.0, 0.0);
-   mitk::FillVector3D(orientAxis1, 0.0, 1.0, 0.0);
-
-   orientAxis0.Normalize();
-   orientAxis1.Normalize();
-
-   sliceCtrl1->ReorientSlices(orientCenter,orientAxis0, orientAxis1);
-
-   newAxis0 = sliceCtrl1->GetCurrentPlaneGeometry()->GetAxisVector(0);
-   newAxis1 = sliceCtrl1->GetCurrentPlaneGeometry()->GetAxisVector(1);
-   newCenter = sliceCtrl1->GetCurrentPlaneGeometry()->GetCenter();
-
-   newAxis0.Normalize();
-   newAxis1.Normalize();
-
-   sliceCtrl1->GetCurrentGeometry3D()->WorldToIndex(orientCenter, orientCenterIdx);
-   sliceCtrl1->GetCurrentGeometry3D()->WorldToIndex(newCenter, newCenterIdx);
-
-   if (
-      (newCenterIdx != orientCenterIdx) ||
-      ( !mitk::Equal(orientAxis0, newAxis0, 1E-12) )  ||
-      ( !mitk::Equal(orientAxis1, newAxis1, 1E-12 ))
-      )
-   {
-      MITK_INFO << "Reorient Planes (point, vec, vec) not working as it should";
-      MITK_INFO << "orientCenterIdx: " << orientCenterIdx;
-      MITK_INFO << "newCenterIdx: " << newCenterIdx;
-      MITK_INFO << "orientAxis0: " << orientAxis0;
-      MITK_INFO << "newAxis0: " << newAxis0;
-      MITK_INFO << "orientAxis1: " << orientAxis1;
-      MITK_INFO << "newAxis1: " << newAxis1;
-      return EXIT_FAILURE;
-   }
-
-   return EXIT_SUCCESS;
-}
-
-int testRestorePlanePostionOperation ()
-{
-   //Create PlaneGeometry
-   mitk::PlaneGeometry::Pointer planegeometry = mitk::PlaneGeometry::New();
-
-   mitk::Point3D origin;
-   mitk::Vector3D right, bottom, normal;
-   mitk::ScalarType width, height;
-   mitk::ScalarType widthInMM, heightInMM, thicknessInMM;
-
-   width  = 100;    widthInMM  = width;
-   height = 200;    heightInMM = height;
-   thicknessInMM = 1.5;
-
-   mitk::FillVector3D(origin, 4.5,              7.3, 11.2);
-   mitk::FillVector3D(right,  widthInMM,          0, 0);
-   mitk::FillVector3D(bottom,         0, heightInMM, 0);
-   mitk::FillVector3D(normal,         0,          0, thicknessInMM);
-
-   mitk::Vector3D spacing;
-   normal.Normalize(); normal *= thicknessInMM;
-   mitk::FillVector3D(spacing, 1.0, 1.0, thicknessInMM);
-   planegeometry->InitializeStandardPlane(right.GetVnlVector(), bottom.GetVnlVector(), &spacing);
-   planegeometry->SetOrigin(origin);
-
-   //Create SlicedGeometry3D out of planeGeometry
-   mitk::SlicedGeometry3D::Pointer slicedgeometry1 = mitk::SlicedGeometry3D::New();
-   unsigned int numSlices = 300;
-   slicedgeometry1->InitializeEvenlySpaced(planegeometry, thicknessInMM, numSlices, false);
-
-   //Create another slicedgeo which will be rotated
-   mitk::SlicedGeometry3D::Pointer slicedgeometry2 = mitk::SlicedGeometry3D::New();
-   slicedgeometry2->InitializeEvenlySpaced(planegeometry, thicknessInMM, numSlices, false);
-
-   //Create  geo3D as reference
-   mitk::Geometry3D::Pointer geometry = mitk::Geometry3D::New();
-   geometry->SetBounds(slicedgeometry1->GetBounds());
-   geometry->SetIndexToWorldTransform(slicedgeometry1->GetIndexToWorldTransform());
-
-   //Initialize planes
-   for (int i=0; i < (int)numSlices; i++)
-   {
-      mitk::PlaneGeometry::Pointer geo2d = mitk::PlaneGeometry::New();
-      geo2d->Initialize();
-      geo2d->SetReferenceGeometry(geometry);
-      slicedgeometry1->SetPlaneGeometry(geo2d,i);
-   }
-
-   for (int i=0; i < (int)numSlices; i++)
-   {
-      mitk::PlaneGeometry::Pointer geo2d = mitk::PlaneGeometry::New();
-      geo2d->Initialize();
-      geo2d->SetReferenceGeometry(geometry);
-      slicedgeometry2->SetPlaneGeometry(geo2d,i);
-   }
-
-   slicedgeometry1->SetReferenceGeometry(geometry);
-   slicedgeometry2->SetReferenceGeometry(geometry);
-
-   //Create SNC
-   mitk::SliceNavigationController::Pointer sliceCtrl1 = mitk::SliceNavigationController::New();
-   sliceCtrl1->SetInputWorldGeometry3D(slicedgeometry1);
-   sliceCtrl1->Update();
-
-   mitk::SliceNavigationController::Pointer sliceCtrl2 = mitk::SliceNavigationController::New();
-   sliceCtrl2->SetInputWorldGeometry3D(slicedgeometry2);
-   sliceCtrl2->Update();
-
-   slicedgeometry1->SetSliceNavigationController(sliceCtrl1);
-   slicedgeometry2->SetSliceNavigationController(sliceCtrl2);
-
-   //Rotate slicedgeo2
-   double angle = 63.84;
-   mitk::Vector3D rotationVector; mitk::FillVector3D( rotationVector, 0.5, 0.95, 0.23 );
-   mitk::Point3D center = slicedgeometry2->GetCenter();
-   mitk::RotationOperation* op = new mitk::RotationOperation( mitk::OpROTATE, center, rotationVector, angle );
-   slicedgeometry2->ExecuteOperation(op);
-   sliceCtrl2->Update();
-
-   us::ServiceReference<mitk::PlanePositionManagerService> serviceRef =
-      us::GetModuleContext()->GetServiceReference<mitk::PlanePositionManagerService>();
-   mitk::PlanePositionManagerService* service = us::GetModuleContext()->GetService(serviceRef);
-   service->AddNewPlanePosition(slicedgeometry2->GetPlaneGeometry(0), 178);
-   sliceCtrl1->ExecuteOperation(service->GetPlanePosition(0));
-   sliceCtrl1->Update();
-   mitk::PlaneGeometry* planeRotated = slicedgeometry2->GetPlaneGeometry(178);
-   mitk::PlaneGeometry* planeRestored = dynamic_cast< const mitk::SlicedGeometry3D*>(sliceCtrl1->GetCurrentGeometry3D())->GetPlaneGeometry(178);
-
-   try{
-      MITK_TEST_CONDITION_REQUIRED(mitk::MatrixEqualElementWise(planeRotated->GetIndexToWorldTransform()->GetMatrix(), planeRestored->GetIndexToWorldTransform()->GetMatrix()),"Testing for IndexToWorld");
-      MITK_TEST_CONDITION_REQUIRED(mitk::Equal(planeRotated->GetOrigin(), planeRestored->GetOrigin(),2*mitk::eps),"Testing for origin");
-      MITK_TEST_CONDITION_REQUIRED(mitk::Equal(planeRotated->GetSpacing(), planeRestored->GetSpacing()),"Testing for spacing");
-      MITK_TEST_CONDITION_REQUIRED(mitk::Equal(slicedgeometry2->GetDirectionVector(), dynamic_cast< const mitk::SlicedGeometry3D*>(sliceCtrl1->GetCurrentGeometry3D())->GetDirectionVector()),"Testing for directionvector");
-      MITK_TEST_CONDITION_REQUIRED(mitk::Equal(slicedgeometry2->GetSlices(), dynamic_cast< const mitk::SlicedGeometry3D*>(sliceCtrl1->GetCurrentGeometry3D())->GetSlices()),"Testing for numslices");
-      MITK_TEST_CONDITION_REQUIRED(mitk::MatrixEqualElementWise(slicedgeometry2->GetIndexToWorldTransform()->GetMatrix(), dynamic_cast< const mitk::SlicedGeometry3D*>(sliceCtrl1->GetCurrentGeometry3D())->GetIndexToWorldTransform()->GetMatrix()),"Testing for IndexToWorld");
-   }
-   catch(...)
-   {
-      return EXIT_FAILURE;
-   }
-
-   return EXIT_SUCCESS;
-}
-
-int mitkSliceNavigationControllerTest(int /*argc*/, char* /*argv*/[])
-{
-   int result=EXIT_FAILURE;
-
-   std::cout << "Creating and initializing a PlaneGeometry: ";
-   mitk::PlaneGeometry::Pointer planegeometry = mitk::PlaneGeometry::New();
-
-   mitk::Point3D origin;
-   mitk::Vector3D right, bottom, normal;
-   mitk::ScalarType width, height;
-   mitk::ScalarType widthInMM, heightInMM, thicknessInMM;
-
-   width  = 100;    widthInMM  = width;
-   height = 200;    heightInMM = height;
-   thicknessInMM = 1.5;
-   //  mitk::FillVector3D(origin,         0,          0, thicknessInMM*0.5);
-   mitk::FillVector3D(origin, 4.5,              7.3, 11.2);
-   mitk::FillVector3D(right,  widthInMM,          0, 0);
-   mitk::FillVector3D(bottom,         0, heightInMM, 0);
-   mitk::FillVector3D(normal,         0,          0, thicknessInMM);
-
-   mitk::Vector3D spacing;
-   normal.Normalize(); normal *= thicknessInMM;
-   mitk::FillVector3D(spacing, 1.0, 1.0, thicknessInMM);
-   planegeometry->InitializeStandardPlane(right.GetVnlVector(), bottom.GetVnlVector(), &spacing);
-   planegeometry->SetOrigin(origin);
-   std::cout<<"[PASSED]"<<std::endl;
-
-   std::cout << "Creating and initializing a SlicedGeometry3D with the PlaneGeometry: ";
-   mitk::SlicedGeometry3D::Pointer slicedgeometry = mitk::SlicedGeometry3D::New();
-   unsigned int numSlices = 5;
-   slicedgeometry->InitializeEvenlySpaced(planegeometry, thicknessInMM, numSlices, false);
-   std::cout<<"[PASSED]"<<std::endl;
-
-   std::cout << "Creating a Geometry3D with the same extent as the SlicedGeometry3D: ";
-   mitk::Geometry3D::Pointer geometry = mitk::Geometry3D::New();
-   geometry->SetBounds(slicedgeometry->GetBounds());
-   geometry->SetIndexToWorldTransform(slicedgeometry->GetIndexToWorldTransform());
-   std::cout<<"[PASSED]"<<std::endl;
-
-   mitk::Point3D cornerpoint0;
-   cornerpoint0 = geometry->GetCornerPoint(0);
-
-   result=testGeometry(geometry, width, height, numSlices, widthInMM, heightInMM, thicknessInMM, cornerpoint0, right, bottom, normal);
-   if(result!=EXIT_SUCCESS)
-      return result;
-
-   mitk::AffineTransform3D::Pointer transform = mitk::AffineTransform3D::New();
-   transform->SetMatrix(geometry->GetIndexToWorldTransform()->GetMatrix());
-   mitk::BoundingBox::Pointer boundingbox = geometry->CalculateBoundingBoxRelativeToTransform(transform);
-   geometry->SetBounds(boundingbox->GetBounds());
-   cornerpoint0 = geometry->GetCornerPoint(0);
-
-   result=testGeometry(geometry, width, height, numSlices, widthInMM, heightInMM, thicknessInMM, cornerpoint0, right, bottom, normal);
-   if(result!=EXIT_SUCCESS)
-      return result;
-
-   std::cout << "Changing the IndexToWorldTransform of the geometry to a rotated version by SetIndexToWorldTransform() (keep cornerpoint0): ";
-   transform = mitk::AffineTransform3D::New();
-   mitk::AffineTransform3D::MatrixType::InternalMatrixType vnlmatrix;
-   vnlmatrix = planegeometry->GetIndexToWorldTransform()->GetMatrix().GetVnlMatrix();
-   mitk::VnlVector axis(3);
-   mitk::FillVector3D(axis, 1.0, 1.0, 1.0); axis.normalize();
-   vnl_quaternion<mitk::ScalarType> rotation(axis, 0.223);
-   vnlmatrix = rotation.rotation_matrix_transpose()*vnlmatrix;
-   mitk::Matrix3D matrix;
-   matrix = vnlmatrix;
-   transform->SetMatrix(matrix);
-   transform->SetOffset(cornerpoint0.GetVectorFromOrigin());
-
-   right.SetVnlVector( rotation.rotation_matrix_transpose()*right.GetVnlVector() );
-   bottom.SetVnlVector(rotation.rotation_matrix_transpose()*bottom.GetVnlVector());
-   normal.SetVnlVector(rotation.rotation_matrix_transpose()*normal.GetVnlVector());
-   geometry->SetIndexToWorldTransform(transform);
-   std::cout<<"[PASSED]"<<std::endl;
-
-   cornerpoint0 = geometry->GetCornerPoint(0);
-
-   result = testGeometry(geometry, width, height, numSlices, widthInMM, heightInMM, thicknessInMM, cornerpoint0, right, bottom, normal);
-   if(result!=EXIT_SUCCESS)
-      return result;
-
-   //Testing Execute RestorePlanePositionOperation
-   result = testRestorePlanePostionOperation();
-   if(result!=EXIT_SUCCESS)
-      return result;
-
-   // Re-Orient planes not working as it should on windows
-   // However, this might be adjusted during a geometry redesign.
-   /*
-   //Testing  ReorientPlanes
-   result = testReorientPlanes();
-   if(result!=EXIT_SUCCESS)
-   return result;
-   */
-
-   std::cout<<"[TEST DONE]"<<std::endl;
-   return EXIT_SUCCESS;
-}
+  CPPUNIT_TEST_SUITE(mitkSliceNavigationControllerTestSuite);
+  CPPUNIT_TEST(validateAxialViewDirection);
+  CPPUNIT_TEST(validateCoronalViewDirection);
+  CPPUNIT_TEST(validateSagittalViewDirection);
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+  void setUp() override
+  {
+    mitk::Point3D origin;
+    mitk::FillVector3D(origin, 10.0, 20.0, 30.0);
+
+    mitk::Vector3D firstAxisVector;
+    mitk::FillVector3D(firstAxisVector, 100.0, 0.0, 0.0);
+
+    mitk::Vector3D secondAxisVector;
+    mitk::FillVector3D(secondAxisVector, 0.0, 50.0, 0.0);
+
+    mitk::Vector3D spacing;
+    mitk::FillVector3D(spacing, 1.0, 1.0, 2.0);
+
+    auto planeGeometry = mitk::PlaneGeometry::New();
+    planeGeometry->InitializeStandardPlane(firstAxisVector, secondAxisVector, &spacing);
+    planeGeometry->SetOrigin(origin);
+
+    unsigned int numberOfSlices = 100U;
+
+    auto slicedGeometry3D = mitk::SlicedGeometry3D::New();
+    slicedGeometry3D->InitializeEvenlySpaced(planeGeometry, numberOfSlices);
+
+    m_Geometry3D = mitk::Geometry3D::New();
+    m_Geometry3D->SetBounds(slicedGeometry3D->GetBounds());
+    m_Geometry3D->SetIndexToWorldTransform(slicedGeometry3D->GetIndexToWorldTransform());
+  }
+
+  void tearDown() override
+  {
+  }
+
+  void validateAxialViewDirection()
+  {
+    auto sliceNavigationController = mitk::SliceNavigationController::New();
+
+    sliceNavigationController->SetInputWorldGeometry3D(m_Geometry3D);
+    sliceNavigationController->SetViewDirection(mitk::SliceNavigationController::Axial);
+    sliceNavigationController->Update();
+
+    mitk::Point3D origin;
+    mitk::FillVector3D(origin, 10.0, 70.0, 229.0);
+
+    mitk::Vector3D firstAxisVector;
+    mitk::FillVector3D(firstAxisVector, 100.0, 0.0, 0.0);
+
+    mitk::Vector3D secondAxisVector;
+    mitk::FillVector3D(secondAxisVector, 0.0, -50.0, 0.0);
+
+    mitk::Vector3D thirdAxisVector;
+    mitk::FillVector3D(thirdAxisVector, 0.0, 0.0, -200.0);
+
+    std::cout << "Axial view direction" << std::endl;
+    CPPUNIT_ASSERT(this->validateGeometry(sliceNavigationController->GetCurrentGeometry3D(), origin, firstAxisVector, secondAxisVector, thirdAxisVector));
+  }
+
+  void validateCoronalViewDirection()
+  {
+    auto sliceNavigationController = mitk::SliceNavigationController::New();
+
+    sliceNavigationController->SetInputWorldGeometry3D(m_Geometry3D);
+    sliceNavigationController->SetViewDirection(mitk::SliceNavigationController::Frontal);
+    sliceNavigationController->Update();
+
+    mitk::Point3D origin;
+    mitk::FillVector3D(origin, 10.0, 69.5, 30.0);
+
+    mitk::Vector3D firstAxisVector;
+    mitk::FillVector3D(firstAxisVector, 100.0, 0.0, 0.0);
+
+    mitk::Vector3D secondAxisVector;
+    mitk::FillVector3D(secondAxisVector, 0.0, 0.0, 200.0);
+
+    mitk::Vector3D thirdAxisVector;
+    mitk::FillVector3D(thirdAxisVector, 0.0, -50.0, 0.0);
+
+    std::cout << "Coronal view direction" << std::endl;
+    CPPUNIT_ASSERT(this->validateGeometry(sliceNavigationController->GetCurrentGeometry3D(), origin, firstAxisVector, secondAxisVector, thirdAxisVector));
+  }
+
+  void validateSagittalViewDirection()
+  {
+    auto sliceNavigationController = mitk::SliceNavigationController::New();
+
+    sliceNavigationController->SetInputWorldGeometry3D(m_Geometry3D);
+    sliceNavigationController->SetViewDirection(mitk::SliceNavigationController::Sagittal);
+    sliceNavigationController->Update();
+
+    mitk::Point3D origin;
+    mitk::FillVector3D(origin, 10.5, 20.0, 30.0);
+
+    mitk::Vector3D firstAxisVector;
+    mitk::FillVector3D(firstAxisVector, 0.0, 50.0, 0.0);
+
+    mitk::Vector3D secondAxisVector;
+    mitk::FillVector3D(secondAxisVector, 0.0, 0.0, 200.0);
+
+    mitk::Vector3D thirdAxisVector;
+    mitk::FillVector3D(thirdAxisVector, 100.0, 0.0, 0.0);
+
+    std::cout << "Sagittal view direction" << std::endl;
+    CPPUNIT_ASSERT(this->validateGeometry(sliceNavigationController->GetCurrentGeometry3D(), origin, firstAxisVector, secondAxisVector, thirdAxisVector));
+  }
+
+private:
+  bool validateGeometry(mitk::BaseGeometry::ConstPointer geometry, const mitk::Point3D &origin, const mitk::Vector3D &firstAxisVector, const mitk::Vector3D &secondAxisVector, const mitk::Vector3D &thirdAxisVector)
+  {
+    bool result = true;
+
+    std::cout << "  Origin" << std::endl;
+
+    if (!mitk::Equal(geometry->GetOrigin(), origin, mitk::eps, true))
+      result = false;
+
+    std::cout << "  First axis vector" << std::endl;
+
+    if (!mitk::Equal(geometry->GetAxisVector(0), firstAxisVector, mitk::eps, true))
+      result = false;
+
+    std::cout << "  Second axis vector" << std::endl;
+
+    if (!mitk::Equal(geometry->GetAxisVector(1), secondAxisVector, mitk::eps, true))
+      result = false;
+
+    std::cout << "  Third axis vector" << std::endl;
+
+    if (!mitk::Equal(geometry->GetAxisVector(2), thirdAxisVector, mitk::eps, true))
+      result = false;
+
+    return result;
+  }
+
+  mitk::Geometry3D::Pointer m_Geometry3D;
+};
+
+MITK_TEST_SUITE_REGISTRATION(mitkSliceNavigationController)

--- a/Modules/Core/test/mitkSlicedGeometry3DTest.cpp
+++ b/Modules/Core/test/mitkSlicedGeometry3DTest.cpp
@@ -14,7 +14,6 @@ See LICENSE.txt or http://www.mitk.org for details.
 
 ===================================================================*/
 
-
 #include "mitkImage.h"
 #include "mitkPlaneGeometry.h"
 #include "mitkSlicedGeometry3D.h"
@@ -24,234 +23,154 @@ See LICENSE.txt or http://www.mitk.org for details.
 #include <vnl/vnl_quaternion.txx>
 
 #include <fstream>
+#include <array>
 
-static const mitk::ScalarType slicedGeometryEps = 1E-9; // epsilon for this testfile. Set to float precision.
+static const mitk::ScalarType slicedGeometryEps = 1e-9; // Set epsilon to float precision for this test
+
+static mitk::PlaneGeometry::Pointer createPlaneGeometry()
+{
+  auto planeGeometry = mitk::PlaneGeometry::New();
+  planeGeometry->Initialize();
+  return planeGeometry;
+}
+
+static mitk::SlicedGeometry3D::Pointer createSlicedGeometry(const mitk::Point3D &origin, const mitk::Vector3D &spacing, int numberOfSlices)
+{
+  auto slicedGeometry = mitk::SlicedGeometry3D::New();
+  slicedGeometry->InitializeSlicedGeometry(static_cast<unsigned int>(numberOfSlices));
+  slicedGeometry->SetOrigin(origin);
+  slicedGeometry->SetSpacing(spacing);
+
+  for (int i = 0; i < numberOfSlices; ++i)
+  {
+    auto planeGeometry = createPlaneGeometry();
+    slicedGeometry->SetPlaneGeometry(planeGeometry, i);
+  }
+
+  return slicedGeometry;
+}
+
+static mitk::SlicedGeometry3D::Pointer createEvenlySpacedSlicedGeometry(mitk::PlaneGeometry::Pointer planeGeometry, mitk::ScalarType spacing, int numberOfSlices)
+{
+  auto slicedGeometry = mitk::SlicedGeometry3D::New();
+  slicedGeometry->InitializeEvenlySpaced(planeGeometry, spacing, numberOfSlices);
+  return slicedGeometry;
+}
+
+template<class T> static T createArray(mitk::ScalarType x, mitk::ScalarType y, mitk::ScalarType z)
+{
+  T array;
+  mitk::FillVector3D(array, x, y, z);
+  return array;
+}
+
+static mitk::Point3D createPoint(mitk::ScalarType x, mitk::ScalarType y, mitk::ScalarType z)
+{
+  return createArray<mitk::Point3D>(x, y, z);
+}
+
+static mitk::Vector3D createVector(mitk::ScalarType x, mitk::ScalarType y, mitk::ScalarType z)
+{
+  return createArray<mitk::Vector3D>(x, y, z);
+}
 
 void mitkSlicedGeometry3D_ChangeImageGeometryConsideringOriginOffset_Test()
 {
-  //Tests for Offset
-  MITK_TEST_OUTPUT( << "====== NOW RUNNING: Tests for pixel-center-based offset concerns ========");
+  MITK_TEST_OUTPUT(<< "====== mitkSlicedGeometry3D_ChangeImageGeometryConsideringOriginOffset_Test() ======");
 
+  auto origin = createPoint(91.3, -13.3, 0);
+  auto spacing = createVector(1.0, 0.9, 0.3);
+  auto numberOfSlices = 5;
+  auto slicedGeometry = createSlicedGeometry(origin, spacing, numberOfSlices);
 
-  // create a SlicedGeometry3D
-  mitk::SlicedGeometry3D::Pointer slicedGeo3D=mitk::SlicedGeometry3D::New();
-  int num_slices = 5;
-  slicedGeo3D->InitializeSlicedGeometry(num_slices); // 5 slices
-  mitk::Point3D newOrigin;
-  newOrigin[0] = 91.3;
-  newOrigin[1] = -13.3;
-  newOrigin[2] = 0;
-  slicedGeo3D->SetOrigin(newOrigin);
-  mitk::Vector3D newSpacing;
-  newSpacing[0] = 1.0f;
-  newSpacing[1] = 0.9f;
-  newSpacing[2] = 0.3f;
-  slicedGeo3D->SetSpacing(newSpacing);
-  // create subslices as well
-  for (int i=0; i < num_slices; i++)
-  {
-    mitk::PlaneGeometry::Pointer geo2d = mitk::PlaneGeometry::New();
-    geo2d->Initialize();
-    slicedGeo3D->SetPlaneGeometry(geo2d,i);
-  }
+  MITK_TEST_OUTPUT(<< "SlicedGeometry3D isn't an image geometry by default");
+  MITK_TEST_CONDITION_REQUIRED(slicedGeometry->GetImageGeometry() == false, "");
 
-  // now run tests
+  MITK_TEST_OUTPUT(<< "First and last PlaneGeometry in SlicedGeometry3D are not image geometries");
+  auto firstPlaneGeometry = slicedGeometry->GetPlaneGeometry(0);
+  auto lastPlaneGeometry = slicedGeometry->GetPlaneGeometry(numberOfSlices - 1);
+  MITK_TEST_CONDITION_REQUIRED(firstPlaneGeometry->GetImageGeometry() == false, "");
+  MITK_TEST_CONDITION_REQUIRED(lastPlaneGeometry->GetImageGeometry() == false, "");
 
-  MITK_TEST_OUTPUT( << "Testing whether slicedGeo3D->GetImageGeometry() is false by default");
-  MITK_TEST_CONDITION_REQUIRED( slicedGeo3D->GetImageGeometry()==false, "");
-  MITK_TEST_OUTPUT( << "Testing whether first and last geometry in the SlicedGeometry3D have GetImageGeometry()==false by default");
-  mitk::BaseGeometry* subSliceGeo2D_first = slicedGeo3D->GetPlaneGeometry(0);
-  mitk::BaseGeometry* subSliceGeo2D_last = slicedGeo3D->GetPlaneGeometry(num_slices-1);
-  MITK_TEST_CONDITION_REQUIRED( subSliceGeo2D_first->GetImageGeometry()==false, "");
-  MITK_TEST_CONDITION_REQUIRED( subSliceGeo2D_last->GetImageGeometry()==false, "");
+  auto originOfSlicedGeometry = slicedGeometry->GetOrigin();
+  auto originOfFirstPlaneGeometry = firstPlaneGeometry->GetOrigin();
+  auto originOfLastPlaneGeometry = lastPlaneGeometry->GetOrigin();
+  auto firstCornerPointOfSlicedGeometry = slicedGeometry->GetCornerPoint(0);
+  auto secondCornerPointOfFirstPlaneGeometry = firstPlaneGeometry->GetCornerPoint(1);
+  auto thirdCornerPointOfLastPlaneGeometry = lastPlaneGeometry->GetCornerPoint(2);
 
-  // Save some Origins and cornerpoints
-  mitk::Point3D OriginSlicedGeo( slicedGeo3D->GetOrigin() );
-  mitk::Point3D OriginFirstGeo( subSliceGeo2D_first->GetOrigin() );
-  mitk::Point3D OriginLastGeo( subSliceGeo2D_last->GetOrigin() );
-  mitk::Point3D CornerPoint0SlicedGeo(slicedGeo3D->GetCornerPoint(0));
-  mitk::Point3D CornerPoint1FirstGeo(subSliceGeo2D_first->GetCornerPoint(1));
-  mitk::Point3D CornerPoint2LastGeo(subSliceGeo2D_last->GetCornerPoint(2));
+  MITK_TEST_OUTPUT(<< "Calling SlicedGeometry3D::ChangeImageGeometryConsideringOriginOffset(true)");
+  slicedGeometry->ChangeImageGeometryConsideringOriginOffset(true);
+  MITK_TEST_OUTPUT(<< "SlicedGeometry3D is an image geometry");
+  MITK_TEST_CONDITION_REQUIRED(slicedGeometry->GetImageGeometry() == true, "");
+  MITK_TEST_OUTPUT(<< "First and last PlaneGeometry in SlicedGeometry3D are image geometries");
+  MITK_TEST_CONDITION_REQUIRED(firstPlaneGeometry->GetImageGeometry() == true, "");
+  MITK_TEST_CONDITION_REQUIRED(lastPlaneGeometry->GetImageGeometry() == true, "");
 
-  MITK_TEST_OUTPUT( << "Calling slicedGeo3D->ChangeImageGeometryConsideringOriginOffset(true)");
-  //std::cout << "vorher Origin: " << subSliceGeo2D_first->GetOrigin() << std::endl;
-  //std::cout << "vorher Corner: " << subSliceGeo2D_first->GetCornerPoint(0) << std::endl;
-  slicedGeo3D->ChangeImageGeometryConsideringOriginOffset(true);
-  //std::cout << "nachher Origin: " << subSliceGeo2D_first->GetOrigin() << std::endl;
-  //std::cout << "nachher Corner: " << subSliceGeo2D_first->GetCornerPoint(0) << std::endl;
-  MITK_TEST_OUTPUT( << "Testing whether slicedGeo3D->GetImageGeometry() is now true");
-  MITK_TEST_CONDITION_REQUIRED( slicedGeo3D->GetImageGeometry()==true, "");
-  MITK_TEST_OUTPUT( << "Testing whether first and last geometry in the SlicedGeometry3D have GetImageGeometry()==true now");
-  MITK_TEST_CONDITION_REQUIRED( subSliceGeo2D_first->GetImageGeometry()==true, "");
-  MITK_TEST_CONDITION_REQUIRED( subSliceGeo2D_last->GetImageGeometry()==true, "");
+  MITK_TEST_OUTPUT(<< "Corner points of geometries didn't change");
+  MITK_TEST_CONDITION_REQUIRED(slicedGeometry->GetCornerPoint(0) == firstCornerPointOfSlicedGeometry, "");
+  MITK_TEST_CONDITION_REQUIRED(firstPlaneGeometry->GetCornerPoint(1) == secondCornerPointOfFirstPlaneGeometry, "");
+  MITK_TEST_CONDITION_REQUIRED(lastPlaneGeometry->GetCornerPoint(2) == thirdCornerPointOfLastPlaneGeometry, "");
 
-  MITK_TEST_OUTPUT( << "Testing wether offset has been added to origins");
-  // Manually adding Offset.
-  OriginSlicedGeo[0] += (slicedGeo3D->GetSpacing()[0]) / 2;
-  OriginSlicedGeo[1] += (slicedGeo3D->GetSpacing()[1]) / 2;
-  OriginSlicedGeo[2] += (slicedGeo3D->GetSpacing()[2]) / 2;
-  OriginFirstGeo[0] += (subSliceGeo2D_first->GetSpacing()[0]) / 2;
-  OriginFirstGeo[1] += (subSliceGeo2D_first->GetSpacing()[1]) / 2;
-  OriginFirstGeo[2] += (subSliceGeo2D_first->GetSpacing()[2]) / 2;
-  OriginLastGeo[0] += (subSliceGeo2D_last->GetSpacing()[0]) / 2;
-  OriginLastGeo[1] += (subSliceGeo2D_last->GetSpacing()[1]) / 2;
-  OriginLastGeo[2] += (subSliceGeo2D_last->GetSpacing()[2]) / 2;
-  MITK_TEST_CONDITION_REQUIRED( subSliceGeo2D_first->GetCornerPoint(1)==CornerPoint1FirstGeo, "");
-  MITK_TEST_CONDITION_REQUIRED( subSliceGeo2D_last->GetCornerPoint(2)==CornerPoint2LastGeo, "");
-  MITK_TEST_CONDITION_REQUIRED( slicedGeo3D->GetCornerPoint(0)==CornerPoint0SlicedGeo, "");
-  MITK_TEST_CONDITION_REQUIRED( slicedGeo3D->GetOrigin()==OriginSlicedGeo, "");
-  MITK_TEST_CONDITION_REQUIRED( subSliceGeo2D_first->GetOrigin()==OriginFirstGeo, "");
-  MITK_TEST_CONDITION_REQUIRED( subSliceGeo2D_last->GetOrigin()==OriginLastGeo, "");
+  MITK_TEST_OUTPUT(<< "Offsets were added to geometry origins");
+  MITK_TEST_CONDITION_REQUIRED(slicedGeometry->GetOrigin() == originOfSlicedGeometry + slicedGeometry->GetSpacing() * 0.5, "");
+  MITK_TEST_CONDITION_REQUIRED(firstPlaneGeometry->GetOrigin() == originOfFirstPlaneGeometry + firstPlaneGeometry->GetSpacing() * 0.5, "");
+  MITK_TEST_CONDITION_REQUIRED(lastPlaneGeometry->GetOrigin() == originOfLastPlaneGeometry + lastPlaneGeometry->GetSpacing() * 0.5, "");
 
-  MITK_TEST_OUTPUT( << "Calling slicedGeo3D->ChangeImageGeometryConsideringOriginOffset(false)");
-  slicedGeo3D->ChangeImageGeometryConsideringOriginOffset(false);
-  MITK_TEST_OUTPUT( << "Testing whether slicedGeo3D->GetImageGeometry() is now false");
-  MITK_TEST_CONDITION_REQUIRED( slicedGeo3D->GetImageGeometry()==false, "");
-  MITK_TEST_OUTPUT( << "Testing whether first and last geometry in the SlicedGeometry3D have GetImageGeometry()==false now");
-  MITK_TEST_CONDITION_REQUIRED( subSliceGeo2D_first->GetImageGeometry()==false, "");
-  MITK_TEST_CONDITION_REQUIRED( subSliceGeo2D_last->GetImageGeometry()==false, "");
+  MITK_TEST_OUTPUT(<< "Calling SlicedGeometry3D::ChangeImageGeometryConsideringOriginOffset(false)");
+  slicedGeometry->ChangeImageGeometryConsideringOriginOffset(false);
+  MITK_TEST_OUTPUT(<< "SlicedGeometry3D isn't an image geometry anymore");
+  MITK_TEST_CONDITION_REQUIRED(slicedGeometry->GetImageGeometry() == false, "");
+  MITK_TEST_OUTPUT(<< "First and last PlaneGeometry in SlicedGeometry3D are no image geometries anymore");
+  MITK_TEST_CONDITION_REQUIRED(firstPlaneGeometry->GetImageGeometry() == false, "");
+  MITK_TEST_CONDITION_REQUIRED(lastPlaneGeometry->GetImageGeometry() == false, "");
 
-  MITK_TEST_OUTPUT( << "Testing wether offset has been added to origins of geometry");
+  MITK_TEST_OUTPUT(<< "Corner points of geometries didn't change");
+  MITK_TEST_CONDITION_REQUIRED(slicedGeometry->GetCornerPoint(0) == firstCornerPointOfSlicedGeometry, "");
+  MITK_TEST_CONDITION_REQUIRED(firstPlaneGeometry->GetCornerPoint(1) == secondCornerPointOfFirstPlaneGeometry, "");
+  MITK_TEST_CONDITION_REQUIRED(lastPlaneGeometry->GetCornerPoint(2) == thirdCornerPointOfLastPlaneGeometry, "");
 
-  // Manually substracting Offset.
-  OriginSlicedGeo[0] -= (slicedGeo3D->GetSpacing()[0]) / 2;
-  OriginSlicedGeo[1] -= (slicedGeo3D->GetSpacing()[1]) / 2;
-  OriginSlicedGeo[2] -= (slicedGeo3D->GetSpacing()[2]) / 2;
-  OriginFirstGeo[0] -= (subSliceGeo2D_first->GetSpacing()[0]) / 2;
-  OriginFirstGeo[1] -= (subSliceGeo2D_first->GetSpacing()[1]) / 2;
-  OriginFirstGeo[2] -= (subSliceGeo2D_first->GetSpacing()[2]) / 2;
-  OriginLastGeo[0] -= (subSliceGeo2D_last->GetSpacing()[0]) / 2;
-  OriginLastGeo[1] -= (subSliceGeo2D_last->GetSpacing()[1]) / 2;
-  OriginLastGeo[2] -= (subSliceGeo2D_last->GetSpacing()[2]) / 2;
-
-  MITK_TEST_CONDITION_REQUIRED( subSliceGeo2D_first->GetCornerPoint(1)==CornerPoint1FirstGeo, "");
-  MITK_TEST_CONDITION_REQUIRED( subSliceGeo2D_last->GetCornerPoint(2)==CornerPoint2LastGeo, "");
-  MITK_TEST_CONDITION_REQUIRED( slicedGeo3D->GetCornerPoint(0)==CornerPoint0SlicedGeo, "");
-  MITK_TEST_CONDITION_REQUIRED( slicedGeo3D->GetOrigin()==OriginSlicedGeo, "");
-  MITK_TEST_CONDITION_REQUIRED( subSliceGeo2D_first->GetOrigin()==OriginFirstGeo, "");
-  MITK_TEST_CONDITION_REQUIRED( subSliceGeo2D_last->GetOrigin()==OriginLastGeo, "");
-
-  MITK_TEST_OUTPUT( << "ALL SUCCESSFULLY!");
+  MITK_TEST_OUTPUT(<< "Offsets were subtracted from geometry origins");
+  MITK_TEST_CONDITION_REQUIRED(slicedGeometry->GetOrigin() == originOfSlicedGeometry, "");
+  MITK_TEST_CONDITION_REQUIRED(firstPlaneGeometry->GetOrigin() == originOfFirstPlaneGeometry, "");
+  MITK_TEST_CONDITION_REQUIRED(lastPlaneGeometry->GetOrigin() == originOfLastPlaneGeometry, "");
 }
 
-int mitkSlicedGeometry3DTest(int /*argc*/, char* /*argv*/[])
+int mitkSlicedGeometry3DTest(int, char *[])
 {
-  mitk::PlaneGeometry::Pointer planegeometry1 = mitk::PlaneGeometry::New();
+  mitk::ScalarType width = 100.0;
+  mitk::ScalarType widthInMM = width;
 
-  mitk::Point3D origin;
-  mitk::Vector3D right, bottom, normal;
-  mitk::ScalarType width, height;
-  mitk::ScalarType widthInMM, heightInMM, thicknessInMM;
+  mitk::ScalarType height = 200.0;
+  mitk::ScalarType heightInMM = height;
 
-  width  = 100;    widthInMM  = width;
-  height = 200;    heightInMM = height;
-  thicknessInMM = 3.5;
-  mitk::FillVector3D(origin, 4.5,              7.3, 11.2);
-  mitk::FillVector3D(right,  widthInMM,          0, 0);
-  mitk::FillVector3D(bottom,         0, heightInMM, 0);
-  mitk::FillVector3D(normal,         0,          0, thicknessInMM);
+  mitk::ScalarType thicknessInMM = 3.0;
 
-  std::cout << "Initializing planegeometry1 by InitializeStandardPlane(rightVector, downVector, spacing = NULL): "<<std::endl;
-  planegeometry1->InitializeStandardPlane(right.GetVnlVector(), bottom.GetVnlVector());
+  auto right = createVector(widthInMM, 0.0, 0.0);
+  auto bottom = createVector(0.0, heightInMM, 0.0);
+  auto spacing = createVector(1.0, 1.0, thicknessInMM);
 
-  std::cout << "Setting planegeometry2 to a cloned version of planegeometry1: "<<std::endl;
-  mitk::PlaneGeometry::Pointer planegeometry2;
-  planegeometry2 = dynamic_cast<mitk::PlaneGeometry*>(planegeometry1->Clone().GetPointer());;
+  auto planeGeometry = mitk::PlaneGeometry::New();
+  planeGeometry->InitializeStandardPlane(right, bottom, &spacing);
 
-  std::cout << "Changing the IndexToWorldTransform of planegeometry2 to a rotated version by SetIndexToWorldTransform() (keep origin): "<<std::endl;
-  mitk::AffineTransform3D::Pointer transform = mitk::AffineTransform3D::New();
-  mitk::AffineTransform3D::MatrixType::InternalMatrixType vnlmatrix;
-  vnlmatrix = planegeometry2->GetIndexToWorldTransform()->GetMatrix().GetVnlMatrix();
-  mitk::VnlVector axis(3);
-  mitk::FillVector3D(axis, 1.0, 1.0, 1.0); axis.normalize();
-  vnl_quaternion<mitk::ScalarType> rotation(axis, 0.123);
-  vnlmatrix = rotation.rotation_matrix_transpose()*vnlmatrix;
-  mitk::Matrix3D matrix;
-  matrix = vnlmatrix;
-  transform->SetMatrix(matrix);
-  transform->SetOffset(planegeometry2->GetIndexToWorldTransform()->GetOffset());
+  auto numberOfSlices = 5;
+  auto slicedGeometry = createEvenlySpacedSlicedGeometry(planeGeometry, thicknessInMM, numberOfSlices);
+  auto firstPlaneGeometry = slicedGeometry->GetPlaneGeometry(0);
 
-  right.SetVnlVector( rotation.rotation_matrix_transpose()*right.GetVnlVector() );
-  bottom.SetVnlVector(rotation.rotation_matrix_transpose()*bottom.GetVnlVector());
-  normal.SetVnlVector(rotation.rotation_matrix_transpose()*normal.GetVnlVector());
-  planegeometry2->SetIndexToWorldTransform(transform);
+  MITK_TEST_OUTPUT(<< "Check if first PlaneGeometry of evenly spaced SlicedGeometry is valid");
+  MITK_TEST_CONDITION_REQUIRED(firstPlaneGeometry != nullptr, "");
+  MITK_TEST_CONDITION_REQUIRED(mitk::Equal(firstPlaneGeometry->GetAxisVector(0), planeGeometry->GetAxisVector(0), slicedGeometryEps), "");
+  MITK_TEST_CONDITION_REQUIRED(mitk::Equal(firstPlaneGeometry->GetAxisVector(1), planeGeometry->GetAxisVector(1), slicedGeometryEps), "");
+  MITK_TEST_CONDITION_REQUIRED(mitk::Equal(firstPlaneGeometry->GetAxisVector(2), planeGeometry->GetAxisVector(2), slicedGeometryEps), "");
 
+  auto lastPlaneGeometry = slicedGeometry->GetPlaneGeometry(numberOfSlices - 1);
+  auto expectedOriginOfLastSlice = createPoint(0.0, 0.0, thicknessInMM * (numberOfSlices - 1));
 
-  std::cout << "Setting planegeometry3 to the backside of planegeometry2: " <<std::endl;
-  mitk::PlaneGeometry::Pointer planegeometry3 = mitk::PlaneGeometry::New();
-  planegeometry3->InitializeStandardPlane(planegeometry2, mitk::PlaneGeometry::Axial, 0, false);
-
-
-  std::cout << "Testing SlicedGeometry3D::InitializeEvenlySpaced(planegeometry3, zSpacing = 1, slices = 5, flipped = false): " <<std::endl;
-  mitk::SlicedGeometry3D::Pointer slicedWorldGeometry=mitk::SlicedGeometry3D::New();
-  unsigned int numSlices = 5;
-  slicedWorldGeometry->InitializeEvenlySpaced(planegeometry3, 1, numSlices, false);
-
-  std::cout << "Testing availability and type (PlaneGeometry) of first geometry in the SlicedGeometry3D: ";
-  mitk::PlaneGeometry* accessedplanegeometry3 = dynamic_cast<mitk::PlaneGeometry*>(slicedWorldGeometry->GetPlaneGeometry(0));
-  if(accessedplanegeometry3==nullptr)
-  {
-    std::cout<<"[FAILED]"<<std::endl;
-    return EXIT_FAILURE;
-  }
-  std::cout<<"[PASSED]"<<std::endl;
-
-  std::cout << "Testing whether the first geometry in the SlicedGeometry3D is identical to planegeometry3 by axis comparison and origin: "<<std::endl;
-  if((mitk::Equal(accessedplanegeometry3->GetAxisVector(0), planegeometry3->GetAxisVector(0), slicedGeometryEps)==false) ||
-     (mitk::Equal(accessedplanegeometry3->GetAxisVector(1), planegeometry3->GetAxisVector(1), slicedGeometryEps)==false) ||
-     (mitk::Equal(accessedplanegeometry3->GetAxisVector(2), planegeometry3->GetAxisVector(2), slicedGeometryEps)==false) ||
-     (mitk::Equal(accessedplanegeometry3->GetOrigin(), planegeometry3->GetOrigin(), slicedGeometryEps)==false))
-  {
-    std::cout<<"[FAILED]"<<std::endl;
-    return EXIT_FAILURE;
-  }
-  std::cout<<"[PASSED]"<<std::endl;
-
-  std::cout << "Testing availability and type (PlaneGeometry) of the last geometry in the SlicedGeometry3D: ";
-  mitk::PlaneGeometry* accessedplanegeometry3last = dynamic_cast<mitk::PlaneGeometry*>(slicedWorldGeometry->GetPlaneGeometry(numSlices-1));
-  mitk::Point3D origin3last; origin3last = planegeometry3->GetOrigin()+slicedWorldGeometry->GetDirectionVector()*(numSlices-1);
-  if(accessedplanegeometry3last==nullptr)
-  {
-    std::cout<<"[FAILED]"<<std::endl;
-    return EXIT_FAILURE;
-  }
-  std::cout<<"[PASSED]"<<std::endl;
-
-  std::cout << "Testing whether the last geometry in the SlicedGeometry3D is identical to planegeometry3 by axis comparison: "<<std::endl;
-  if((mitk::Equal(accessedplanegeometry3last->GetAxisVector(0), planegeometry3->GetAxisVector(0), slicedGeometryEps)==false) ||
-     (mitk::Equal(accessedplanegeometry3last->GetAxisVector(1), planegeometry3->GetAxisVector(1), slicedGeometryEps)==false) ||
-     (mitk::Equal(accessedplanegeometry3last->GetAxisVector(2), planegeometry3->GetAxisVector(2), slicedGeometryEps)==false) ||
-     (mitk::Equal(accessedplanegeometry3last->GetOrigin(), origin3last, slicedGeometryEps)==false) ||
-     (mitk::Equal(accessedplanegeometry3last->GetIndexToWorldTransform()->GetOffset(), origin3last.GetVectorFromOrigin(), slicedGeometryEps)==false))
-  {
-    std::cout<<"[FAILED]"<<std::endl;
-    return EXIT_FAILURE;
-  }
-  std::cout<<"[PASSED]"<<std::endl;
-
-  std::cout << "Again for first slice - Testing availability and type (PlaneGeometry) of first geometry in the SlicedGeometry3D: ";
-  accessedplanegeometry3 = dynamic_cast<mitk::PlaneGeometry*>(slicedWorldGeometry->GetPlaneGeometry(0));
-  if(accessedplanegeometry3==nullptr)
-  {
-    std::cout<<"[FAILED]"<<std::endl;
-    return EXIT_FAILURE;
-  }
-  std::cout<<"[PASSED]"<<std::endl;
-
-  std::cout << "Again for first slice - Testing whether the first geometry in the SlicedGeometry3D is identical to planegeometry3 by axis comparison and origin: "<<std::endl;
-  if((mitk::Equal(accessedplanegeometry3->GetAxisVector(0), planegeometry3->GetAxisVector(0), slicedGeometryEps)==false) ||
-     (mitk::Equal(accessedplanegeometry3->GetAxisVector(1), planegeometry3->GetAxisVector(1), slicedGeometryEps)==false) ||
-     (mitk::Equal(accessedplanegeometry3->GetAxisVector(2), planegeometry3->GetAxisVector(2), slicedGeometryEps)==false) ||
-     (mitk::Equal(accessedplanegeometry3->GetOrigin(), planegeometry3->GetOrigin(), slicedGeometryEps)==false) ||
-     (mitk::Equal(accessedplanegeometry3->GetIndexToWorldTransform()->GetOffset(), planegeometry3->GetOrigin().GetVectorFromOrigin(), slicedGeometryEps)==false))
-  {
-    std::cout<<"[FAILED]"<<std::endl;
-    return EXIT_FAILURE;
-  }
-  std::cout<<"[PASSED]"<<std::endl;
+  MITK_TEST_OUTPUT(<< "Check if origin of last PlaneGeometry is at expected location");
+  MITK_TEST_CONDITION_REQUIRED(mitk::Equal(lastPlaneGeometry->GetOrigin(), expectedOriginOfLastSlice, slicedGeometryEps), "");
 
   mitkSlicedGeometry3D_ChangeImageGeometryConsideringOriginOffset_Test();
 
-  std::cout<<"[TEST DONE]"<<std::endl;
+  std::cout << "[TEST DONE]" << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Modules/QtWidgets/src/QmitkStdMultiWidget.cpp
+++ b/Modules/QtWidgets/src/QmitkStdMultiWidget.cpp
@@ -2252,45 +2252,15 @@ mitk::DataNode::Pointer QmitkStdMultiWidget::GetWidgetPlane(int id)
   }
 }
 
-int valFromIntProp(mitk::Image* image, int axisIndex, int slice, int defaultVal)
-{
-  mitk::IntProperty* prop = nullptr;
-  if (image) {
-    static const char* axisNameInd[] = { "autoplan.mainAxisIndex_%d", "autoplan.secondaryAxisIndex_%d", "autoplan.tertiaryAxisIndex_%d" };
-    auto propName = boost::str(boost::format(axisNameInd[axisIndex]) % slice);
-    prop = dynamic_cast<mitk::IntProperty*>(static_cast<mitk::BaseProperty*>(image->GetProperty(propName.c_str())));
-    if (!prop) {
-      static const char* axisName[] = { "autoplan.mainAxisIndex", "autoplan.secondaryAxisIndex", "autoplan.tertiaryAxisIndex" };
-      prop = dynamic_cast<mitk::IntProperty*>(static_cast<mitk::BaseProperty*>(image->GetProperty(axisName[axisIndex])));
-    }
-  }
-  return prop ? prop->GetValue() : defaultVal;
-}
-
-bool valFromBoolProp(mitk::Image* image, int axisIndex, int slice, bool defaultVal)
-{
-  mitk::BoolProperty* prop = nullptr;
-  if (image) {
-    static const char* axisNameInd[] = { "autoplan.mainAxisSign_%d", "autoplan.secondaryAxisSign_%d", "autoplan.tertiaryAxisSign_%d" };
-    auto propName = boost::str(boost::format(axisNameInd[axisIndex]) % slice);
-    prop = dynamic_cast<mitk::BoolProperty*>(static_cast<mitk::BaseProperty*>(image->GetProperty(propName.c_str())));
-    if (!prop) {
-      static const char* axisName[] = { "autoplan.mainAxisSign", "autoplan.secondaryAxisSign", "autoplan.tertiaryAxisSign" };
-      prop = dynamic_cast<mitk::BoolProperty*>(static_cast<mitk::BaseProperty*>(image->GetProperty(axisName[axisIndex])));
-    }
-  }
-  return prop ? prop->GetValue() : defaultVal;
-}
-
 void QmitkStdMultiWidget::setViewDirectionAnnontation(mitk::Image* image, int slice, int i)
 {
-  auto mainAxis = valFromIntProp(image, 0, slice, -1);
-  auto secondAxis = valFromIntProp(image, 1, slice, -1);
-  auto tertiaryAxis = valFromIntProp(image, 2, slice, -1);
+  auto mainAxis = 2;
+  auto secondAxis = 0;
+  auto tertiaryAxis = 1;
 
-  auto mainSign = valFromBoolProp(image, 0, slice, true);
-  auto secondSign = valFromBoolProp(image, 1, slice, true);
-  auto tertiarySign = valFromBoolProp(image, 2, slice, true);
+  auto mainSign = true;
+  auto secondSign = true;
+  auto tertiarySign = true;
 
   if (!m_displayMetaInfo) {
     mainAxis = secondAxis = -1;

--- a/Modules/QtWidgetsExt/include/QmitkSliderNavigatorWidget.h
+++ b/Modules/QtWidgetsExt/include/QmitkSliderNavigatorWidget.h
@@ -52,6 +52,10 @@ public:
 
   int GetPos();
 
+  bool GetInverseDirection() const;
+
+  bool GetInvertedControls() const;
+
 public slots:
 
   /**
@@ -76,9 +80,11 @@ public slots:
 
   void SetInverseDirection (bool inverseDirection);
 
+  void SetInvertedControls(bool invertedControls);
+
 protected slots:
 
-  void slider_valueChanged( int );
+  void slider_valueChanged(double);
 
   /**
    * \brief Set range minimum and maximum (displayed as labels left and right
@@ -99,7 +105,7 @@ protected slots:
    */
   void SetLabels();
 
-  void spinBox_valueChanged( int );
+  void spinBox_valueChanged(double);
 
 
 protected:
@@ -115,6 +121,7 @@ protected:
   float m_MaxValue;
 
   bool m_InverseDirection;
+  bool m_InvertedControls;
 
 };
 

--- a/Modules/QtWidgetsExt/src/QmitkSliderNavigator.ui
+++ b/Modules/QtWidgetsExt/src/QmitkSliderNavigator.ui
@@ -48,71 +48,12 @@
     <number>0</number>
    </property>
    <item row="0" column="3">
-    <widget class="QSpinBox" name="m_SpinBox">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>50</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="maximum">
-      <number>0</number>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QSlider" name="m_Slider">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="maximum">
-      <number>0</number>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="2">
-    <widget class="QLabel" name="m_SliderLabelRight">
+    <widget class="ctkDoubleSpinBox" name="m_SpinBox" native="true">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>45</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>45</width>
-       <height>32767</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>&lt;p align=&quot;center&quot;&gt;XXX&lt;/p&gt;</string>
-     </property>
-     <property name="wordWrap">
-      <bool>false</bool>
      </property>
     </widget>
    </item>
@@ -147,45 +88,64 @@
      </property>
     </widget>
    </item>
+   <item row="0" column="1">
+    <widget class="ctkDoubleSlider" name="m_Slider" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2">
+    <widget class="QLabel" name="m_SliderLabelRight">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>45</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>45</width>
+       <height>32767</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>&lt;p align=&quot;center&quot;&gt;XXX&lt;/p&gt;</string>
+     </property>
+     <property name="wordWrap">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <layoutdefault spacing="0" margin="0"/>
+ <customwidgets>
+  <customwidget>
+   <class>ctkDoubleSlider</class>
+   <extends>QWidget</extends>
+   <header location="global">ctkDoubleSlider.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ctkDoubleSpinBox</class>
+   <extends>QWidget</extends>
+   <header location="global">ctkDoubleSpinBox.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <includes>
   <include location="global">mitkStepper.h</include>
  </includes>
  <resources/>
- <connections>
-  <connection>
-   <sender>m_Slider</sender>
-   <signal>valueChanged(int)</signal>
-   <receiver>QmitkSliderNavigator</receiver>
-   <slot>slider_valueChanged(int)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>m_SpinBox</sender>
-   <signal>valueChanged(int)</signal>
-   <receiver>QmitkSliderNavigator</receiver>
-   <slot>spinBox_valueChanged(int)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/Modules/QtWidgetsExt/src/QmitkSliderNavigatorWidget.cpp
+++ b/Modules/QtWidgetsExt/src/QmitkSliderNavigatorWidget.cpp
@@ -21,7 +21,23 @@ QmitkSliderNavigatorWidget::QmitkSliderNavigatorWidget(QWidget* parent, Qt::Wind
 {
   this->setupUi(this);
 
-  // this avoids trying to use m_Stepper until it is set to something != NULL
+  m_Slider->setOrientation(Qt::Horizontal);
+  m_Slider->setMinimum(0);
+  m_Slider->setMaximum(0);
+  m_Slider->setValue(0);
+  m_Slider->setSingleStep(1);
+  m_Slider->setPageStep(10);
+
+  m_SpinBox->setMinimum( 0 );
+  m_SpinBox->setMaximum(0);
+  m_SpinBox->setValue(0);
+  m_SpinBox->setDecimals(0);
+  m_SpinBox->setSingleStep(1);
+
+  this->connect(m_Slider, SIGNAL(valueChanged(double)), SLOT(slider_valueChanged(double)));
+  this->connect(m_SpinBox, SIGNAL(valueChanged(double)), SLOT(spinBox_valueChanged(double)));
+
+  // this avoids trying to use m_Stepper until it is set to something != nullptr
   // (additionally to the avoiding recursions during refetching)
   m_InRefetch = true;
 
@@ -34,34 +50,43 @@ QmitkSliderNavigatorWidget::QmitkSliderNavigatorWidget(QWidget* parent, Qt::Wind
   m_HasLabels = false;
   m_HasLabelUnit = true;
   m_InverseDirection = false;
+  m_InvertedControls = false;
 }
 
 void QmitkSliderNavigatorWidget::Refetch()
 {
-  if ( !m_InRefetch )
+  if (!m_InRefetch)
   {
     m_InRefetch = true;
 
-    m_Slider->setMinimum( 0 );
-    m_Slider->setMaximum( m_Stepper->GetSteps() - 1 );
-    if (m_InverseDirection)
+    if (m_Stepper->GetSteps() == 0)
     {
-      m_Slider->setValue( m_Stepper->GetSteps()-1-m_Stepper->GetPos() );
+      m_Slider->setMaximum(0);
+      m_Slider->setValue(0);
+      m_SpinBox->setMaximum(0);
+      m_SpinBox->setValue(0);
     }
     else
     {
-      m_Slider->setValue( m_Stepper->GetPos() );
-    }
+      m_Slider->setMaximum(m_Stepper->GetSteps() - 1);
+      if (m_InverseDirection)
+      {
+        m_Slider->setValue(m_Stepper->GetSteps() - 1 - m_Stepper->GetPos());
+      }
+      else
+      {
+        m_Slider->setValue(m_Stepper->GetPos());
+      }
 
-    m_SpinBox->setMinimum( 0 );
-    m_SpinBox->setMaximum( m_Stepper->GetSteps() - 1 );
-    if (m_InverseDirection)
-    {
-      m_SpinBox->setValue( m_Stepper->GetSteps()-1-m_Stepper->GetPos() );
-    }
-    else
-    {
-      m_SpinBox->setValue( m_Stepper->GetPos() );
+      m_SpinBox->setMaximum(m_Stepper->GetSteps() - 1);
+      if (m_InverseDirection)
+      {
+        m_SpinBox->setValue(m_Stepper->GetSteps() - 1 - m_Stepper->GetPos());
+      }
+      else
+      {
+        m_SpinBox->setValue(m_Stepper->GetPos());
+      }
     }
 
     if ( m_Stepper->HasRange() && m_HasLabels )
@@ -112,7 +137,7 @@ void QmitkSliderNavigatorWidget::SetStepper( mitk::Stepper * stepper)
 }
 
 
-void QmitkSliderNavigatorWidget::slider_valueChanged( int )
+void QmitkSliderNavigatorWidget::slider_valueChanged(double)
 {
   if (!m_InRefetch)
   {
@@ -232,7 +257,7 @@ void QmitkSliderNavigatorWidget::SetLabels()
   m_SliderLabelRight->setText( maxText );
 }
 
-void QmitkSliderNavigatorWidget::spinBox_valueChanged( int )
+void QmitkSliderNavigatorWidget::spinBox_valueChanged(double)
 {
   if(!m_InRefetch)
   {
@@ -261,8 +286,33 @@ void QmitkSliderNavigatorWidget::SetPos(int val)
   }
 }
 
+bool QmitkSliderNavigatorWidget::GetInverseDirection() const
+{
+  return m_InverseDirection;
+}
+
 void QmitkSliderNavigatorWidget::SetInverseDirection(bool inverseDirection)
 {
-  m_InverseDirection = inverseDirection;
+  if (inverseDirection != m_InverseDirection)
+  {
+    m_InverseDirection = inverseDirection;
+    this->Refetch();
+  }
+}
+
+bool QmitkSliderNavigatorWidget::GetInvertedControls() const
+{
+  return m_InvertedControls;
+}
+
+void QmitkSliderNavigatorWidget::SetInvertedControls(bool invertedControls)
+{
+  if (invertedControls != m_InvertedControls)
+  {
+    m_InvertedControls = invertedControls;
+    m_Slider->setInvertedAppearance(invertedControls);
+    m_Slider->setInvertedControls(invertedControls);
+    m_SpinBox->setInvertedControls(invertedControls);
+  }
 }
 

--- a/Plugins/org.mitk.gui.qt.imagenavigator/src/internal/QmitkImageNavigatorView.cpp
+++ b/Plugins/org.mitk.gui.qt.imagenavigator/src/internal/QmitkImageNavigatorView.cpp
@@ -16,6 +16,8 @@ See LICENSE.txt or http://www.mitk.org for details.
 
 #include "QmitkImageNavigatorView.h"
 
+#include <itkSpatialOrientationAdapter.h>
+
 #include <QmitkStepperAdapter.h>
 #include <QmitkRenderWindow.h>
 
@@ -83,7 +85,6 @@ void QmitkImageNavigatorView::CreateQtPartControl(QWidget *parent)
   // create GUI widgets
   m_Parent = parent;
   m_Controls.setupUi(parent);
-  m_Controls.m_SliceNavigatorAxial->SetInverseDirection(true);
 
   connect(m_Controls.m_XWorldCoordinateSpinBox, SIGNAL(valueChanged(double)), this, SLOT(OnMillimetreCoordinateValueChanged()));
   connect(m_Controls.m_YWorldCoordinateSpinBox, SIGNAL(valueChanged(double)), this, SLOT(OnMillimetreCoordinateValueChanged()));
@@ -550,6 +551,80 @@ void QmitkImageNavigatorView::OnRefetch()
       m_Controls.m_XWorldCoordinateSpinBox->blockSignals(false);
       m_Controls.m_YWorldCoordinateSpinBox->blockSignals(false);
       m_Controls.m_ZWorldCoordinateSpinBox->blockSignals(false);
+
+      /// Calculating 'inverse direction' property.
+
+      mitk::AffineTransform3D::MatrixType matrix = geometry->GetIndexToWorldTransform()->GetMatrix();
+      matrix.GetVnlMatrix().normalize_columns();
+      mitk::AffineTransform3D::MatrixType::InternalMatrixType inverseMatrix = matrix.GetInverse();
+
+      for (int worldAxis = 0; worldAxis < 3; ++worldAxis)
+      {
+        QmitkRenderWindow* renderWindow =
+            worldAxis == 0 ? m_IRenderWindowPart->GetQmitkRenderWindow("sagittal") :
+            worldAxis == 1 ? m_IRenderWindowPart->GetQmitkRenderWindow("coronal") :
+                             m_IRenderWindowPart->GetQmitkRenderWindow("axial");
+
+        if (renderWindow)
+        {
+          const mitk::BaseGeometry* rendererGeometry = renderWindow->GetRenderer()->GetCurrentWorldGeometry();
+
+          /// Because of some problems with the current way of event signalling,
+          /// 'Modified' events are sent out from the stepper while the renderer
+          /// does not have a geometry yet. Therefore, we do a nullptr check here.
+          /// See bug T22122. This check can be resolved after T22122 got fixed.
+          if (rendererGeometry)
+          {
+            int dominantAxis = itk::Function::Max3(
+                inverseMatrix[0][worldAxis],
+                inverseMatrix[1][worldAxis],
+                inverseMatrix[2][worldAxis]);
+
+            bool referenceGeometryAxisInverted = inverseMatrix[dominantAxis][worldAxis] < 0;
+            bool rendererZAxisInverted = rendererGeometry->GetAxisVector(2)[worldAxis] < 0;
+
+            /// `referenceGeometryAxisInverted` tells if the direction of the corresponding axis
+            /// of the reference geometry is flipped compared to the 'world direction' or not.
+            ///
+            /// `rendererZAxisInverted` tells if direction of the renderer geometry z axis is
+            /// flipped compared to the 'world direction' or not. This is the same as the indexing
+            /// direction in the slice navigation controller and matches the 'top' property when
+            /// initialising the renderer planes. (If 'top' was true then the direction is
+            /// inverted.)
+            ///
+            /// The world direction can be +1 ('up') that means right, anterior or superior, or
+            /// it can be -1 ('down') that means left, posterior or inferior, respectively.
+            ///
+            /// If these two do not match, we have to invert the index between the slice navigation
+            /// controller and the slider navigator widget, so that the user can see and control
+            /// the index according to the reference geometry, rather than the slice navigation
+            /// controller. The index in the slice navigation controller depends on in which way
+            /// the reference geometry has been resliced for the renderer, and it does not necessarily
+            /// match neither the world direction, nor the direction of the corresponding axis of
+            /// the reference geometry. Hence, it is a merely internal information that should not
+            /// be exposed to the GUI.
+            ///
+            /// So that one can navigate in the same world direction by dragging the slider
+            /// right, regardless of the direction of the corresponding axis of the reference
+            /// geometry, we invert the direction of the controls if the reference geometry axis
+            /// is inverted but the direction is not ('inversDirection' is false) or the other
+            /// way around.
+
+            bool inverseDirection = referenceGeometryAxisInverted != rendererZAxisInverted;
+
+            QmitkSliderNavigatorWidget* navigatorWidget =
+                worldAxis == 0 ? m_Controls.m_SliceNavigatorSagittal :
+                worldAxis == 1 ? m_Controls.m_SliceNavigatorFrontal :
+                                 m_Controls.m_SliceNavigatorAxial;
+
+            navigatorWidget->SetInverseDirection(inverseDirection);
+
+            // This should be a preference (see T22254)
+            // bool invertedControls = referenceGeometryAxisInverted != inverseDirection;
+            // navigatorWidget->SetInvertedControls(invertedControls);
+          }
+        }
+      }
     }
 
     this->SetBorderColors();


### PR DESCRIPTION
http://samsmu.net:8083/browse/AUT-2202

Для корректной работы требуется https://github.com/samsmu/AutoplanApplication/pull/1627, лучше вмерживать одновременно.

Тестовые шаги:

1. Загрузить 0499 исследование в универсальный кейс.
   - Серии с основной осью, отличной от аксиальной, отображаются в правильных окнах мультивиджета.