### PR TITLE
Инструменты сегментации. Mouse Wraparound в 2D Region Growing

### DIFF
--- a/Modules/Segmentation/Interactions/mitkRegionGrowingTool.cpp
+++ b/Modules/Segmentation/Interactions/mitkRegionGrowingTool.cpp
@@ -285,10 +285,13 @@ void mitk::RegionGrowingTool::OnMousePressed ( StateMachineAction*, InteractionE
 
     //cursor position
     POINT p;
-    if (GetCursorPos(&p)) {
+    if (GetCursorPos(&p))
+    {
       m_LastScreenPosition[0] = p.x;
       m_LastScreenPosition[1] = p.y;
-    } else {
+    }
+    else
+    {
       // but why
       MITK_WARN("Failed to get cursor position");
     }


### PR DESCRIPTION
Поправил переход мыши по экрану по кругу
Инвертировал ось Y, чтобы + был вверху
Уменьшил коэфициент, чтоб было поточнее

http://jira.samsmu.net:8083/browse/AUT-2838