### PR TITLE
ThreadPool: Исправил приоритеты и добавил Reset()

### DIFF
--- a/Modules/Utilities/include/ThreadPoolUtilities.h
+++ b/Modules/Utilities/include/ThreadPoolUtilities.h
@@ -18,11 +18,11 @@ namespace Utilities
 {
   enum class TaskPriority
   {
-    CRITICAL,
-    HI,
-    NORMAL,
+    LOWEST,
     LOW,
-    LOWEST
+    NORMAL,
+    HI,
+    CRITICAL
   };
 
   typedef std::function<void()> Task;
@@ -36,6 +36,7 @@ namespace Utilities
     ~ThreadPool();
 
     void Stop();
+    void Reset();
 
     void AddThreads(size_t count);
 

--- a/Modules/Utilities/src/ThreadPoolUtilities.cpp
+++ b/Modules/Utilities/src/ThreadPoolUtilities.cpp
@@ -59,6 +59,17 @@ namespace Utilities
     m_pool.join_all();
   }
 
+  void ThreadPool::Reset()
+  {
+    if (m_work) {
+      m_work = boost::none;
+    }
+    m_service.stop();
+    m_pool.join_all();
+    m_service.reset();
+    m_work = boost::in_place<boost::asio::io_service::work>(boost::ref(m_service));
+  }
+
   void ThreadPool::AddThreads(size_t count)
   {
     const boost::unique_lock<boost::shared_mutex> lock(m_guard);


### PR DESCRIPTION
* Приоритеты действуют наоборот, поэтому поменял порядок.
* Новый метод Reset() удаляет все потоки после ожидания исполняющихся задач и подготавливает пул к повторному запуску.  Далее нужно вызывать AddThreads(n), чтобы продолжить выполнение задач из очереди с новым количеством потоков. Метод будет использован при уменьшении числа потоков на PACS-сервер.
[AUT-3464](https://jira.samsmu.net/browse/AUT-3464)