### PR TITLE
Added support unsigned char image AUT-2842

### DIFF
--- a/Modules/Segmentation/Interactions/mitkFastMarchingTool3D.h
+++ b/Modules/Segmentation/Interactions/mitkFastMarchingTool3D.h
@@ -132,6 +132,8 @@ class MITKSEGMENTATION_EXPORT FastMarchingTool3D : public AutoSegmentationTool
     /// \brief Reset all relevant inputs of the itk pipeline.
     void Reset();
 
+    mitk::Image::Pointer getImageAtCurrentTimeStep(mitk::Image::Pointer workingImage);
+
     mitk::ToolCommand::Pointer m_ProgressCommand;
 
     Image::Pointer m_ReferenceImage;


### PR DESCRIPTION
http://samsmu.net:8083/browse/AUT-2842

Плагин Сегментация. 
Инструмент Fast Marching 3D не принимал изображения с типом usigned char (которые создаются в segmanager), поэтому была добавлена поддержка таких изображений.

Не удалось решить проблему через шаблон, так как в алгоритме используется фильтр itk::OrImageFilter целочисленный тип (принудительный каст не работает). Поэтому было реализовано для конкретных типов (unsigned char и label).
 