### PR TITLE
Removed unnecessary hotkeys and functions AUT-3533

### DIFF
--- a/Modules/Core/include/mitkDisplayInteractor.h
+++ b/Modules/Core/include/mitkDisplayInteractor.h
@@ -165,9 +165,6 @@ namespace mitk
      */
     virtual void Rotate(StateMachineAction*, InteractionEvent* event);
     
-    virtual void RotateBack(StateMachineAction*, InteractionEvent*);
-    virtual void RotateUp(StateMachineAction*, InteractionEvent*);
-    virtual void RotateDown(StateMachineAction*, InteractionEvent*);
     virtual void RotateClock(StateMachineAction*, InteractionEvent*);
     virtual void RotateBackClock(StateMachineAction*, InteractionEvent*);
 

--- a/Modules/Core/resource/Interactions/DisplayInteraction.xml
+++ b/Modules/Core/resource/Interactions/DisplayInteraction.xml
@@ -57,18 +57,6 @@ TODO Std move to abort interaction of scroll/pan/zoom
         <transition event_class="MousePressEvent" event_variant="MouseRotationPress" target="mouseCameraRotation">
             <action name="init"/>
         </transition>
-        <transition event_class="InteractionKeyEvent" event_variant="StdArrowRight" target="start" >
-          <action name="rotate" />
-        </transition>
-        <transition event_class="InteractionKeyEvent" event_variant="StdArrowLeft" target="start" >
-          <action name="rotateBack" />
-        </transition>
-        <transition event_class="InteractionKeyEvent" event_variant="StdArrowUp" target="start" >
-          <action name="rotateUp" />
-        </transition>
-        <transition event_class="InteractionKeyEvent" event_variant="StdArrowDown" target="start" >
-          <action name="rotateDown" />
-        </transition>
         <transition event_class="InteractionKeyEvent" event_variant="RotateClock" target="start" >
           <action name="rotateClock" />
         </transition>

--- a/Modules/Core/src/Interactions/mitkDisplayInteractor.cpp
+++ b/Modules/Core/src/Interactions/mitkDisplayInteractor.cpp
@@ -82,12 +82,9 @@ void mitk::DisplayInteractor::ConnectActionsAndFunctions()
   CONNECT_FUNCTION("endRotation", EndRotation);
   CONNECT_FUNCTION("rotationModeChanged", EndRotation);
   CONNECT_FUNCTION("rotate", Rotate);
-  CONNECT_FUNCTION("rotateBack", RotateBack);
 
   CONNECT_FUNCTION("swivel", Swivel);
 
-  CONNECT_FUNCTION("rotateUp", RotateUp);
-  CONNECT_FUNCTION("rotateDown", RotateDown);
   CONNECT_FUNCTION("rotateClock", RotateClock);
   CONNECT_FUNCTION("rotateBackClock", RotateBackClock);
   CONNECT_FUNCTION("selectObject", SelectObject);
@@ -940,44 +937,6 @@ void mitk::DisplayInteractor::UpdateStatusbar(mitk::StateMachineAction *, mitk::
   {
     statusBar->DisplayImageInfoInvalid();
   }
-}
-
-/*
-void mitk::DisplayInteractor::Rotate(StateMachineAction*, InteractionEvent* interactionEvent)
-{
-  BaseRenderer::Pointer sender = interactionEvent->GetSender();
-  mitk::Stepper* slice = sender->GetCameraRotationController()->GetSlice();
-  slice->Next();
-
-  sender->GetRenderingManager()->RequestUpdateAll();
-}
-*/
-
-void mitk::DisplayInteractor::RotateBack(StateMachineAction*, InteractionEvent* interactionEvent)
-{
-  BaseRenderer::Pointer sender = interactionEvent->GetSender();
-  mitk::Stepper* slice = sender->GetCameraRotationController()->GetSlice();
-  slice->Previous();
-
-  sender->GetRenderingManager()->RequestUpdateAll();
-}
-
-void mitk::DisplayInteractor::RotateUp(StateMachineAction*, InteractionEvent* interactionEvent)
-{
-  BaseRenderer::Pointer sender = interactionEvent->GetSender();
-  mitk::Stepper* slice = sender->GetCameraRotationController()->GetElevationSlice();
-  slice->Next();
-
-  sender->GetRenderingManager()->RequestUpdateAll();
-}
-
-void mitk::DisplayInteractor::RotateDown(StateMachineAction*, InteractionEvent* interactionEvent)
-{
-  BaseRenderer::Pointer sender = interactionEvent->GetSender();
-  mitk::Stepper* slice = sender->GetCameraRotationController()->GetElevationSlice();
-  slice->Previous();
-
-  sender->GetRenderingManager()->RequestUpdateAll();
 }
 
 void mitk::DisplayInteractor::RotateClock(StateMachineAction*, InteractionEvent* interactionEvent)


### PR DESCRIPTION
http://samsmu.net:8083/browse/AUT-3533

Были удалены хоткеи: (ALT + стрелки) и (CTRL + arrowUp(arrowDown)) и связанные с ними функции в виду ненадобности 