### PR TITLE
[StatisticsCalculator] fix comparison of double values

### DIFF
--- a/Modules/ImageStatistics/mitkImageStatisticsCalculator.cpp
+++ b/Modules/ImageStatistics/mitkImageStatisticsCalculator.cpp
@@ -1263,7 +1263,7 @@ namespace mitk
 
     while( !itmask.IsAtEnd() )
     {
-      if(m_IgnorePixelValue == itimage.Get())
+      if (itk::Math::AlmostEquals<double>(m_IgnorePixelValue, static_cast<double>(itimage.Get())))
       {
         itmask.Set(0);
       }


### PR DESCRIPTION
Fix comparison of double values in `StatisticsCalculator` class for correct ignoring a pixel value.