### PR TITLE
Количество фрагментов в фильтре фрагментов

### DIFF
--- a/Modules/Segmentation/SegmentationUtilities/MorphologicalOperations/mitkMorphologicalOperations.cpp
+++ b/Modules/Segmentation/SegmentationUtilities/MorphologicalOperations/mitkMorphologicalOperations.cpp
@@ -403,7 +403,7 @@ template<typename TPixel, unsigned int VDimension>
 void mitk::MorphologicalOperations::itkRemoveFragments(itk::Image<TPixel, VDimension>* sourceImage, int percent, mitk::Image::Pointer& resultImage)
 {
   typedef itk::Image<TPixel, VDimension> ImageType;
-  typedef itk::Image<unsigned char, VDimension> OutputImageType;
+  typedef itk::Image<unsigned int, VDimension> OutputImageType;
   typedef itk::ConnectedComponentImageFilter<ImageType, OutputImageType> ConnectedComponentImageFilterType;
   typename ConnectedComponentImageFilterType::Pointer connected = ConnectedComponentImageFilterType::New();
   connected->SetInput(sourceImage);
@@ -449,7 +449,7 @@ void mitk::MorphologicalOperations::itkRemoveFragments(itk::Image<TPixel, VDimen
   typedef itk::BinaryThresholdImageFilter< OutputImageType, ImageType > BinaryThresholdImageFilter;
   typename BinaryThresholdImageFilter::Pointer thresholdFilter = BinaryThresholdImageFilter::New();
   thresholdFilter->SetLowerThreshold(1);
-  thresholdFilter->SetUpperThreshold(255);
+  thresholdFilter->SetUpperThreshold(std::numeric_limits<unsigned int>::max());
   thresholdFilter->SetOutsideValue(0);
   thresholdFilter->SetInsideValue(1);
   thresholdFilter->SetInput(labelShapeKeepNObjectsImageFilter->GetOutput());


### PR DESCRIPTION
http://samsmu.net:8083/browse/AUT-2546

Раньше мы использовали unsigned char, из-за этого количество фрагментов не могло превышать 256. Для VR число несвязанных областей может быть гораздо больше, так что теперь мы используем unsigned int.

Тестировать не надо, это dev-задача.