### PR TITLE
Ability to get active modes from MouseModeSwitcher

### DIFF
--- a/Modules/Core/include/mitkMouseModeSwitcher.h
+++ b/Modules/Core/include/mitkMouseModeSwitcher.h
@@ -20,6 +20,7 @@ See LICENSE.txt or http://www.mitk.org for details.
 #include "MitkCoreExports.h"
 #include <itkObject.h>
 #include "mitkDisplayInteractor.h"
+#include <map>
 
 
 namespace mitk {
@@ -97,6 +98,8 @@ namespace mitk {
       MouseRotation,
     };
 
+    typedef std::set<int> IntSetType; // set of Active buttons
+    typedef std::map<MouseMode, IntSetType> MouseModeMap;
     /**
     * \brief Setter for interaction scheme
     */
@@ -105,12 +108,15 @@ namespace mitk {
     /**
     * \brief Setter for mouse mode
     */
-    void SelectMouseMode( MouseMode mode, const std::string& button = "Left");
+    // Qt::LeftButton = 0x00000001
+    void SelectMouseMode( MouseMode mode, const unsigned int& button = 1 );
 
     /**
     * \brief Returns the current mouse mode
     */
     MouseMode GetCurrentMouseMode() const;
+
+    MouseModeMap GetActiveMouseModes();
 
     /**
     * \brief Enable 3D view selection events
@@ -137,6 +143,8 @@ namespace mitk {
      * it is needed to unregister the observer on unload.
      */
     std::vector<us::ServiceRegistration<InteractionEventObserver>> m_ServiceRegistrations;
+
+    MouseModeMap m_ActiveMouseModes;
   };
 } // namespace mitk
 

--- a/Modules/QtWidgets/include/QmitkStdMultiWidget.h
+++ b/Modules/QtWidgets/include/QmitkStdMultiWidget.h
@@ -70,7 +70,7 @@ public:
   void ForceImmediateUpdate();
 
   mitk::MouseModeSwitcher* GetMouseModeSwitcher();
-  void setMouseMode(mitk::MouseModeSwitcher::MouseMode mode, const std::string& button);
+  void setMouseMode(mitk::MouseModeSwitcher::MouseMode mode, const Qt::MouseButton& button);
 
   QmitkRenderWindow* GetRenderWindow1() const;
 

--- a/Modules/QtWidgets/src/QmitkStdMultiWidget.cpp
+++ b/Modules/QtWidgets/src/QmitkStdMultiWidget.cpp
@@ -2500,7 +2500,7 @@ void QmitkStdMultiWidget::setAnnotationVisibility(std::vector<bool>& visibility)
   HandleCrosshairPositionEvent();
 }
 
-void QmitkStdMultiWidget::setMouseMode(mitk::MouseModeSwitcher::MouseMode mode, const std::string& button)
+void QmitkStdMultiWidget::setMouseMode(mitk::MouseModeSwitcher::MouseMode mode, const Qt::MouseButton& button)
 {
   m_MouseModeSwitcher->SelectMouseMode(mode, button);
 }


### PR DESCRIPTION
http://samsmu.net:8083/browse/AUT-3594

Добавлена возможность получить активные режимы из MouseModeSwitcher, и переделано со строк на целочисленное для совместимости с перечислением Qt::MouseButtons.