### PR TITLE
Финальный фикс для прогресс-бара

### DIFF
--- a/Modules/QtWidgets/include/QmitkProgressBar.h
+++ b/Modules/QtWidgets/include/QmitkProgressBar.h
@@ -89,6 +89,7 @@ private:
 
   QTimer* m_timer;
   bool m_pulce;
+  bool m_Active;
 };
 
 #endif /* define QMITKPROGRESSBAR_H */

--- a/Modules/QtWidgets/src/QmitkProgressBar.cpp
+++ b/Modules/QtWidgets/src/QmitkProgressBar.cpp
@@ -39,6 +39,7 @@ void QmitkProgressBar::Reset()
   m_TotalSteps = 0;
   m_Progress = 0;
   m_pulce = false;
+  m_Active = false;
 }
 
 /**
@@ -55,6 +56,7 @@ void QmitkProgressBar::SetPercentageVisible(bool visible)
  */
 void QmitkProgressBar::AddStepsToDo(unsigned int steps)
 {
+  m_Active = true;
   emit SignalAddStepsToDo(steps);
 }
 
@@ -73,6 +75,7 @@ QmitkProgressBar::QmitkProgressBar(QWidget * parent, const char *  /*name*/)
 :QProgressBar(parent), ProgressBarImplementation()
 {
   m_TotalSteps = 0; m_Progress = 0;
+  m_Active = false;
   this->hide();
   this->SetPercentageVisible(true);
 
@@ -175,5 +178,5 @@ void QmitkProgressBar::SlotOnTimeout()
 
 bool QmitkProgressBar::active()
 {
-  return m_TotalSteps > 0;
+  return m_Active;
 }


### PR DESCRIPTION
http://samsmu.net:8083/browse/AUT-3067

Из-за сигнал-слотов прогресс-бар считался запущенным позже, чем надо.

Тестовые шаги:

1. Открыть МИТК-проект.
2. Сохранить его.
   - Прогресс-бар дошел до конца.