### PR TITLE
Adds model opacity property for mitk filter. AUT-3344

### DIFF
--- a/Modules/Core/src/DataManagement/mitkPropertyList.cpp
+++ b/Modules/Core/src/DataManagement/mitkPropertyList.cpp
@@ -68,6 +68,7 @@ void mitk::PropertyList::SetProperty(const std::string& propertyKey, BasePropert
                  << " to a property with different type " << property->GetNameOfClass() << "."
                  << " Use ReplaceProperty() instead."
                  << std::endl;
+      assert(false);
     }
     return;
   }

--- a/Modules/Segmentation/Algorithms/mitkShowSegmentationAsSurface.cpp
+++ b/Modules/Segmentation/Algorithms/mitkShowSegmentationAsSurface.cpp
@@ -55,6 +55,7 @@ void ShowSegmentationAsSurface::Initialize(const NonBlockingAlgorithm* other)
   SetParameter("Decimation rate", 0.2f );
   SetParameter("Wireframe", false );
   SetParameter("Creation type", 0u );
+  SetParameter("Model Opacity", 1.0f);
 }
 
 
@@ -177,7 +178,10 @@ void ShowSegmentationAsSurface::ThreadedUpdateSuccessful()
       np->SetRepresentationToWireframe();
   }
 
-  m_Node->SetProperty("opacity", FloatProperty::New(1.0) );
+  float opacity;
+  GetParameter("Model Opacity", opacity);
+
+  m_Node->SetProperty("opacity", FloatProperty::New(opacity) );
   m_Node->SetProperty("line width", IntProperty::New(1) );
   m_Node->SetProperty("scalar visibility", BoolProperty::New(false) );
 


### PR DESCRIPTION
http://samsmu.net:8083/browse/AUT-3344

Добавляет свойство управляющее прозрачностью итоговой модели в фильтр ShowSegmentationAsSurface.cpp

Добавляет assert при не успешной установке свойства, что могло приводить к не ожидаемую итоговому свойству