### PR TITLE
Removes camera resseting for zooming. AUT-3387

### DIFF
--- a/Modules/Core/include/mitkDisplayInteractor.h
+++ b/Modules/Core/include/mitkDisplayInteractor.h
@@ -49,7 +49,7 @@ namespace mitk
     virtual void Notify(InteractionEvent* interactionEvent, bool isHandled) override;
 
     void SetSelectionMode(bool selection);
-    static void SetMouseRotationMode(bool active, std::function<void()> globalCallback);
+    static void SetMouseRotationMode(bool active, std::function<void(std::string)> globalCallback);
     static bool GetMouseRotationMode();
 
     static void RotateCamera(BaseRenderer* renderer, bool clockwise);
@@ -316,7 +316,7 @@ namespace mitk
     * 3D view selection mode
     */
     static bool m_MouseRotationMode;
-    static std::function<void()> m_CurrentCallbackFunction;
+    static std::function<void(std::string)> m_CurrentCallbackFunction;
     bool m_SelectionMode;
     /// <summary>
     /// TODO: select world point on multiwidget

--- a/Modules/Core/include/mitkInteractionPositionEvent.h
+++ b/Modules/Core/include/mitkInteractionPositionEvent.h
@@ -47,6 +47,7 @@ namespace mitk
 
     Point2D GetPointerPositionOnScreen() const;
     Point3D GetPositionInWorld() const;
+    Point3D GetPlanePositionInWorld() const;
 
     virtual bool IsSuperClassOf(const InteractionEvent::Pointer& baseClass) const override;
 

--- a/Modules/Core/resource/Interactions/DisplayConfigMITK.xml
+++ b/Modules/Core/resource/Interactions/DisplayConfigMITK.xml
@@ -24,6 +24,10 @@
   <event_variant class="MouseReleaseEvent" name="EndMoveCrosshair">
     <attribute name="EventButton" value="LeftMouseButton"/>
   </event_variant>
+  <event_variant class="InternalEvent" name="MouseCameraRotation">
+    <attribute name="SignalName" value="MouseCameraRotation"/>
+  </event_variant>
+
   <!-- Moving -->
   <event_variant name="MovePointer" class="MouseMoveEvent" >
   </event_variant>

--- a/Modules/Core/resource/Interactions/DisplayInteraction.xml
+++ b/Modules/Core/resource/Interactions/DisplayInteraction.xml
@@ -93,7 +93,7 @@ TODO Std move to abort interaction of scroll/pan/zoom
             <condition name="check_can_swivel" inverted="true"/>
         </transition>
 
-        <transition event_class="InternalEvent" event_variant="" target="mouseCameraRotation">
+        <transition event_class="InternalEvent" event_variant="MouseCameraRotation" target="mouseCameraRotation">
             <condition name="check_is_in_mouse_rotation_mode"/>
             <action name="startMouseCameraRotation"/>
         </transition>
@@ -220,7 +220,7 @@ TODO Std move to abort interaction of scroll/pan/zoom
         <transition event_class="MouseReleaseEvent" event_variant="EndMoveCrosshair" target="start">
             <action name="stopMouseCameraRotation"/>
         </transition>
-        <transition event_class="InternalEvent" event_variant="" target="start">
+        <transition event_class="InternalEvent" event_variant="MouseCameraRotation" target="start">
             <action name="stopMouseCameraRotation"/>
             <condition name="check_is_in_mouse_rotation_mode" inverted="true"/>
         </transition>

--- a/Modules/Core/src/Controllers/mitkCameraController.cpp
+++ b/Modules/Core/src/Controllers/mitkCameraController.cpp
@@ -227,7 +227,19 @@ void mitk::CameraController::Zoom(ScalarType factor, const Point2D& zoomPointInM
     this->GetRenderer()->GetVtkRenderer()->GetActiveCamera()->SetParallelScale(parallelScale);
     //Move camera in a way that the clicked point stays visible on the display where it was.
     Point2D planePoint = GetCameraPositionOnPlane();
-    MoveCameraToPoint(planePoint + ((zoomPointInMM - planePoint) * (factor - 1)));
+
+    planePoint = planePoint + ((zoomPointInMM - planePoint) * (factor - 1));
+
+    AdjustConstrainedCameraPosition(planePoint);
+
+    mitk::Point3D world;
+    this->GetRenderer()->PlaneToDisplay(planePoint, planePoint);
+    this->GetRenderer()->DisplayToWorld(planePoint, world);
+   
+    vtkCamera* camera = this->GetRenderer()->GetVtkRenderer()->GetActiveCamera();
+    double* pos = camera->GetPosition();
+    camera->SetPosition(world[0], world[1], pos[2]);
+    camera->SetFocalPoint(world[0], world[1], world[2]);
   }
 }
 

--- a/Modules/Core/src/Interactions/mitkDisplayInteractor.cpp
+++ b/Modules/Core/src/Interactions/mitkDisplayInteractor.cpp
@@ -100,7 +100,7 @@ void mitk::DisplayInteractor::ConnectActionsAndFunctions()
 
 double mitk::DisplayInteractor::m_ClockRotationSpeed = 90.;
 bool mitk::DisplayInteractor::m_MouseRotationMode = false;
-std::function<void()> mitk::DisplayInteractor::m_CurrentCallbackFunction = nullptr;
+std::function<void(std::string) > mitk::DisplayInteractor::m_CurrentCallbackFunction = nullptr;
 
 mitk::DisplayInteractor::DisplayInteractor()
   : m_Selector(true)
