### PR TITLE
Fixes path marker. AUT-3652

### DIFF
--- a/Modules/PlanarFigure/src/Interactions/mitkPlanarFigureInteractor.cpp
+++ b/Modules/PlanarFigure/src/Interactions/mitkPlanarFigureInteractor.cpp
@@ -523,11 +523,9 @@ void mitk::PlanarFigureInteractor::SetPreviewPointPosition( StateMachineAction*,
     return;
 
   mitk::PlanarFigure *planarFigure = dynamic_cast<mitk::PlanarFigure *>( GetDataNode()->GetData() );
-  const mitk::BaseRenderer *renderer = interactionEvent->GetSender();
+  mitk::BaseRenderer *renderer = interactionEvent->GetSender();
 
   planarFigure->DeselectControlPoint();
-
-  mitk::Point2D pointProjectedOntoLine = positionEvent->GetPointerPositionOnScreen();
 
   bool selected(false);
   bool isExtendable(false);
@@ -538,7 +536,8 @@ void mitk::PlanarFigureInteractor::SetPreviewPointPosition( StateMachineAction*,
 
   if ( selected &&  isExtendable && isEditable )
   {
-    renderer->DisplayToPlane( pointProjectedOntoLine, pointProjectedOntoLine );
+    mitk::Point2D pointProjectedOntoLine;
+    this->TransformPositionEventToPoint2D(positionEvent, dynamic_cast< PlaneGeometry * >(planarFigure->GetGeometry(0)), pointProjectedOntoLine);
     planarFigure->SetPreviewControlPoint( pointProjectedOntoLine );
   }
 


### PR DESCRIPTION
http://samsmu.net:8083/browse/AUT-3652

Проблема была в том, что координаты маркера задаются относительно геометрии объекта. Чаще всего геометрия объекта совпадает с геометрией плоскости, но не в случае с PreviewPoint.

1. Построить планарную фигуру путь
2. Навести мышку на линию между точками
ER: Под указателем появилась точка, показывающая, где появиться разделяющая точка