### PR TITLE
Исправление экспорта всех изображений в серии

### DIFF
--- a/Modules/Core/include/mitkTimeGeometry.h
+++ b/Modules/Core/include/mitkTimeGeometry.h
@@ -80,7 +80,7 @@ namespace mitk {
       /**
      *\brief Contains number of components
     */
-    unsigned int componentSize = 0;
+    unsigned int componentSize = 1;
 
     /**
     * \brief Returns the first time point for which the object is valid.


### PR DESCRIPTION
http://samsmu.net:8083/browse/AUT-2991

Задача говорит о цветах, но у нас вообще был сломан экспорт всех изображений серии и всех серий.
Цвета были исправлены чуть раньше, в AUT-2989, это исправило и их экспорт.

Остались известные проблемы: 
http://samsmu.net:8083/browse/AUT-3018
http://samsmu.net:8083/browse/AUT-3019

Тестовые шаги:

1. Загрузить перфузионные данные, построить перфузионные карты.
2. Перейти во вьювер.
3. Экспортировать один срез как картинку.
   - Картинка цветная.
4. Экспортировать все срезы выбранной серии как картинки.
   - Картинки цветные.