### PR TITLE
Убраны аннотации для изображений. AUT-3017

### DIFF
--- a/Modules/QtWidgets/src/QmitkStdMultiWidget.cpp
+++ b/Modules/QtWidgets/src/QmitkStdMultiWidget.cpp
@@ -1691,8 +1691,10 @@ void QmitkStdMultiWidget::HandleCrosshairPositionEventDelayed()
       mainProp ? mainProp->GetValue() : 2
     };
 
+    bool imageIsFlat = image->GetDimension(2) < 2 && seriesNumber == "";
+
     for(int i = 0; i < 3; i++) {
-      if (m_displayPositionInfo) {
+      if (m_displayPositionInfo && !imageIsFlat) {
         _infoStringStream[axisIndices[i]] << "Im: " << (p[i] + 1) << "/" << bounds[(i*2 + 1)];
         if (timeSteps > 1) {
           _infoStringStream[axisIndices[i]]<< "\nT: " << (timestep + 1) << "/" << timeSteps;


### PR DESCRIPTION
http://samsmu.net:8083/browse/AUT-3017

Теперь при просмотре обычных изображений (например формата png) в редакторе, у них не отображаются аннотации.

Это часть изменений по AUT-3017

1. Открыть картинку при помощи автоплана
ER: У картинки не отображаются аннотации