### PR TITLE
Removes distance check for planar figures. AUT-3387 [skip-CI]

### DIFF
--- a/Modules/PlanarFigure/src/Interactions/mitkPlanarFigureInteractor.cpp
+++ b/Modules/PlanarFigure/src/Interactions/mitkPlanarFigureInteractor.cpp
@@ -717,12 +717,14 @@ bool mitk::PlanarFigureInteractor::CheckFigureOnRenderingGeometry( const Interac
   if ( abstractTransformGeometry != nullptr)
     return false;
 
+  // Distance check was disabled due to disabling camera movement each frame, being not important and it works wrong by checking extent only for third axis
+  /*
   const double planeThickness = planarFigurePlaneGeometry->GetExtentInMM( 2 );
   if ( planarFigurePlaneGeometry->Distance( worldPoint3D ) > planeThickness )
   {
     // don't react, when interaction is too far away
     return false;
-  }
+  }*/
   return true;
 }
 


### PR DESCRIPTION
https://jira.samsmu.net/browse/AUT-3387

Убирает проверку на расстояние между камерой и планарной фигурой для интерактора планарных фигур. Это исправляет ошибку с рисованием планарных фигур.