### PR TITLE
Исправление itk-предупреждений при закрытии

### DIFF
--- a/Modules/Core/include/mitkTransferFunctionPresetManager.h
+++ b/Modules/Core/include/mitkTransferFunctionPresetManager.h
@@ -24,7 +24,15 @@ struct TransferFunctionPreset
 class MITKCORE_EXPORT TransferFunctionPresetManager : public itk::Object
 {
 public:
-  mitkClassMacroItkParent(TransferFunctionPresetManager, itk::Object);
+  typedef TransferFunctionPresetManager Self;
+  typedef itk::ObjectFactoryBase  Superclass;
+  typedef itk::SmartPointer<Self>  Pointer;
+  typedef itk::SmartPointer<const Self>  ConstPointer;
+
+  itkTypeMacro(TransferFunctionPresetManager, itk::Object);
+  itkFactorylessNewMacro(Self);
+
+  //mitkClassMacroItkParent(TransferFunctionPresetManager, itk::Object);
 
   //Define Transfer Function
   enum TransferFunctionMode
@@ -64,6 +72,16 @@ private:
   std::vector<std::string> m_presetNames;
   std::vector<TransferFunctionPreset> m_presetPoints;
 };
+
+class TransferFunctionPresetManagerHolder
+{
+public:
+  TransferFunctionPresetManagerHolder();
+  ~TransferFunctionPresetManagerHolder();
+
+  TransferFunctionPresetManager::Pointer m_tfpm;
+};
+
 }
 
 #endif /* MITK_TRANSFER_FUNCTION_PRESET_MANAGER_H_HEADER_INCLUDED */

--- a/Modules/Core/src/DataManagement/mitkTransferFunctionPresetManager.cpp
+++ b/Modules/Core/src/DataManagement/mitkTransferFunctionPresetManager.cpp
@@ -165,10 +165,24 @@ const mitk::TransferFunctionPreset presetMrGeneric = {
 
 namespace mitk
 {
+
+TransferFunctionPresetManagerHolder tfpmHolder;
+
+TransferFunctionPresetManagerHolder::TransferFunctionPresetManagerHolder()
+  : m_tfpm(TransferFunctionPresetManager::New().GetPointer())
+{
+
+}
+
+TransferFunctionPresetManagerHolder::~TransferFunctionPresetManagerHolder()
+{
+
+}
+
+
 TransferFunctionPresetManager& TransferFunctionPresetManager::GetInstance()
 {
-  static TransferFunctionPresetManager instance;
-  return instance;
+  return *tfpmHolder.m_tfpm;
 }
 
 TransferFunctionPresetManager::TransferFunctionPresetManager()

--- a/Modules/ToFHardware/KinectV2/mitkKinectV2DeviceFactory.h
+++ b/Modules/ToFHardware/KinectV2/mitkKinectV2DeviceFactory.h
@@ -38,7 +38,7 @@ namespace mitk
   * This offers users the oppertunity to generate new KinectDevices via a global instance of this factory.
   * @ingroup ToFHardware
   */
-  class MITKKINECTV2_EXPORT KinectV2DeviceFactory : public itk::LightObject, public AbstractToFDeviceFactory {
+  class MITKKINECTV2_EXPORT KinectV2DeviceFactory : public AbstractToFDeviceFactory {
 
   public:
 


### PR DESCRIPTION
http://samsmu.net:8083/browse/AUT-2728

itk::Object и его наследники очень не любят быть глобальными объектами и вообще существовать вне системы itk-указателей. У них сбивается счетчик ссылок и они страдают в деструкторе.

Перенес один объект в глобальный холдер, другой сделал не itk-объектом (это все равно не использовалось).

Полностью предупреждения уйдут после еще одного ПР в Автоплане: https://github.com/samsmu/AutoplanApplication/pull/1745

Тестовые шаги:

1. Запустить Автоплан, 
2. Перейти во вьювер.
3. Перейти в универсальный кейс.
4. Открыть плагин трекинга.
5. Закрыть Автоплан.
   - В консоли нет предупреждений вида 
```
[ItkLogging] WARNING: In /home/sergio/src/autoplan/SB0/MITK-superbuild/ep/src/ITK/Modules/Core/Common/src/itkLightObject.cxx, line 206
LightObject (0x7fffefee1cc0): Trying to delete object with non-zero reference count.
```
