### PR TITLE
Исправление прогресс-бара при сохранении МИТК-проекта

### DIFF
--- a/Modules/Core/include/mitkProgressBar.h
+++ b/Modules/Core/include/mitkProgressBar.h
@@ -69,6 +69,8 @@ namespace mitk
     //## @brief Sets whether the current progress value is displayed.
     void SetPercentageVisible (bool visible);
 
+    bool IsProgressBarActive() const;
+
   protected:
 
     typedef std::vector< ProgressBarImplementation* > ProgressBarImplementationsList;

--- a/Modules/Core/include/mitkProgressBarImplementation.h
+++ b/Modules/Core/include/mitkProgressBarImplementation.h
@@ -53,6 +53,8 @@ namespace mitk
     //## @brief Sets the current amount of progress to current progress + steps.
     //## @param steps the number of steps done since last Progress(int steps) call.
     virtual void Progress(unsigned int steps) =0;
+
+    virtual bool active() = 0;
   };
 
 }// end namespace mitk

--- a/Modules/Core/src/Controllers/mitkProgressBar.cpp
+++ b/Modules/Core/src/Controllers/mitkProgressBar.cpp
@@ -138,6 +138,19 @@ namespace mitk
     }
   }
 
+  bool ProgressBar::IsProgressBarActive() const
+  {
+    for (auto impl : m_Implementations) 
+    {
+      if (impl->active())
+      {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   ProgressBar::ProgressBar()
   {
   }

--- a/Modules/Core/src/IO/mitkIOUtil.cpp
+++ b/Modules/Core/src/IO/mitkIOUtil.cpp
@@ -953,7 +953,10 @@ std::string IOUtil::Save(std::vector<SaveInfo>& saveInfos, WriterOptionsFunctorB
   }
 
   int filesToWrite = saveInfos.size();
-  mitk::ProgressBar::GetInstance()->AddStepsToDo(2*filesToWrite);
+
+  if (!mitk::ProgressBar::GetInstance()->IsProgressBarActive()) {
+    mitk::ProgressBar::GetInstance()->AddStepsToDo(2 * filesToWrite);
+  }
 
   std::string errMsg;
 
@@ -967,6 +970,9 @@ std::string IOUtil::Save(std::vector<SaveInfo>& saveInfos, WriterOptionsFunctorB
     if (writers.empty())
     {
       errMsg += std::string("No writer available for ") + baseDataType + " data.\n";
+      if (!mitk::ProgressBar::GetInstance()->IsProgressBarActive()) {
+        mitk::ProgressBar::GetInstance()->Progress(2 * filesToWrite);
+      }
       continue;
     }
 
@@ -1018,6 +1024,10 @@ std::string IOUtil::Save(std::vector<SaveInfo>& saveInfos, WriterOptionsFunctorB
     if (saveInfo.m_Cancel)
     {
       errMsg += "Writing operation(s) cancelled.";
+      if (!mitk::ProgressBar::GetInstance()->IsProgressBarActive()) {
+        mitk::ProgressBar::GetInstance()->Progress(2 * filesToWrite);
+      }
+
       break;
     }
 
@@ -1025,6 +1035,10 @@ std::string IOUtil::Save(std::vector<SaveInfo>& saveInfos, WriterOptionsFunctorB
     if (writer == NULL)
     {
       errMsg += "Unexpected NULL writer.";
+      if (!mitk::ProgressBar::GetInstance()->IsProgressBarActive()) {
+        mitk::ProgressBar::GetInstance()->Progress(2 * filesToWrite);
+      }
+
       break;
     }
 
@@ -1038,7 +1052,9 @@ std::string IOUtil::Save(std::vector<SaveInfo>& saveInfos, WriterOptionsFunctorB
     {
       errMsg += std::string("Exception occurred when writing to ") + saveInfo.m_Path + ":\n" + e.what() + "\n";
     }
-    mitk::ProgressBar::GetInstance()->Progress(2);
+    if (!mitk::ProgressBar::GetInstance()->IsProgressBarActive()) {
+      mitk::ProgressBar::GetInstance()->Progress(2);
+    }
     --filesToWrite;
   }
 
@@ -1046,8 +1062,6 @@ std::string IOUtil::Save(std::vector<SaveInfo>& saveInfos, WriterOptionsFunctorB
   {
     MITK_ERROR << errMsg;
   }
-
-  mitk::ProgressBar::GetInstance()->Progress(2*filesToWrite);
 
   return errMsg;
 }

--- a/Modules/QtWidgets/include/QmitkProgressBar.h
+++ b/Modules/QtWidgets/include/QmitkProgressBar.h
@@ -60,6 +60,7 @@ public:
   //## @param: steps the number of steps done since last Progress(int steps) call.
   virtual void Progress(unsigned int steps) override;
 
+  virtual bool active() override;
 signals:
 
   void SignalAddStepsToDo(unsigned int steps);

--- a/Modules/QtWidgets/src/QmitkProgressBar.cpp
+++ b/Modules/QtWidgets/src/QmitkProgressBar.cpp
@@ -172,3 +172,8 @@ void QmitkProgressBar::SlotOnTimeout()
 
   QApplication::processEvents();
 }
+
+bool QmitkProgressBar::active()
+{
+  return m_TotalSteps > 0;
+}

--- a/Modules/SceneSerialization/src/mitkSceneIO.cpp
+++ b/Modules/SceneSerialization/src/mitkSceneIO.cpp
@@ -283,6 +283,8 @@ bool mitk::SceneIO::SaveScene( DataStorage::SetOfObjects::ConstPointer sceneNode
 
     //DataStorage::SetOfObjects::ConstPointer sceneNodes = storage->GetSubset( predicate );
 
+    int compressSteps = sceneNodes->size() / 3;
+
     if ( sceneNodes.IsNull() )
     {
       MITK_WARN << "Saving empty scene to " << filename;
@@ -304,6 +306,11 @@ bool mitk::SceneIO::SaveScene( DataStorage::SetOfObjects::ConstPointer sceneNode
       }
 
       ProgressBar::GetInstance()->AddStepsToDo( sceneNodes->size() );
+      if (compress)
+      {
+        ProgressBar::GetInstance()->AddStepsToDo(compressSteps);
+      }
+
 
       // find out about dependencies
       typedef std::map< DataNode*, std::string > UIDMapType;
@@ -522,6 +529,8 @@ bool mitk::SceneIO::SaveScene( DataStorage::SetOfObjects::ConstPointer sceneNode
             zipper.addRecursive(tmpdir);
             zipper.close();
           }
+
+          ProgressBar::GetInstance()->Progress(compressSteps);
         }
         else
         {


### PR DESCRIPTION
http://samsmu.net:8083/browse/AUT-3067

Во-первых, теперь мы не добавляем дополнительные шаги в прогресс-бар в самом сохранении, если там уже есть какие-то шаги.
Во-вторых, я расширил прогресс-бар на архивацию, теперь он не заканчивается раньше времени.

Тестовые шаги:

1. Загрузить данные в универсальный кейс.
2. Сохранить МИТК-проект.
   - Прогресс-бар идет от начала до конца и заканчивается вместе с сохранением.