### PR TITLE
Прокрутка срезов не должна менять позицию

### DIFF
--- a/Modules/QtWidgets/include/QmitkRenderWindow.h
+++ b/Modules/QtWidgets/include/QmitkRenderWindow.h
@@ -161,8 +161,8 @@ private:
 
   // Helper Functions to Convert Qt-Events to Mitk-Events
 
-  mitk::Point2D GetMousePosition(QMouseEvent* me) const;
-  mitk::Point2D GetMousePosition(QWheelEvent* we) const;
+  mitk::Point2D GetMousePosition(QMouseEvent* me);
+  mitk::Point2D GetMousePosition(QWheelEvent* we);
   mitk::InteractionEvent::MouseButtons GetEventButton(QMouseEvent* me) const;
   mitk::InteractionEvent::MouseButtons GetButtonState(QMouseEvent* me) const;
   mitk::InteractionEvent::ModifierKeys GetModifiers(QInputEvent* me) const;
@@ -177,6 +177,8 @@ private:
 
   unsigned int m_LayoutIndex;
   bool m_FullScreenMode;
+
+  mitk::Point2D m_CrosshairPosition;
 };
 
 #endif

--- a/Modules/QtWidgets/include/QmitkRenderWindow.h
+++ b/Modules/QtWidgets/include/QmitkRenderWindow.h
@@ -161,8 +161,8 @@ private:
 
   // Helper Functions to Convert Qt-Events to Mitk-Events
 
-  mitk::Point2D GetMousePosition(QMouseEvent* me);
-  mitk::Point2D GetMousePosition(QWheelEvent* we);
+  mitk::Point2D GetMousePosition(QMouseEvent* me) const;
+  mitk::Point2D GetMousePosition(QWheelEvent* we) const;
   mitk::InteractionEvent::MouseButtons GetEventButton(QMouseEvent* me) const;
   mitk::InteractionEvent::MouseButtons GetButtonState(QMouseEvent* me) const;
   mitk::InteractionEvent::ModifierKeys GetModifiers(QInputEvent* me) const;

--- a/Modules/QtWidgets/src/QmitkRenderWindow.cpp
+++ b/Modules/QtWidgets/src/QmitkRenderWindow.cpp
@@ -368,7 +368,7 @@ void QmitkRenderWindow::dropEvent(QDropEvent * event)
   }
 }
 
-mitk::Point2D QmitkRenderWindow::GetMousePosition(QMouseEvent* me)
+mitk::Point2D QmitkRenderWindow::GetMousePosition(QMouseEvent* me) const
 {
   mitk::Point2D point;
   point[0] = me->x();
@@ -378,7 +378,7 @@ mitk::Point2D QmitkRenderWindow::GetMousePosition(QMouseEvent* me)
   return point;
 }
 
-mitk::Point2D QmitkRenderWindow::GetMousePosition(QWheelEvent* we)
+mitk::Point2D QmitkRenderWindow::GetMousePosition(QWheelEvent* we) const
 {
   mitk::Point2D point;
   point[0] = we->x();


### PR DESCRIPTION
http://samsmu.net:8083/browse/AUT-3553

Всё ещё берёт положение мыши при скролле с использованием mouse mode

Как решение можно рассылать положение курсора в методе `QmitkStdMultiWidget::HandleCrosshairPositionEventDelayed`