@@ -136,11 +136,11 @@ void mitk::DisplayInteractor::SetSelectionMode(bool selection)
   m_SelectionMode = selection;
 }
 
-void mitk::DisplayInteractor::SetMouseRotationMode(bool active,  std::function<void()> globalCallback)
+void mitk::DisplayInteractor::SetMouseRotationMode(bool active, std::function<void(std::string) > globalCallback)
 {
   m_MouseRotationMode = active;
   m_CurrentCallbackFunction = globalCallback;
-  globalCallback();
+  globalCallback("MouseCameraRotation");
 }
 
 bool mitk::DisplayInteractor::GetMouseRotationMode()
@@ -759,7 +759,7 @@ void mitk::DisplayInteractor::StopMouseRotation(StateMachineAction* state, Inter
 {
   EndRotation(state, e);
   m_MouseRotationMode = false;
-  m_CurrentCallbackFunction();
+  m_CurrentCallbackFunction("MouseCameraRotation");
 }
 
 void mitk::DisplayInteractor::Rotate(mitk::StateMachineAction *, mitk::InteractionEvent * event)

--- a/Modules/Core/src/Interactions/mitkInteractionPositionEvent.cpp
+++ b/Modules/Core/src/Interactions/mitkInteractionPositionEvent.cpp
@@ -36,6 +36,17 @@ mitk::Point3D mitk::InteractionPositionEvent::GetPositionInWorld() const
   return worldPos;
 }
 
