### PR TITLE
Улучшение ThreadPoolUtilities

### DIFF
--- a/Modules/Utilities/include/ThreadPoolUtilities.h
+++ b/Modules/Utilities/include/ThreadPoolUtilities.h
@@ -3,9 +3,9 @@
 #include <queue>
 #include <map>
 #include <set>
+#include <thread>
 
 #include <boost/noncopyable.hpp>
-#include <boost/thread/thread.hpp>
 #include <boost/thread/recursive_mutex.hpp>
 #include <boost/thread/shared_mutex.hpp>
 #include <boost/thread/condition_variable.hpp>
@@ -30,7 +30,7 @@ namespace Utilities
   class MITKUTILITIES_EXPORT ThreadPool : private boost::noncopyable
   {
   public:
-    ThreadPool();
+    ThreadPool(unsigned int size = std::thread::hardware_concurrency()); ///< \param size - number of threads in the pool
     ~ThreadPool();
 
     size_t Enqueue(const Task& task, TaskPriority priority = TaskPriority::NORMAL);
@@ -59,7 +59,7 @@ namespace Utilities
 
     boost::asio::io_service m_service;
     boost::optional<boost::asio::io_service::work> m_work;
-    boost::thread_group m_pool;
+    std::vector<std::thread> m_pool;
     boost::system::error_code m_error;
 
     boost::shared_mutex m_queueGuard;


### PR DESCRIPTION
Можно указывать количество потоков в пуле.
Переделал на использование std::thread вместо boost::thread, из-за ошибок в Linux видимо связанными с принудительным заверешением pthread-потоков по выходу из main() (а boost ничего об этом не знает).
Тртебуется для: [AUT-3286](http://samsmu.net:8083/browse/AUT-3286), [AUT-3278](http://samsmu.net:8083/browse/AUT-3278)