### PR TITLE
Поддержка диффузионных тэгов. Исправление для массива метасловарей

### DIFF
--- a/Modules/Core/include/mitkDicomTagsList.h
+++ b/Modules/Core/include/mitkDicomTagsList.h
@@ -693,6 +693,22 @@ namespace mitk {
     "7fe0|0010", // TAG_PIXEL_DATA
     "0051|100E", // TAG_EX_INFO
     "0018|0050", // TAG_SLICE_THICKNESS
+
+    // Diffusion vendor-specific tags
+    "0043|0010",
+    "0043|1039",
+    "0019|10bb",
+    "0019|10bc",
+    "0019|10bd",
+    "0029|1010",
+    "0018|9087",
+    "0021|1146",
+    "0052|9230",
+    "0018|9117",
+    "0021|9230",
+    "2001|1003",
+    "0018|9087",
+    "0018|9089"
   };
   
   static const std::map<std::string, std::string> tagToPropertyMap = {

--- a/Modules/Core/src/DataManagement/mitkImage.cpp
+++ b/Modules/Core/src/DataManagement/mitkImage.cpp
@@ -52,9 +52,11 @@ mitk::ReaderType::DictionaryArrayType mitk::Image::GetMetaDataDictionaryArray()
   }
 
   int numberSlices = GetLargestPossibleRegion().GetSize()[2];
+  int timeSteps = GetTimeSteps();
+  int numberOfComponents = GetPixelType().GetNumberOfComponents();
   
   //mitk::ReaderType::DictionaryArrayType outputArray;
-  m_MetaDataDictionaryArray.resize(numberSlices);
+  m_MetaDataDictionaryArray.resize(numberSlices * timeSteps * numberOfComponents);
 
   for (unsigned int i = 0; i < m_MetaDataDictionaryArray.size(); ++i)
   {
@@ -66,7 +68,7 @@ mitk::ReaderType::DictionaryArrayType mitk::Image::GetMetaDataDictionaryArray()
   {
     std::string tagkey = dicomTagsList[i];
     mitk::StringLookupTableProperty* tagsValueList =
-    dynamic_cast<mitk::StringLookupTableProperty*>(GetProperty(tagkey.c_str()).GetPointer());
+      dynamic_cast<mitk::StringLookupTableProperty*>(GetProperty(tagkey.c_str()).GetPointer());
 
     for (unsigned int j = 0; j < m_MetaDataDictionaryArray.size(); ++j)
     {


### PR DESCRIPTION
http://samsmu.net:8083/browse/AUT-2910

Требует https://github.com/samsmu/AutoplanApplication/pull/1667 для корректной работы, надо вливать одновременно.

Поддержка диффузионных тэгов.