+mitk::Point3D mitk::InteractionPositionEvent::GetPlanePositionInWorld() const
+{
+  const PlaneGeometry* planeGeometry = GetSender()->GetCurrentWorldPlaneGeometry();
+  mitk::Point2D position;
+  planeGeometry->Map(GetPositionInWorld(), position);
+  mitk::Point3D point;
+  planeGeometry->Map(position, point);
+
+  return point;
+}
+
 bool mitk::InteractionPositionEvent::IsEqual(const InteractionEvent& other) const
 {
   return Superclass::IsEqual(other);

--- a/Modules/Core/src/Interactions/mitkPointSetDataInteractor.cpp
+++ b/Modules/Core/src/Interactions/mitkPointSetDataInteractor.cpp
@@ -57,7 +57,7 @@ void mitk::PointSetDataInteractor::AddPoint(StateMachineAction* stateMachineActi
   InteractionPositionEvent* positionEvent = dynamic_cast<InteractionPositionEvent*>(interactionEvent);
   if (positionEvent != NULL)
   {
-    mitk::Point3D itkPoint = positionEvent->GetPositionInWorld();
+    mitk::Point3D itkPoint = positionEvent->GetPlanePositionInWorld();
 
     this->UnselectAll( timeStep, timeInMs);
 
@@ -121,7 +121,7 @@ void mitk::PointSetDataInteractor::SelectPoint(StateMachineAction*, InteractionE
   InteractionPositionEvent* positionEvent = dynamic_cast<InteractionPositionEvent*>(interactionEvent);
   if (positionEvent != NULL)
   {
-    Point3D point = positionEvent->GetPositionInWorld();
+    Point3D point = positionEvent->GetPlanePositionInWorld();
     // iterate over point set and check if it contains a point close enough to the pointer to be selected
     int index = GetPointIndexByPosition(point, timeStep);
     if (index != -1)
@@ -168,7 +168,7 @@ void mitk::PointSetDataInteractor::RemovePoint(StateMachineAction*, InteractionE
   InteractionPositionEvent* positionEvent = dynamic_cast<InteractionPositionEvent*>(interactionEvent);
   if (positionEvent != NULL)
   {
-    mitk::Point3D itkPoint = positionEvent->GetPositionInWorld();
+    mitk::Point3D itkPoint = positionEvent->GetPlanePositionInWorld();
 
     //search the point in the list
     int position = m_PointSet->SearchPoint( itkPoint , m_SelectionAccuracy, timeStep);
@@ -213,7 +213,7 @@ void mitk::PointSetDataInteractor::IsClosedContour(StateMachineAction*, Interact
   InteractionPositionEvent* positionEvent = dynamic_cast<InteractionPositionEvent*>(interactionEvent);
   if (positionEvent != NULL)
   {
-    Point3D point = positionEvent->GetPositionInWorld();
+    Point3D point = positionEvent->GetPlanePositionInWorld();
     // iterate over point set and check if it contains a point close enough to the pointer to be selected
     if (GetPointIndexByPosition(point, timeStep) != -1 && m_PointSet->GetSize(timeStep) >= 3)
     {
@@ -232,7 +232,7 @@ void mitk::PointSetDataInteractor::MovePoint(StateMachineAction* stateMachineAct
   {
     IsClosedContour(stateMachineAction, interactionEvent);
     mitk::Point3D newPoint, resultPoint;
-    newPoint = positionEvent->GetPositionInWorld();
+    newPoint = positionEvent->GetPlanePositionInWorld();
 
     // search the elements in the list that are selected then calculate the
     // vector, because only with the vector we can move several elements in
@@ -285,7 +285,7 @@ void mitk::PointSetDataInteractor::UnSelectPointAtPosition(StateMachineAction*, 
   InteractionPositionEvent* positionEvent = dynamic_cast<InteractionPositionEvent*>(interactionEvent);
   if (positionEvent != NULL)
   {
-    Point3D point = positionEvent->GetPositionInWorld();
+    Point3D point = positionEvent->GetPlanePositionInWorld();
     // iterate over point set and check if it contains a point close enough to the pointer to be selected
     int index = GetPointIndexByPosition(point, timeStep);
     // here it is ensured that we don't switch from one point being selected to another one being selected,
@@ -319,7 +319,7 @@ void mitk::PointSetDataInteractor::UnSelectAll(mitk::StateMachineAction *, mitk:
   if (positionEvent != NULL)
   {
 
-    Point3D positioninWorld = positionEvent->GetPositionInWorld();
+    Point3D positioninWorld = positionEvent->GetPlanePositionInWorld();
     PointSet::PointsContainer::Iterator it, end;
 
 
@@ -421,7 +421,7 @@ void mitk::PointSetDataInteractor::InitMove(StateMachineAction*, InteractionEven
 
   // start of the Movement is stored to calculate the undoKoordinate
   // in FinishMovement
-  m_LastPoint = positionEvent->GetPositionInWorld();
+  m_LastPoint = positionEvent->GetPlanePositionInWorld();
 
   // initialize a value to calculate the movement through all
   // MouseMoveEvents from MouseClick to MouseRelease
@@ -544,7 +544,7 @@ bool mitk::PointSetDataInteractor::CheckSelection(const mitk::InteractionEvent *
   if (positionEvent != NULL)
   {
     int timeStep = positionEvent->GetSender()->GetTimeStep();
-    Point3D point = positionEvent->GetPositionInWorld();
+    Point3D point = positionEvent->GetPlanePositionInWorld();
     // iterate over point set and check if it contains a point close enough to the pointer to be selected
     int index = GetPointIndexByPosition(point, timeStep);
     if (index != -1)

--- a/Modules/Core/src/Interactions/mitkSinglePointDataInteractor.cpp
+++ b/Modules/Core/src/Interactions/mitkSinglePointDataInteractor.cpp
@@ -59,13 +59,13 @@ void mitk::SinglePointDataInteractor::AddPoint(StateMachineAction* /*stateMachin
       itkPoint[1] = pt[1];
       itkPoint[2] = pt[2];
 
-      doOp = new mitk::PointOperation(OpMOVE,timeInMs,positionEvent->GetPositionInWorld(), 0);
+      doOp = new mitk::PointOperation(OpMOVE,timeInMs,positionEvent->GetPlanePositionInWorld(), 0);
       undoOp = new mitk::PointOperation(OpMOVE,timeInMs,itkPoint, 0);
     }
     else
     {
-      doOp = new mitk::PointOperation(OpINSERT,timeInMs,positionEvent->GetPositionInWorld(), 0);
-      undoOp = new mitk::PointOperation(OpREMOVE,timeInMs,positionEvent->GetPositionInWorld(), 0);
+      doOp = new mitk::PointOperation(OpINSERT,timeInMs,positionEvent->GetPlanePositionInWorld(), 0);
+      undoOp = new mitk::PointOperation(OpREMOVE,timeInMs,positionEvent->GetPlanePositionInWorld(), 0);
     }
 
 

--- a/Modules/DataTypesExt/src/mitkAffineImageCropperInteractor.cpp
+++ b/Modules/DataTypesExt/src/mitkAffineImageCropperInteractor.cpp
@@ -70,7 +70,7 @@ bool mitk::AffineImageCropperInteractor::CheckOverObject(const InteractionEvent*
   if (dn.IsNull())
     return false;
   const InteractionPositionEvent* positionEvent = dynamic_cast<const InteractionPositionEvent*>(interactionEvent);
-  Point3D currentPickedPoint = positionEvent->GetPositionInWorld();
+  Point3D currentPickedPoint = positionEvent->GetPlanePositionInWorld();
   mitk::BoundingObject* object = dynamic_cast<mitk::BoundingObject*> (dn->GetData());
   object->GetGeometry()->WorldToIndex(currentPickedPoint,currentPickedPoint);
   return object && object->GetGeometry()->GetBoundingBox()->IsInside(currentPickedPoint);
@@ -117,7 +117,7 @@ void mitk::AffineImageCropperInteractor::ScaleRadius(StateMachineAction*, Intera
   mitk::Point3D newScale;
   newScale[0] = newScale[1] = newScale[2] = scale;
 
-  mitk::Point3D anchorPoint = wheelEvent->GetPositionInWorld();
+  mitk::Point3D anchorPoint = wheelEvent->GetPlanePositionInWorld();
   ScaleOperation* doOp = new mitk::ScaleOperation(OpSCALE, newScale, anchorPoint);
   m_SelectedNode->GetData()->GetGeometry()->ExecuteOperation(doOp);
 
@@ -131,7 +131,7 @@ void mitk::AffineImageCropperInteractor::InitTranslate(StateMachineAction*, Inte
   if(positionEvent == NULL)
     return;
 
-  m_InitialPickedPoint = positionEvent->GetPositionInWorld();
+  m_InitialPickedPoint = positionEvent->GetPlanePositionInWorld();
   m_InitialPickedDisplayPoint = positionEvent->GetPointerPositionOnScreen();
 
   mitk::Surface::Pointer surface = dynamic_cast<mitk::Surface*> (m_SelectedNode->GetData());
@@ -145,7 +145,7 @@ void mitk::AffineImageCropperInteractor::InitRotate(StateMachineAction*, Interac
   if(positionEvent == NULL)
     return;
 
-  m_InitialPickedPoint = positionEvent->GetPositionInWorld();
+  m_InitialPickedPoint = positionEvent->GetPlanePositionInWorld();
   m_InitialPickedDisplayPoint = positionEvent->GetPointerPositionOnScreen();
 
   mitk::Surface::Pointer surface = dynamic_cast<mitk::Surface*> (m_SelectedNode->GetData());
@@ -159,7 +159,7 @@ void mitk::AffineImageCropperInteractor::InitDeformation(StateMachineAction*, In
   if(positionEvent == NULL)
     return;
 
-  m_InitialPickedPoint = positionEvent->GetPositionInWorld();
+  m_InitialPickedPoint = positionEvent->GetPlanePositionInWorld();
   m_InitialPickedDisplayPoint = positionEvent->GetPointerPositionOnScreen();
 
   mitk::Surface::Pointer surface = dynamic_cast<mitk::Surface*> (m_SelectedNode->GetData());
@@ -173,7 +173,7 @@ void mitk::AffineImageCropperInteractor::TranslateObject (StateMachineAction*, I
   if(positionEvent == NULL)
     return;
 
-  Point3D currentPickedPoint = positionEvent->GetPositionInWorld();
+  Point3D currentPickedPoint = positionEvent->GetPlanePositionInWorld();
 
   Vector3D interactionMove;
   interactionMove[0] = currentPickedPoint[0] - m_InitialPickedPoint[0];
@@ -194,7 +194,7 @@ void mitk::AffineImageCropperInteractor::DeformObject (StateMachineAction*, Inte
   if(positionEvent == NULL)
     return;
 
-  Point3D currentPickedPoint = positionEvent->GetPositionInWorld();
+  Point3D currentPickedPoint = positionEvent->GetPlanePositionInWorld();
   Vector3D interactionMove = currentPickedPoint-m_InitialPickedPoint;
 
   mitk::Surface::Pointer surface = dynamic_cast<mitk::Surface*> (m_SelectedNode->GetData());

--- a/Modules/Gizmo/src/mitkGizmoInteractor.cpp
+++ b/Modules/Gizmo/src/mitkGizmoInteractor.cpp
@@ -119,7 +119,7 @@ bool mitk::GizmoInteractor::HasPickedHandle(const InteractionEvent* interactionE
 
     // note initial state
     m_InitialClickPosition2D = positionEvent->GetPointerPositionOnScreen();
-    m_InitialClickPosition3D = positionEvent->GetPositionInWorld();
+    m_InitialClickPosition3D = positionEvent->GetPlanePositionInWorld();
 
     auto renderer = positionEvent->GetSender()->GetVtkRenderer();
     renderer->SetWorldPoint(m_InitialClickPosition3D[0],

--- a/Modules/PlanarFigure/src/Interactions/mitkPlanarFigureInteractor.cpp
+++ b/Modules/PlanarFigure/src/Interactions/mitkPlanarFigureInteractor.cpp
@@ -700,7 +700,7 @@ bool mitk::PlanarFigureInteractor::CheckFigureOnRenderingGeometry( const Interac
   if ( posEvent == nullptr )
     return false;
 
-  const mitk::Point3D worldPoint3D = posEvent->GetPositionInWorld();
+  const mitk::Point3D worldPoint3D = posEvent->GetPlanePositionInWorld();
   const mitk::PlanarFigure *planarFigure = dynamic_cast<mitk::PlanarFigure *>(
     GetDataNode()->GetData() );
 
@@ -717,14 +717,12 @@ bool mitk::PlanarFigureInteractor::CheckFigureOnRenderingGeometry( const Interac
   if ( abstractTransformGeometry != nullptr)
     return false;
 
-  // Distance check was disabled due to disabling camera movement each frame, being not important and it works wrong by checking extent only for third axis
-  /*
   const double planeThickness = planarFigurePlaneGeometry->GetExtentInMM( 2 );
   if ( planarFigurePlaneGeometry->Distance( worldPoint3D ) > planeThickness )
   {
     // don't react, when interaction is too far away
     return false;
-  }*/
+  }
   return true;
 }
 
@@ -744,7 +742,7 @@ bool mitk::PlanarFigureInteractor::TransformPositionEventToPoint2D( const Intera
                                                                     const PlaneGeometry *planarFigureGeometry,
                                                                     Point2D &point2D )
 {
-  const mitk::Point3D worldPoint3D = positionEvent->GetPositionInWorld();
+  const mitk::Point3D worldPoint3D = positionEvent->GetPlanePositionInWorld();
 
   // TODO: proper handling of distance tolerance
   /*

--- a/Modules/Segmentation/Interactions/mitkClassicRegionGrowingTool.cpp
+++ b/Modules/Segmentation/Interactions/mitkClassicRegionGrowingTool.cpp
@@ -142,14 +142,14 @@ void mitk::ClassicRegionGrowingTool::OnMousePressed(StateMachineAction*, Interac
       // 2. Determine if the user clicked inside or outside of the segmentation
       const BaseGeometry* workingSliceGeometry = m_WorkingSlice->GetGeometry();
       Point3D mprojectedPointIn2D;
-      workingSliceGeometry->WorldToIndex(positionEvent->GetPositionInWorld(), mprojectedPointIn2D);
+      workingSliceGeometry->WorldToIndex(positionEvent->GetPlanePositionInWorld(), mprojectedPointIn2D);
       itk::Index<2> projectedPointInWorkingSlice2D;
       projectedPointInWorkingSlice2D[0] = static_cast<int>(mprojectedPointIn2D[0] - 0.5);
       projectedPointInWorkingSlice2D[1] = static_cast<int>(mprojectedPointIn2D[1] - 0.5);
 
       if (workingSliceGeometry->IsIndexInside(projectedPointInWorkingSlice2D))
       {
-        MITK_DEBUG << "OnMousePressed: point " << positionEvent->GetPositionInWorld() << " (index coordinates " << projectedPointInWorkingSlice2D << ") IS in working slice" << std::endl;
+        MITK_DEBUG << "OnMousePressed: point " << positionEvent->GetPlanePositionInWorld() << " (index coordinates " << projectedPointInWorkingSlice2D << ") IS in working slice" << std::endl;
 
         // Convert to ipMITKSegmentationTYPE (because getting pixels relys on that data type)
         itk::Image< ipMITKSegmentationTYPE, 2 >::Pointer correctPixelTypeImage;
@@ -286,14 +286,14 @@ void mitk::ClassicRegionGrowingTool::OnMousePressedOutside(StateMachineAction*, 
   // if click was outside the image, don't continue
   const BaseGeometry* sliceGeometry = m_ReferenceSlice->GetGeometry();
   Point3D mprojectedPointIn2D;
-  sliceGeometry->WorldToIndex(positionEvent->GetPositionInWorld(), mprojectedPointIn2D);
+  sliceGeometry->WorldToIndex(positionEvent->GetPlanePositionInWorld(), mprojectedPointIn2D);
   itk::Index<2> projectedPointIn2D;
   projectedPointIn2D[0] = static_cast<int>(mprojectedPointIn2D[0] - 0.5);
   projectedPointIn2D[1] = static_cast<int>(mprojectedPointIn2D[1] - 0.5);
 
   if (sliceGeometry->IsIndexInside(mprojectedPointIn2D))
   {
-    MITK_DEBUG << "OnMousePressed: point " << positionEvent->GetPositionInWorld() << " (index coordinates " << mprojectedPointIn2D << ") IS in reference slice" << std::endl;
+    MITK_DEBUG << "OnMousePressed: point " << positionEvent->GetPlanePositionInWorld() << " (index coordinates " << mprojectedPointIn2D << ") IS in reference slice" << std::endl;
 
     // 3.2.1 Remember Y cursor position and initial seed point
 #ifdef _WIN32

--- a/Modules/Segmentation/Interactions/mitkContourModelInteractor.cpp
+++ b/Modules/Segmentation/Interactions/mitkContourModelInteractor.cpp
@@ -56,7 +56,7 @@ bool mitk::ContourModelInteractor::OnCheckPointClick(const InteractionEvent *int
 
   contour->Deselect();
 
-  mitk::Point3D click = positionEvent->GetPositionInWorld();
+  mitk::Point3D click = positionEvent->GetPlanePositionInWorld();
 
   if (contour->SelectVertexAt(click, 1.5, timestep) )
   {
@@ -96,7 +96,7 @@ bool mitk::ContourModelInteractor::IsHovering(const InteractionEvent* interactio
 
   mitk::ContourModel *contour = dynamic_cast<mitk::ContourModel *>( this->GetDataNode()->GetData() );
 
-  mitk::Point3D currentPosition = positionEvent->GetPositionInWorld();
+  mitk::Point3D currentPosition = positionEvent->GetPlanePositionInWorld();
 
 
   bool isHover = false;
@@ -129,13 +129,13 @@ void mitk::ContourModelInteractor::OnMovePoint(StateMachineAction*, InteractionE
   mitk::ContourModel *contour = dynamic_cast<mitk::ContourModel *>( this->GetDataNode()->GetData() );
 
   mitk::Vector3D translation;
-  mitk::Point3D currentPosition = positionEvent->GetPositionInWorld();
+  mitk::Point3D currentPosition = positionEvent->GetPlanePositionInWorld();
   translation[0] = currentPosition[0] - this->m_lastMousePosition[0];
   translation[1] = currentPosition[1] - this->m_lastMousePosition[1];
   translation[2] = currentPosition[2] - this->m_lastMousePosition[2];
   contour->ShiftSelectedVertex(translation);
 
-  this->m_lastMousePosition = positionEvent->GetPositionInWorld();
+  this->m_lastMousePosition = positionEvent->GetPlanePositionInWorld();
   mitk::RenderingManager::GetInstance()->RequestUpdate( positionEvent->GetSender()->GetRenderWindow() );
 }
 
@@ -150,13 +150,13 @@ void mitk::ContourModelInteractor::OnMoveContour(StateMachineAction*, Interactio
 
   mitk::ContourModel *contour = dynamic_cast<mitk::ContourModel *>( this->GetDataNode()->GetData() );
   mitk::Vector3D translation;
-  mitk::Point3D currentPosition = positionEvent->GetPositionInWorld();
+  mitk::Point3D currentPosition = positionEvent->GetPlanePositionInWorld();
   translation[0] = currentPosition[0] - this->m_lastMousePosition[0];
   translation[1] = currentPosition[1] - this->m_lastMousePosition[1];
   translation[2] = currentPosition[2] - this->m_lastMousePosition[2];
   contour->ShiftContour(translation, timestep);
 
-  this->m_lastMousePosition = positionEvent->GetPositionInWorld();
+  this->m_lastMousePosition = positionEvent->GetPlanePositionInWorld();
 
   mitk::RenderingManager::GetInstance()->RequestUpdate( positionEvent->GetSender()->GetRenderWindow() );
 }

--- a/Modules/Segmentation/Interactions/mitkContourModelLiveWireInteractor.cpp
+++ b/Modules/Segmentation/Interactions/mitkContourModelLiveWireInteractor.cpp
@@ -70,7 +70,7 @@ bool mitk::ContourModelLiveWireInteractor::OnCheckPointClick( const InteractionE
 
   // Check distance to any vertex.
   // Transition YES if click close to a vertex
-  mitk::Point3D click = positionEvent->GetPositionInWorld();
+  mitk::Point3D click = positionEvent->GetPlanePositionInWorld();
 
   if (contour->SelectVertexAt(click, 1.5, timestep) )
   {
@@ -208,7 +208,7 @@ void mitk::ContourModelLiveWireInteractor::OnMovePoint(StateMachineAction*, Inte
   if (!positionEvent) return;
 
   int timestep = positionEvent->GetSender()->GetTimeStep();
-  mitk::Point3D currentPosition = positionEvent->GetPositionInWorld();
+  mitk::Point3D currentPosition = positionEvent->GetPlanePositionInWorld();
 
   mitk::ContourModel *contour = dynamic_cast<mitk::ContourModel *>( this->GetDataNode()->GetData() );
   if (contour == nullptr)
@@ -323,7 +323,7 @@ bool mitk::ContourModelLiveWireInteractor::IsHovering(const InteractionEvent* in
 
   mitk::ContourModel *contour = dynamic_cast<mitk::ContourModel *>( this->GetDataNode()->GetData() );
 
-  mitk::Point3D currentPosition = positionEvent->GetPositionInWorld();
+  mitk::Point3D currentPosition = positionEvent->GetPlanePositionInWorld();
 
 
   bool isHover = false;

--- a/Modules/Segmentation/Interactions/mitkContourTool.cpp
+++ b/Modules/Segmentation/Interactions/mitkContourTool.cpp
@@ -78,7 +78,8 @@ void mitk::ContourTool::OnMousePressed( StateMachineAction*, InteractionEvent* i
   //draw as a closed contour
   contour->SetClosed(true,timestep);
   //add first mouse position
-  mitk::Point3D point = positionEvent->GetPositionInWorld();
+
+  mitk::Point3D point = positionEvent->GetPlanePositionInWorld();
   contour->AddVertex( point, timestep );
 
   FeedbackContourTool::SetFeedbackContourVisible(true);
@@ -97,7 +98,7 @@ void mitk::ContourTool::OnMouseMoved( StateMachineAction*, InteractionEvent* int
   int timestep = positionEvent->GetSender()->GetTimeStep();
 
   ContourModel* contour = FeedbackContourTool::GetFeedbackContour();
-  mitk::Point3D point = positionEvent->GetPositionInWorld();
+  mitk::Point3D point = positionEvent->GetPlanePositionInWorld();
   contour->AddVertex( point, timestep );
 
   assert( positionEvent->GetSender()->GetRenderWindow() );

--- a/Modules/Segmentation/Interactions/mitkCorrectorTool2D.cpp
+++ b/Modules/Segmentation/Interactions/mitkCorrectorTool2D.cpp
@@ -101,7 +101,7 @@ void mitk::CorrectorTool2D::OnMousePressed ( StateMachineAction*, InteractionEve
   contour->Initialize();
   contour->Expand(timestep + 1);
   contour->SetClosed(false, timestep);
-  mitk::Point3D point = positionEvent->GetPositionInWorld();
+  mitk::Point3D point = positionEvent->GetPlanePositionInWorld();
   contour->AddVertex( point, timestep );
 
   FeedbackContourTool::SetFeedbackContourVisible(true);
@@ -114,7 +114,7 @@ void mitk::CorrectorTool2D::OnMouseMoved( StateMachineAction*, InteractionEvent*
 
   int timestep = positionEvent->GetSender()->GetTimeStep();
   ContourModel* contour = FeedbackContourTool::GetFeedbackContour();
-  mitk::Point3D point = positionEvent->GetPositionInWorld();
+  mitk::Point3D point = positionEvent->GetPlanePositionInWorld();
   contour->AddVertex( point, timestep );
 
   assert( positionEvent->GetSender()->GetRenderWindow() );

--- a/Modules/Segmentation/Interactions/mitkFastMarchingTool.cpp
+++ b/Modules/Segmentation/Interactions/mitkFastMarchingTool.cpp
@@ -333,7 +333,7 @@ void mitk::FastMarchingTool::OnAddPoint( StateMachineAction*, InteractionEvent* 
 
   mitk::Point3D clickInIndex;
 
-  m_ReferenceImageSlice->GetGeometry()->WorldToIndex(m_PositionEvent->GetPositionInWorld(), clickInIndex);
+  m_ReferenceImageSlice->GetGeometry()->WorldToIndex(m_PositionEvent->GetPlanePositionInWorld(), clickInIndex);
   itk::Index<2> seedPosition;
   seedPosition[0] = clickInIndex[0];
   seedPosition[1] = clickInIndex[1];
@@ -345,7 +345,7 @@ void mitk::FastMarchingTool::OnAddPoint( StateMachineAction*, InteractionEvent* 
   this->m_SeedContainer->InsertElement(this->m_SeedContainer->Size(), node);
   m_FastMarchingFilter->Modified();
 
-  m_SeedsAsPointSet->InsertPoint(m_SeedsAsPointSet->GetSize(), m_PositionEvent->GetPositionInWorld());
+  m_SeedsAsPointSet->InsertPoint(m_SeedsAsPointSet->GetSize(), m_PositionEvent->GetPlanePositionInWorld());
 
   mitk::RenderingManager::GetInstance()->RequestUpdateAll();
 

--- a/Modules/Segmentation/Interactions/mitkLiveWireTool2D.cpp
+++ b/Modules/Segmentation/Interactions/mitkLiveWireTool2D.cpp
@@ -242,7 +242,7 @@ bool mitk::LiveWireTool2D::IsPositionEventInsideImageRegion(mitk::InteractionPos
 {
   bool IsPositionEventInsideImageRegion =
       data != nullptr &&
-      data->GetGeometry()->IsInside(positionEvent->GetPositionInWorld());
+      data->GetGeometry()->IsInside(positionEvent->GetPlanePositionInWorld());
   if(!IsPositionEventInsideImageRegion)
   {
     MITK_WARN("LiveWireTool2D") << "PositionEvent is outside ImageRegion!";
@@ -321,7 +321,7 @@ void mitk::LiveWireTool2D::OnInitLiveWire ( StateMachineAction*, InteractionEven
   m_LiveWireFilter->SetInput(m_WorkingSlice);
 
   //map click to pixel coordinates
-  mitk::Point3D click = positionEvent->GetPositionInWorld();
+  mitk::Point3D click = positionEvent->GetPlanePositionInWorld();
   itk::Index<3> idx;
   m_WorkingSlice->GetGeometry()->WorldToIndex(click, idx);
 
@@ -361,7 +361,7 @@ void mitk::LiveWireTool2D::OnAddPoint ( StateMachineAction*, InteractionEvent* i
   if (m_PlaneGeometry != NULL)
   {
     // this checks that the point is in the correct slice
-    if (m_PlaneGeometry->DistanceFromPlane(positionEvent->GetPositionInWorld()) > mitk::sqrteps)
+    if (m_PlaneGeometry->DistanceFromPlane(positionEvent->GetPlanePositionInWorld()) > mitk::sqrteps)
     {
       return;
     }
@@ -393,7 +393,7 @@ void mitk::LiveWireTool2D::OnAddPoint ( StateMachineAction*, InteractionEvent* i
   m_LiveWireContour->Clear(timestep);
 
   //set new start point
-  m_LiveWireFilter->SetStartPoint(positionEvent->GetPositionInWorld());
+  m_LiveWireFilter->SetStartPoint(positionEvent->GetPlanePositionInWorld());
 
   if( m_CreateAndUseDynamicCosts )
   {
@@ -416,7 +416,7 @@ void mitk::LiveWireTool2D::OnMouseMoved( StateMachineAction*, InteractionEvent* 
   // actual LiveWire computation
   int timestep = positionEvent->GetSender()->GetTimeStep();
 
-  m_LiveWireFilter->SetEndPoint(positionEvent->GetPositionInWorld());
+  m_LiveWireFilter->SetEndPoint(positionEvent->GetPlanePositionInWorld());
 
   m_LiveWireFilter->SetTimeStep( timestep );
   m_LiveWireFilter->Update();
@@ -452,7 +452,7 @@ bool mitk::LiveWireTool2D::OnCheckPoint( const InteractionEvent* interactionEven
   {
     int timestep = positionEvent->GetSender()->GetTimeStep();
 
-    mitk::Point3D click = positionEvent->GetPositionInWorld();
+    mitk::Point3D click = positionEvent->GetPlanePositionInWorld();
     mitk::Point3D first = this->m_Contour->GetVertexAt(0, timestep)->Coordinates;
 
     if (first.EuclideanDistanceTo(click) < 4.5)

--- a/Modules/Segmentation/Interactions/mitkPaintbrushTool.cpp
+++ b/Modules/Segmentation/Interactions/mitkPaintbrushTool.cpp
@@ -322,7 +322,7 @@ void mitk::PaintbrushTool::OnMousePressed ( StateMachineAction*, InteractionEven
   if (m_WorkingSlice.IsNull()) return;
 
   mitk::InteractionPositionEvent* positionEvent = dynamic_cast<mitk::InteractionPositionEvent*>( interactionEvent );
-  m_WorkingSlice->GetGeometry()->WorldToIndex( positionEvent->GetPositionInWorld(), m_LastPosition );
+  m_WorkingSlice->GetGeometry()->WorldToIndex( positionEvent->GetPlanePositionInWorld(), m_LastPosition );
 
   if (!positionEvent) return;
 
@@ -351,7 +351,7 @@ void mitk::PaintbrushTool::MouseMoved(mitk::InteractionEvent* interactionEvent, 
   mitk::InteractionPositionEvent* positionEvent = dynamic_cast<mitk::InteractionPositionEvent*>( interactionEvent );
 
   m_LastTimeStep = positionEvent->GetSender()->GetTimeStep();
-  m_LastWorldCoordinates = positionEvent->GetPositionInWorld();
+  m_LastWorldCoordinates = positionEvent->GetPlanePositionInWorld();
 
   MouseMovedImpl(positionEvent->GetSender()->GetCurrentWorldPlaneGeometry(), leftMouseButtonPressed);
 

--- a/Modules/Segmentation/Interactions/mitkRegionGrowingTool.cpp
+++ b/Modules/Segmentation/Interactions/mitkRegionGrowingTool.cpp
@@ -310,14 +310,14 @@ void mitk::RegionGrowingTool::OnMousePressed ( StateMachineAction*, InteractionE
         // 2. Determine if the user clicked inside or outside of the segmentation/working slice (i.e. the whole volume)
         mitk::BaseGeometry::Pointer workingSliceGeometry;
         workingSliceGeometry = m_WorkingSlice->GetTimeGeometry()->GetGeometryForTimeStep(m_LastEventSender->GetTimeStep());
-        workingSliceGeometry->WorldToIndex(positionEvent->GetPositionInWorld(), m_SeedPoint);
+        workingSliceGeometry->WorldToIndex(positionEvent->GetPlanePositionInWorld(), m_SeedPoint);
         itk::Index<2> indexInWorkingSlice2D;
         indexInWorkingSlice2D[0] = m_SeedPoint[0];
         indexInWorkingSlice2D[1] = m_SeedPoint[1];
 
         if (workingSliceGeometry->IsIndexInside(m_SeedPoint))
         {
-            MITK_DEBUG << "OnMousePressed: point " << positionEvent->GetPositionInWorld() << " (index coordinates " << m_SeedPoint << ") is inside working slice";
+            MITK_DEBUG << "OnMousePressed: point " << positionEvent->GetPlanePositionInWorld() << " (index coordinates " << m_SeedPoint << ") is inside working slice";
 
             // 3. determine the pixel value under the last click to determine what to do
             bool inside(true);
@@ -417,7 +417,7 @@ void mitk::RegionGrowingTool::OnMousePressedOutside(StateMachineAction*, Interac
         referenceSliceGeometry = m_ReferenceSlice->GetTimeGeometry()->GetGeometryForTimeStep(m_LastEventSender->GetTimeStep());
         itk::Index<3> indexInReferenceSlice;
         itk::Index<2> indexInReferenceSlice2D;
-        referenceSliceGeometry->WorldToIndex(positionEvent->GetPositionInWorld(), indexInReferenceSlice);
+        referenceSliceGeometry->WorldToIndex(positionEvent->GetPlanePositionInWorld(), indexInReferenceSlice);
         indexInReferenceSlice2D[0] = indexInReferenceSlice[0];
         indexInReferenceSlice2D[1] = indexInReferenceSlice[1];
 

--- a/Modules/Segmentation/Interactions/mitkSetRegionTool.cpp
+++ b/Modules/Segmentation/Interactions/mitkSetRegionTool.cpp
@@ -70,7 +70,7 @@ void mitk::SetRegionTool::OnMousePressed ( StateMachineAction*, InteractionEvent
   // if click was outside the image, don't continue
   const BaseGeometry* sliceGeometry = workingSlice->GetGeometry();
   itk::Index<3> projectedPointIn2D;
-  sliceGeometry->WorldToIndex( positionEvent->GetPositionInWorld(), projectedPointIn2D );
+  sliceGeometry->WorldToIndex( positionEvent->GetPlanePositionInWorld(), projectedPointIn2D );
   if ( !sliceGeometry->IsIndexInside( projectedPointIn2D ) )
   {
     MITK_ERROR << "point apparently not inside segmentation slice" << std::endl;
@@ -84,7 +84,7 @@ void mitk::SetRegionTool::OnMousePressed ( StateMachineAction*, InteractionEvent
 
   // convert world coordinates to image indices
   IndexType seedIndex;
-  sliceGeometry->WorldToIndex( positionEvent->GetPositionInWorld(), seedIndex);
+  sliceGeometry->WorldToIndex( positionEvent->GetPlanePositionInWorld(), seedIndex);
 
   //perform region growing in desired segmented region
   InputImageType::Pointer itkImage = InputImageType::New();

--- a/Modules/TubeGraph/src/Interactions/mitkTubeGraphDataInteractor.cpp
+++ b/Modules/TubeGraph/src/Interactions/mitkTubeGraphDataInteractor.cpp
@@ -77,7 +77,7 @@ bool mitk::TubeGraphDataInteractor::CheckOverTube(const InteractionEvent* intera
   TubeGraphPicker* picker = new mitk::TubeGraphPicker();
   picker->SetTubeGraph(m_TubeGraph);
 
-  TubeGraph::TubeDescriptorType tubeDescriptor = picker->GetPickedTube(positionEvent->GetPositionInWorld()).first;
+  TubeGraph::TubeDescriptorType tubeDescriptor = picker->GetPickedTube(positionEvent->GetPlanePositionInWorld()).first;
 
   if(tubeDescriptor != TubeGraph::ErrorId )
   {


### PR DESCRIPTION
https://jira.samsmu.net/browse/AUT-3387
http://samsmu.net:8083/browse/AUT-3475

* Изменяет функцию для зума. Теперь при зумировании камера сохраняет трансформации.
* Исправляет различные проблемы с нахождением точки в мире для интеракторов
* Убирает предупреждение о пустом InternalEvent

1. Открыть исследовнаие
2. Применить трансформацию
3. Отзумировать изображение
ER: Камера сохранила примененную ранее трансформацию