### PR TITLE
Removes legacy activation. AUT-3610

### DIFF
--- a/Plugins/org.mitk.gui.qt.common.legacy/src/QmitkFunctionalityCoordinator.cpp
+++ b/Plugins/org.mitk.gui.qt.common.legacy/src/QmitkFunctionalityCoordinator.cpp
@@ -182,7 +182,7 @@ void QmitkFunctionalityCoordinator::ActivateStandaloneFunctionality( berry::IWor
     MITK_INFO << "setting active flag";
     // call activated on this functionality
     functionality->SetActivated(true);
-    functionality->Activated();
+    //functionality->Activated();
   }
   else if (dynamic_cast<mitk::IZombieViewPart*>(partRef->GetPart(false).GetPointer()) &&
            m_StandaloneFuntionality != partRef)


### PR DESCRIPTION
http://samsmu.net:8083/browse/AUT-3610

Исправляет краш после закрытия плагина "сегментация"

Краш был связан с порядком активации плагинов. Плагин сегментаций наследуется от legacy класса `QmitkFunctionality`. При переходе на плагин берри пробрасывал сигнал в `QmitkFunctionality` а потом в `PluginInteractionController`. 

Это приводило к активации в таком порядке:
1) Активация нового плагина в `QmitkFunctionality` (видит ноды от предыдущего плагина)
2) Деактивация предыдущего плагина в `PluginInteractionController` (убирает ноды)
3) Активация нового плагина в `PluginInteractionController` (не активируется, потому что не был деактивирован с последней активации)

При деактивации плагин не мог найти ноду и падал.

PR убирает активацию из `QmitkFunctionality`, и теперь при активации этот класс только предполагает что активировал плагин, в то время как активацией полностью занимается `PluginInteractionController`. В качестве лучшего решения можно перенести плагин сегментаций на базовый класс `QmitkAbstractView`, но это требует некоторых изменений в логике работы плагина.

Возможно исправляет ошибки с двойной активацией в старых плагинах.

1. Открыть плагин инкрементальная сегментация
2. Создать сегментацию
3. Не закрывая плагин инкрементальной сегментации, открыть плагин редактирования сегментаций
4. Закрыть плагин редактирования сегментаций или перейти на другой плагин
ER: Автоплан не упал