### PR TITLE
Fix crash boolen operation

### DIFF
--- a/Modules/Segmentation/SegmentationUtilities/BooleanOperations/mitkBooleanOperation.cpp
+++ b/Modules/Segmentation/SegmentationUtilities/BooleanOperations/mitkBooleanOperation.cpp
@@ -14,6 +14,8 @@ See LICENSE.txt or http://www.mitk.org for details.
 
 ===================================================================*/
 
+#include <exception>
+
 #include "mitkBooleanOperation.h"
 #include <mitkExceptionMacro.h>
 #include <mitkImageCast.h>
@@ -109,6 +111,7 @@ mitk::LabelSetImage::Pointer mitk::BooleanOperation::GetDifference() const
   notFilter->SetInput(input2);
 
   auto andFilter = itk::AndImageFilter<ImageType, ImageType>::New();
+
   andFilter->SetInput1(input1);
   andFilter->SetInput2(notFilter->GetOutput());
 
@@ -131,6 +134,7 @@ mitk::LabelSetImage::Pointer mitk::BooleanOperation::GetIntersection() const
   auto input2 = CastTo3DItkImage(m_SegmentationB, m_Time);
 
   auto andFilter = itk::AndImageFilter<ImageType, ImageType>::New();
+
   andFilter->SetInput1(input1);
   andFilter->SetInput2(input2);
 
@@ -153,6 +157,7 @@ mitk::LabelSetImage::Pointer mitk::BooleanOperation::GetUnion() const
   auto input2 = CastTo3DItkImage(m_SegmentationB, m_Time);
 
   auto orFilter = itk::OrImageFilter<ImageType, ImageType>::New();
+
   orFilter->SetInput1(input1);
   orFilter->SetInput2(input2);
 

--- a/Modules/Segmentation/SegmentationUtilities/BooleanOperations/mitkBooleanOperation.cpp
+++ b/Modules/Segmentation/SegmentationUtilities/BooleanOperations/mitkBooleanOperation.cpp
@@ -14,8 +14,6 @@ See LICENSE.txt or http://www.mitk.org for details.
 
 ===================================================================*/
 
-#include <exception>
-
 #include "mitkBooleanOperation.h"
 #include <mitkExceptionMacro.h>
 #include <mitkImageCast.h>
@@ -111,7 +109,6 @@ mitk::LabelSetImage::Pointer mitk::BooleanOperation::GetDifference() const
   notFilter->SetInput(input2);
 
   auto andFilter = itk::AndImageFilter<ImageType, ImageType>::New();
-
   andFilter->SetInput1(input1);
   andFilter->SetInput2(notFilter->GetOutput());
 
@@ -134,7 +131,6 @@ mitk::LabelSetImage::Pointer mitk::BooleanOperation::GetIntersection() const
   auto input2 = CastTo3DItkImage(m_SegmentationB, m_Time);
 
   auto andFilter = itk::AndImageFilter<ImageType, ImageType>::New();
-
   andFilter->SetInput1(input1);
   andFilter->SetInput2(input2);
 
@@ -157,7 +153,6 @@ mitk::LabelSetImage::Pointer mitk::BooleanOperation::GetUnion() const
   auto input2 = CastTo3DItkImage(m_SegmentationB, m_Time);
 
   auto orFilter = itk::OrImageFilter<ImageType, ImageType>::New();
-
   orFilter->SetInput1(input1);
   orFilter->SetInput2(input2);
 

--- a/Plugins/org.mitk.gui.qt.segmentation/src/internal/SegmentationUtilities/BooleanOperations/QmitkBooleanOperationsWidget.cpp
+++ b/Plugins/org.mitk.gui.qt.segmentation/src/internal/SegmentationUtilities/BooleanOperations/QmitkBooleanOperationsWidget.cpp
@@ -128,7 +128,9 @@ void QmitkBooleanOperationsWidget::DoBooleanOperation(mitk::BooleanOperation::Ty
     mitk::BooleanOperation booleanOperation(type, segmentationA, segmentationB, timeNavigationController->GetTime()->GetPos());
     result = booleanOperation.GetResult();
 
-    assert(result.IsNotNull());
+    if (!result.IsNotNull()){
+      return;
+    }
 
     auto dataSelectionWidget = m_Controls.dataSelectionWidget;
 
@@ -138,9 +140,9 @@ void QmitkBooleanOperationsWidget::DoBooleanOperation(mitk::BooleanOperation::Ty
       GetPrefix(type) + dataSelectionWidget->GetSelection(1)->GetName(),
       dataSelectionWidget->GetSelection(0));
   }
-  catch (const mitk::Exception& exception)
+  catch (const std::exception& exp)
   {
-    MITK_ERROR << "Boolean operation failed: " << exception.GetDescription();
-    QMessageBox::information(nullptr, "Boolean operation failed", exception.GetDescription());
+    MITK_ERROR << "Boolean operation failed: " << exp.what();
+    QMessageBox::information(nullptr, "Boolean operation failed", exp.what());
   }
 }

--- a/Plugins/org.mitk.gui.qt.segmentation/src/internal/SegmentationUtilities/BooleanOperations/QmitkBooleanOperationsWidget.cpp
+++ b/Plugins/org.mitk.gui.qt.segmentation/src/internal/SegmentationUtilities/BooleanOperations/QmitkBooleanOperationsWidget.cpp
@@ -14,13 +14,16 @@ See LICENSE.txt or http://www.mitk.org for details.
 
 ===================================================================*/
 
+#include <exception>
+#include <cassert>
+
+#include <QMessageBox>
+#include <QWidget>
+
 #include "QmitkBooleanOperationsWidget.h"
 #include "../../Common/QmitkDataSelectionWidget.h"
 #include <mitkException.h>
 #include <mitkSliceNavigationController.h>
-#include <cassert>
-#include <QMessageBox>
-#include <QWidget>
 
 static QString const HelpText = QWidget::tr("Select two different segmentations above");
 
@@ -128,7 +131,7 @@ void QmitkBooleanOperationsWidget::DoBooleanOperation(mitk::BooleanOperation::Ty
     mitk::BooleanOperation booleanOperation(type, segmentationA, segmentationB, timeNavigationController->GetTime()->GetPos());
     result = booleanOperation.GetResult();
 
-    if (!result.IsNotNull()){
+    if (result.IsNull()){
       return;
     }
 


### PR DESCRIPTION
  Исправляет падение Автоплана, при использовании булевых операций в плагине Segmentation. Это первая часть изменений. Вторая часть будет заключаться в написании собственного фильтра для булевых операций над сегментациями. Она будет выполняться в рамках отдельной задачи.

http://samsmu.net:8083/browse/AUT-2836