### PR TITLE
Fixes russian path trimming. AUT-3754

### DIFF
--- a/Modules/CppMicroServices/core/src/module/usModuleSettings.cpp
+++ b/Modules/CppMicroServices/core/src/module/usModuleSettings.cpp
@@ -42,10 +42,11 @@ namespace {
 #endif
     if (in.empty()) return in;
     std::string::const_iterator lastChar = --in.end();
-    while (lastChar != in.begin() && std::isspace(*lastChar)) lastChar--;
+    // Don't trim unsuported symbols
+    while (lastChar != in.begin() && (*lastChar >= 0 && *lastChar < 255) && std::isspace(*lastChar)) lastChar--;
     if (*lastChar != separator) lastChar++;
     std::string::const_iterator firstChar = in.begin();
-    while (firstChar < lastChar && std::isspace(*firstChar)) firstChar++;
+    while (firstChar < lastChar && (*firstChar >= 0 && *firstChar < 255) && std::isspace(*firstChar)) firstChar++;
     return std::string(firstChar, lastChar);
   }
 

--- a/Modules/CppMicroServices/core/src/module/usModuleSettings.cpp
+++ b/Modules/CppMicroServices/core/src/module/usModuleSettings.cpp
@@ -43,10 +43,10 @@ namespace {
     if (in.empty()) return in;
     std::string::const_iterator lastChar = --in.end();
     // Don't trim unsuported symbols
-    while (lastChar != in.begin() && (*lastChar >= 0 && *lastChar < 255) && std::isspace(*lastChar)) lastChar--;
+    while (lastChar != in.begin() && *lastChar >= 0 && std::isspace(*lastChar)) lastChar--;
     if (*lastChar != separator) lastChar++;
     std::string::const_iterator firstChar = in.begin();
-    while (firstChar < lastChar && (*firstChar >= 0 && *firstChar < 255) && std::isspace(*firstChar)) firstChar++;
+    while (firstChar < lastChar && *firstChar >= 0 && std::isspace(*firstChar)) firstChar++;
     return std::string(firstChar, lastChar);
   }
 


### PR DESCRIPTION
https://jira.samsmu.net/browse/AUT-3754

Проблема была в том что isspace работает только с signed char. Теперь неподдерживаемые стандартной локалью символы не тримятся.

1. Запустить Автоплан из папки с русскими символами в названии
ER: Автоплан запустился