### PR TITLE
Preferences dialog delete Qt::WindowContextHelpButtonHint flag

### DIFF
--- a/Plugins/org.mitk.gui.qt.application/src/QmitkPreferencesDialog.cpp
+++ b/Plugins/org.mitk.gui.qt.application/src/QmitkPreferencesDialog.cpp
@@ -205,6 +205,8 @@ QmitkPreferencesDialog::QmitkPreferencesDialog(QWidget * parent, Qt::WindowFlags
   this->UpdateTree();
 
   activeDialog = this;
+  
+  setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 }
 
 QmitkPreferencesDialog::~QmitkPreferencesDialog()


### PR DESCRIPTION
Убирает знак вопроса в заголовке окна с настройками.

http://samsmu.net:8083/browse/AUT-2686