### PR TITLE
Added parentWidget in crosshairManager AUT-3853

### DIFF
--- a/Modules/QtWidgets/include/mitkCrosshairManager.h
+++ b/Modules/QtWidgets/include/mitkCrosshairManager.h
@@ -38,7 +38,7 @@ private:
 class MITKQTWIDGETS_EXPORT mitkCrosshairManager : public QObject {
   Q_OBJECT
 public:
-  mitkCrosshairManager();
+  mitkCrosshairManager(const QString& parentWidget);
 
   // Changes crosshair mode for selected windows
   void setCrosshairMode(CrosshairMode mode);
@@ -130,4 +130,6 @@ private:
 
   mitk::Color m_SwivelColor;
   mitk::Color m_SwivelSelectedColor;
+
+  QString m_ParentWidget;
 };

--- a/Modules/QtWidgets/src/QmitkStdMultiWidget.cpp
+++ b/Modules/QtWidgets/src/QmitkStdMultiWidget.cpp
@@ -256,7 +256,7 @@ QmitkStdMultiWidget::QmitkStdMultiWidget(QWidget* parent, Qt::WindowFlags f, mit
 
 void QmitkStdMultiWidget::InitializeWidget()
 {
-  crosshairManager = new mitkCrosshairManager();
+  crosshairManager = new mitkCrosshairManager(m_Name);
   crosshairManager->removeAll();
   crosshairManager->setShowSelectedOnly(false);
   crosshairManager->setShowSelectedOnly(false);

--- a/Modules/QtWidgets/src/mitkCrosshairManager.cpp
+++ b/Modules/QtWidgets/src/mitkCrosshairManager.cpp
@@ -5,13 +5,14 @@
 
 CrosshairModeController* CrosshairModeController::instance = nullptr;
 
-mitkCrosshairManager::mitkCrosshairManager() :
+mitkCrosshairManager::mitkCrosshairManager(const QString& parentWidget) :
   m_Selected(nullptr),
   m_ShowSelected(false),
   checkWindowsShareCrosshair(nullptr),
   m_ShowPlanesIn3d(true),
   m_ShowPlanesIn3dWithoutCursor(true),
-  m_SingleDataStorage(false)
+  m_SingleDataStorage(false),
+  m_ParentWidget(parentWidget)
 {
   m_CrosshairPredicate = mitk::NodePredicateProperty::New("crosshair", mitk::BoolProperty::New(true));
 
@@ -96,6 +97,7 @@ void mitkCrosshairManager::setDefaultProperties(mitk::DataNode::Pointer crosshai
   crosshair->SetBoolProperty("crosshair", true);
   crosshair->SetBoolProperty("includeInBoundingBox", false);
   crosshair->SetBoolProperty("helper object", true);
+  crosshair->SetProperty("parentWidget", mitk::StringProperty::New(m_ParentWidget.toStdString()));
 }
 
 void mitkCrosshairManager::addPlaneCrosshair(QmitkRenderWindow* window, bool render2d, bool render3d)


### PR DESCRIPTION
Плоскости в crosshairManager добавлялись без привязки родительского виджета.

https://jira.samsmu.net/browse/AUT-3853