### PR TITLE
Reworks vtk corner annotation font size fitting. AUT-3257 [clean]

### DIFF
--- a/CMakeExternals/VTK.cmake
+++ b/CMakeExternals/VTK.cmake
@@ -87,6 +87,7 @@ if(NOT DEFINED VTK_DIR)
     URL ${VTK_URL}
     URL_MD5 ${VTK_URL_MD5}
     PATCH_COMMAND ${PATCH_COMMAND} -N -p1 -i ${CMAKE_CURRENT_LIST_DIR}/VTK.patch
+	    COMMAND ${PATCH_COMMAND} -N -p1 -i ${CMAKE_CURRENT_LIST_DIR}/VtkCornerAnnotation.patch
     CMAKE_GENERATOR ${gen}
     CMAKE_ARGS
         ${ep_common_args}

--- a/CMakeExternals/VtkCornerAnnotation.patch
+++ b/CMakeExternals/VtkCornerAnnotation.patch
@@ -1,0 +1,231 @@
+diff --git a/Rendering/Annotation/vtkCornerAnnotation.cxx b/Rendering/Annotation/vtkCornerAnnotation.cxx
+--- a/Rendering/Annotation/vtkCornerAnnotation.cxx
++++ b/Rendering/Annotation/vtkCornerAnnotation.cxx
+@@ -383,8 +383,6 @@
+ //----------------------------------------------------------------------------
+ int vtkCornerAnnotation::RenderOpaqueGeometry(vtkViewport *viewport)
+ {
+-  int fontSize;
+-
+   // Check to see whether we have to rebuild everything
+   // If the viewport has changed we may - or may not need
+   // to rebuild, it depends on if the projected coords chage
+@@ -457,12 +455,12 @@
+       // Perform shallow copy here since each individual corner has a
+       // different aligment/size but they share the other this->TextProperty
+       // attributes.
+-      fontSize = this->TextMapper[0]->GetTextProperty()->GetFontSize();
+-
+       if (tprop_has_changed)
+         {
+         for (int i = 0; i < NumTextPositions; i++)
+           {
++          int fontSize = this->TextMapper[i]->GetTextProperty()->GetFontSize();
++
+           vtkTextProperty *tprop = this->TextMapper[i]->GetTextProperty();
+           tprop->ShallowCopy(this->TextProperty);
+           tprop->SetFontSize(fontSize);
+@@ -483,12 +481,12 @@
+           +---------+
+       */
+ 
+-      int tempi[2*NumTextPositions];
++      int tempi[2 * NumTextPositions];
+       int allZeros = 1;
+       for (int i = 0; i < NumTextPositions; i++)
+         {
+         this->TextMapper[i]->GetSize(viewport, tempi + i * 2);
+-        if (tempi[2*i] > 0 || tempi[2*i+1] > 0)
++        if (tempi[2 * i] > 0 || tempi[2 * i + 1] > 0)
+           {
+           allZeros = 0;
+           }
+@@ -499,115 +497,24 @@
+         return 0;
+         }
+ 
+-      int height_02 = tempi[1] + tempi[5];  // total height of text in left top/bottom corners
+-      int height_13 = tempi[3] + tempi[7];  // total height of text in right top/bottom corners
+-      int height_47 = tempi[9] + tempi[15]; // total height of text at center of top/bottom edges
+-
+-      int width_01 = tempi[0] + tempi[2];   // total width of text on botttom left/right corners
+-      int width_23 = tempi[4] + tempi[6];   // total width of text on top left/right corners
+-      int width_56 = tempi[10] + tempi[12]; // total width of text at center of left/right edges
+-
+-      int max_width_corners = (width_01 > width_23) ? width_01 : width_23;
+-      int max_width         = (width_56 > max_width_corners) ? width_56 : max_width_corners;
+-
+-      int num_lines_02 = GetNumberOfLines(this->TextMapper[0]->GetInput())
+-          + GetNumberOfLines(this->TextMapper[2]->GetInput());
+-
+-      int num_lines_13 = GetNumberOfLines(this->TextMapper[1]->GetInput())
+-          + GetNumberOfLines(this->TextMapper[3]->GetInput());
+-
+-      int num_lines_47 = GetNumberOfLines(this->TextMapper[4]->GetInput())
+-          + GetNumberOfLines(this->TextMapper[7]->GetInput());
+-
+-      int line_max_02 = (int)(vSize[1] * this->MaximumLineHeight) *
+-        (num_lines_02 ? num_lines_02 : 1);
+-
+-      int line_max_13 = (int)(vSize[1] * this->MaximumLineHeight) *
+-        (num_lines_13 ? num_lines_13 : 1);
+-
+-      int line_max_47 = (int)(vSize[1] * this->MaximumLineHeight) *
+-        (num_lines_47 ? num_lines_47 : 1);
+-
+-      // Target size is to use 90% of x and y
+-
+-      int tSize[2];
+-      tSize[0] = (int)(0.9*vSize[0]);
+-      tSize[1] = (int)(0.9*vSize[1]);
+-
+-      // While the size is too small increase it
+-
+-      while (height_02 < tSize[1] &&
+-             height_13 < tSize[1] &&
+-             height_47 < tSize[1] &&
+-             max_width < tSize[0] &&
+-             height_02 < line_max_02 &&
+-             height_13 < line_max_13 &&
+-             height_47 < line_max_47 &&
+-             fontSize < 100)
+-        {
+-        fontSize++;
+-        for (int i = 0; i < NumTextPositions; i++)
+-          {
+-          this->TextMapper[i]->GetTextProperty()->SetFontSize(fontSize);
+-          this->TextMapper[i]->GetSize(viewport, tempi + i * 2);
+-          }
+-        height_02 = tempi[1] + tempi[5];
+-        height_13 = tempi[3] + tempi[7];
+-        height_47 = tempi[9] + tempi[15];
+-
+-        width_01 = tempi[0] + tempi[2];
+-        width_23 = tempi[4] + tempi[6];
+-        width_56 = tempi[10] + tempi[12];
+-
+-        max_width_corners = (width_01 > width_23) ? width_01 : width_23;
+-        max_width         = (width_56 > max_width_corners) ? width_56 : max_width_corners;
+-        }
+-
+-      // While the size is too large decrease it
++      int* desiredFonts = getBestFitFont(viewport);
+ 
+-      while ((height_02 > tSize[1] ||
+-              height_13 > tSize[1] ||
+-              height_47 > tSize[1] ||
+-              max_width > tSize[0] ||
+-              height_02 > line_max_02 ||
+-              height_13 > line_max_13 ||
+-              height_47 > line_max_47) &&
+-             fontSize > 0)
++      for (int i = 0; i < NumTextPositions; i++)
+         {
+-        fontSize--;
+-        for (int i = 0; i < NumTextPositions; i++)
++        desiredFonts[i] = static_cast<int>(pow((double)desiredFonts[i], NonlinearFontScaleFactor)*LinearFontScaleFactor);
++        if (desiredFonts[i] > this->MaximumFontSize)
+           {
+-          this->TextMapper[i]->GetTextProperty()->SetFontSize(fontSize);
+-          this->TextMapper[i]->GetSize(viewport, tempi + i * 2);
++          desiredFonts[i] = this->MaximumFontSize;
+           }
+-        height_02 = tempi[1] + tempi[5];
+-        height_13 = tempi[3] + tempi[7];
+-        height_47 = tempi[9] + tempi[15];
+-
+-        width_01 = tempi[0] + tempi[2];
+-        width_23 = tempi[4] + tempi[6];
+-        width_56 = tempi[10] + tempi[12];
+ 
+-        max_width_corners = (width_01 > width_23) ? width_01 : width_23;
+-        max_width         = (width_56 > max_width_corners) ? width_56 : max_width_corners;
+-        }
+-
+-      fontSize = static_cast<int>(pow((double)fontSize,
+-              NonlinearFontScaleFactor)*LinearFontScaleFactor);
+-      if (fontSize > this->MaximumFontSize)
+-        {
+-        fontSize = this->MaximumFontSize;
+-        }
+-      this->FontSize = fontSize;
+-      for (int i = 0; i < NumTextPositions; i++)
+-        {
+-        this->TextMapper[i]->GetTextProperty()->SetFontSize(fontSize);
++        this->TextMapper[i]->GetTextProperty()->SetFontSize(desiredFonts[i]);
+         }
+ 
+       // Now set the position of the TextActors
+-
+       this->SetTextActorsPosition(vSize);
+ 
++      delete[] desiredFonts;
++
+       for (int i = 0; i < NumTextPositions; i++)
+         {
+         this->TextActor[i]->SetProperty(this->GetProperty());
+@@ -630,6 +537,52 @@
+   return 1;
+ }
+ 
++int* vtkCornerAnnotation::getBestFitFont(vtkViewport* viewport)
++{
++  int *vSize = viewport->GetSize();
++
++  // Get previous fonts sizes
++  int* fonts = new int[NumTextPositions];
++  for (int i = 0; i < NumTextPositions; i++)
++    {
++    fonts[i] = this->TextMapper[i]->GetTextProperty()->GetFontSize();
++    }
++
++  // Set target size to a little bit less of half a vieport size. 
++  int tSize[2];
++  tSize[0] = (int)(0.45*vSize[0]);
++  tSize[1] = (int)(0.45*vSize[1]);
++  int annSize[2] = { 0, 0 };
++
++  // For each corener annotation find best font size
++  for (int i = 0; i < NumTextPositions; i++)
++    {
++    this->TextMapper[i]->GetSize(viewport, annSize);
++
++    // Increase font size until big enough
++    while (annSize[0] < tSize[0] &&
++     annSize[1] < tSize[1] &&
++     fonts[i] < 100)
++      {
++      fonts[i]++;
++      this->TextMapper[i]->GetTextProperty()->SetFontSize(fonts[i]);
++      this->TextMapper[i]->GetSize(viewport, annSize);
++      }
++
++    // Decrease font size until fit
++    while ((annSize[0] > tSize[0] ||
++     annSize[1] > tSize[1]) &&
++     fonts[i] > 0)
++      {
++      fonts[i]--;
++      this->TextMapper[i]->GetTextProperty()->SetFontSize(fonts[i]);
++      this->TextMapper[i]->GetSize(viewport, annSize);
++      }
++    }
++
++  return fonts;
++}
++
+ //-----------------------------------------------------------------------------
+ // Description:
+ // Does this prop have some translucent polygonal geometry?
+diff --git a/Rendering/Annotation/vtkCornerAnnotation.h b/Rendering/Annotation/vtkCornerAnnotation.h
+index ecfae31..11e7fad 100644
+--- a/Rendering/Annotation/vtkCornerAnnotation.h
++++ b/Rendering/Annotation/vtkCornerAnnotation.h
+@@ -195,6 +195,7 @@
+ private:
+   vtkCornerAnnotation(const vtkCornerAnnotation&);  // Not implemented.
+   void operator=(const vtkCornerAnnotation&);  // Not implemented.
++  int* getBestFitFont(vtkViewport* viewport);
+ };
+ 
+ 


### PR DESCRIPTION
http://samsmu.net:8083/browse/AUT-3257

Теперь для каждой угловой анотации расчитывается свой наиболее подходящий размер шрифта. Это позволяет не менять размер шрифта одной из угловой сегментации при нехватки места у других.

1. Открыть исследование 0003
2. Включить аннотации с дополнительной информацией
3. Выбрать серию body и потом перейти на серию arterial
ER: Уменьшается шрифт только той угловой аннотации, которой это было необходимо.