### PR TITLE
Загрузка 0040 исследования

### DIFF
--- a/CMakeExternals/ITK.cmake
+++ b/CMakeExternals/ITK.cmake
@@ -100,7 +100,10 @@ if(NOT DEFINED ITK_DIR)
      URL ${MITK_THIRDPARTY_DOWNLOAD_PREFIX_URL}/InsightToolkit-4.9.0.tar.xz
      URL_MD5 0ce83c0f3c08f8ee992675fca4401572
      # work with external GDCM
-     PATCH_COMMAND ${PATCH_COMMAND} -N -p1 -i ${CMAKE_CURRENT_LIST_DIR}/ITK-4.9.0.patch COMMAND ${PATCH_COMMAND} -N -p1 -i ${CMAKE_CURRENT_LIST_DIR}/ITK_search_gpu.patch COMMAND ${PATCH_COMMAND} -N -p1 -i ${CMAKE_CURRENT_LIST_DIR}/ITK_fixed_4D_progress.patch
+     PATCH_COMMAND ${PATCH_COMMAND} -N -p1 -i ${CMAKE_CURRENT_LIST_DIR}/ITK-4.9.0.patch 
+       COMMAND ${PATCH_COMMAND} -N -p1 -i ${CMAKE_CURRENT_LIST_DIR}/ITK_search_gpu.patch 
+       COMMAND ${PATCH_COMMAND} -N -p1 -i ${CMAKE_CURRENT_LIST_DIR}/ITK_fixed_4D_progress.patch
+       COMMAND ${PATCH_COMMAND} -N -p1 -i ${CMAKE_CURRENT_LIST_DIR}/ITK_rescaling_fix.patch
      CMAKE_GENERATOR ${gen}
      CMAKE_ARGS
        ${ep_common_args}

--- a/CMakeExternals/ITK_rescaling_fix.patch
+++ b/CMakeExternals/ITK_rescaling_fix.patch
@@ -1,0 +1,35 @@
+From b1eff4f29e4c906d7d9c2dfaadc35899250049aa Mon Sep 17 00:00:00 2001
+From: KuznetsovAlexander <KuznetsovAlexander@rambler.ru>
+Date: Tue, 22 Aug 2017 14:08:21 +0400
+Subject: [PATCH] Fixed loading of multicomponent images with rescaling.
+
+AUT-2882
+Signed-off-by: KuznetsovAlexander <KuznetsovAlexander@rambler.ru>
+---
+ Modules/IO/GDCM/src/itkGDCMImageIO.cxx | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+index 2ea3587..7abf1dd 100644
+--- a/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
++++ b/Modules/IO/GDCM/src/itkGDCMImageIO.cxx
+@@ -320,8 +320,14 @@ void GDCMImageIO::InternalReadImageInformation()
+       itkExceptionMacro("Unhandled PixelFormat: " << pixeltype);
+     }
+ 
+-  m_RescaleIntercept = image.GetIntercept();
+-  m_RescaleSlope = image.GetSlope();
++  // GDCM can't handle rescaling of multiple components
++  if (pixeltype.GetSamplesPerPixel() == 1) {
++    m_RescaleIntercept = image.GetIntercept();
++    m_RescaleSlope = image.GetSlope();
++  } else {
++    m_RescaleIntercept = 0.0;
++    m_RescaleSlope = 1.0;
++  }
+   gdcm::Rescaler r;
+   r.SetIntercept(m_RescaleIntercept);
+   r.SetSlope(m_RescaleSlope);
+-- 
+2.9.0.windows.1
+


### PR DESCRIPTION
http://samsmu.net:8083/browse/AUT-2882

Проблема в том, что GDCM не умеет делать rescale RGB-изображениям, и я тоже не совсем понимаю, как это должно быть сделано.
Так что я отключил rescale, если в вокселе больше одного компонента.

Тестовые шаги:

1. Загрузить 0040 исследование.
   - Исследование загружено.