### PR TITLE
Исправление инструментов Wipe и Paint

### DIFF
--- a/Modules/Segmentation/Interactions/mitkPaintbrushTool.h
+++ b/Modules/Segmentation/Interactions/mitkPaintbrushTool.h
@@ -58,6 +58,9 @@ class MITKSEGMENTATION_EXPORT PaintbrushTool : public FeedbackContourTool
 
     void SetSize(int value);
 
+    void SetGeometrySlice(const itk::EventObject& geometrySliceEvent);
+    void SetGeometry(const itk::EventObject&) {};
+
   protected:
 
     PaintbrushTool(int paintingPixelValue = 1); // purposely hidden
@@ -75,11 +78,13 @@ class MITKSEGMENTATION_EXPORT PaintbrushTool : public FeedbackContourTool
     virtual void OnMouseReleased( StateMachineAction*, InteractionEvent* );
     virtual void OnInvertLogic  ( StateMachineAction*, InteractionEvent* );
 
+    void MouseMovedImpl(const mitk::PlaneGeometry* planeGeometry, bool leftMouseButtonPressed);
+
     /**
      * \todo This is a possible place where to introduce
      *       different types of pens
      */
-    void UpdateContour( const InteractionPositionEvent* );
+    void UpdateContour();
 
 
     /**
@@ -90,7 +95,7 @@ class MITKSEGMENTATION_EXPORT PaintbrushTool : public FeedbackContourTool
     /**
       * Checks  if the current slice has changed
       */
-    void CheckIfCurrentSliceHasChanged(const InteractionPositionEvent* event);
+    void CheckIfCurrentSliceHasChanged(const mitk::PlaneGeometry* planeGeometry);
 
     void OnToolManagerWorkingDataModified();
     void OnToolManagerImageModified(const itk::EventObject&);
@@ -108,6 +113,8 @@ class MITKSEGMENTATION_EXPORT PaintbrushTool : public FeedbackContourTool
     mitk::Point3D m_LastPosition;
     Image::Pointer m_WorkingImage;
     int m_ImageObserverTag;
+    int m_LastTimeStep;
+    Point3D m_LastWorldCoordinates;
 };
 
 } // namespace


### PR DESCRIPTION
http://samsmu.net:8083/browse/AUT-2277

Тестовые шаги:

1. Загрузить данные с сегментациями в универсальный кейс.
2. Открыть плагин Segmentation, активировать инструмент Wipe.
3. Увеличить его радиус, чтобы его было лучше видно.
4. Пролистать срезы колесиком мыши.
   - На каждом новом срезе круг инструмента по-прежнему видно на предыдущем месте.
   - Инструмент работает как надо.
5. Проверить то же самое для инструмента Paint.
