### PR TITLE
Тёмная тема: поправлены чекбоксы, радиокнопки и подсветка

### DIFF
--- a/Plugins/org.blueberry.ui.qt/resources/dark/checkbox-checked-hover.svg
+++ b/Plugins/org.blueberry.ui.qt/resources/dark/checkbox-checked-hover.svg
@@ -63,7 +63,7 @@
        x="0.5"
        y="1039.8622" />
     <path
-       style="fill:none;stroke:#6bc3ff;stroke-width:1.3125;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:none;stroke:#6bd3ff;stroke-width:1.3125;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        d="m 2.0892276,1045.413 3.5012909,4.8112 5.3208585,-8.7163"
        id="path7264"
        inkscape:connector-curvature="0" />

--- a/Plugins/org.blueberry.ui.qt/resources/dark/radiobutton-checked-disabled.svg
+++ b/Plugins/org.blueberry.ui.qt/resources/dark/radiobutton-checked-disabled.svg
@@ -9,12 +9,12 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="13"
-   height="13"
+   width="13.866667"
+   height="13.866667"
    viewBox="0 0 13 13"
    id="svg2"
    version="1.1"
-   inkscape:version="0.91 r13725"
+   inkscape:version="0.92.1 r15371"
    sodipodi:docname="radiobutton-checked-disabled.svg">
   <defs
      id="defs4" />
@@ -26,7 +26,7 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="32"
-     inkscape:cx="0.6942247"
+     inkscape:cx="5.2802086"
      inkscape:cy="1.9319291"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
@@ -34,9 +34,9 @@
      units="px"
      inkscape:showpageshadow="false"
      inkscape:window-width="1264"
-     inkscape:window-height="1361"
-     inkscape:window-x="1280"
-     inkscape:window-y="0"
+     inkscape:window-height="1027"
+     inkscape:window-x="654"
+     inkscape:window-y="24"
      inkscape:window-maximized="0" />
   <metadata
      id="metadata7">
@@ -46,7 +46,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -56,16 +56,16 @@
      id="layer1"
      transform="translate(0,-1039.3622)">
     <circle
-       style="fill:#2d2d30;fill-opacity:1;stroke:#434346;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:#414141;fill-opacity:1;stroke:#696969;stroke-width:0.94218749;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path4134"
        cx="6.5"
        cy="1045.8622"
-       r="6" />
+       r="6.0278969" />
     <circle
-       style="fill:#555558;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:#5e6368;fill-opacity:1;stroke:#a0a0a0;stroke-width:1.24687499;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:1.24687499,1.24687499;stroke-dashoffset:0;stroke-opacity:1"
        id="path4136"
        cx="6.5"
        cy="1045.8622"
-       r="4.5" />
+       r="3.5534382" />
   </g>
 </svg>

--- a/Plugins/org.blueberry.ui.qt/resources/dark/radiobutton-checked-hover.svg
+++ b/Plugins/org.blueberry.ui.qt/resources/dark/radiobutton-checked-hover.svg
@@ -9,12 +9,12 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="13"
-   height="13"
+   width="13.866667"
+   height="13.866667"
    viewBox="0 0 13 13"
    id="svg2"
    version="1.1"
-   inkscape:version="0.91 r13725"
+   inkscape:version="0.92.1 r15371"
    sodipodi:docname="radiobutton-checked-hover.svg">
   <defs
      id="defs4" />
@@ -26,17 +26,17 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="32"
-     inkscape:cx="6.362741"
-     inkscape:cy="-5.0439298"
+     inkscape:cx="7.5002874"
+     inkscape:cy="1.9319291"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
      units="px"
      inkscape:showpageshadow="false"
      inkscape:window-width="1264"
-     inkscape:window-height="1361"
-     inkscape:window-x="1280"
-     inkscape:window-y="0"
+     inkscape:window-height="1027"
+     inkscape:window-x="654"
+     inkscape:window-y="24"
      inkscape:window-maximized="0" />
   <metadata
      id="metadata7">
@@ -56,16 +56,16 @@
      id="layer1"
      transform="translate(0,-1039.3622)">
     <circle
-       style="fill:#3f3f46;fill-opacity:1;stroke:#434346;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:#2d353d;fill-opacity:1;stroke:#90a0b0;stroke-width:0.94218749;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path4134"
        cx="6.5"
        cy="1045.8622"
-       r="6" />
+       r="6.0278969" />
     <circle
-       style="fill:#1c97ea;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:#69b7f0;fill-opacity:1;stroke:#6bc3ff;stroke-width:1.24273252;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path4136"
        cx="6.5"
        cy="1045.8622"
-       r="4.5" />
+       r="3.5534382" />
   </g>
 </svg>

--- a/Plugins/org.blueberry.ui.qt/resources/dark/radiobutton-checked.svg
+++ b/Plugins/org.blueberry.ui.qt/resources/dark/radiobutton-checked.svg
@@ -9,12 +9,12 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="13"
-   height="13"
+   width="13.866667"
+   height="13.866667"
    viewBox="0 0 13 13"
    id="svg2"
    version="1.1"
-   inkscape:version="0.91 r13725"
+   inkscape:version="0.92.1 r15371"
    sodipodi:docname="radiobutton-checked.svg">
   <defs
      id="defs4" />
@@ -26,18 +26,18 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="32"
-     inkscape:cx="0.6942247"
+     inkscape:cx="4.3583336"
      inkscape:cy="1.9319291"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
      units="px"
      inkscape:showpageshadow="false"
-     inkscape:window-width="1264"
-     inkscape:window-height="1361"
-     inkscape:window-x="1280"
-     inkscape:window-y="0"
-     inkscape:window-maximized="0" />
+     inkscape:window-width="1920"
+     inkscape:window-height="1028"
+     inkscape:window-x="0"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1" />
   <metadata
      id="metadata7">
     <rdf:RDF>
@@ -46,7 +46,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -56,16 +56,16 @@
      id="layer1"
      transform="translate(0,-1039.3622)">
     <circle
-       style="fill:#333337;fill-opacity:1;stroke:#434346;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:#333337;fill-opacity:1;stroke:#9b9b9b;stroke-width:0.94174564;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path4134"
        cx="6.5"
        cy="1045.8622"
-       r="6" />
+       r="6.0276546" />
     <circle
-       style="fill:#686868;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:#bbbec1;fill-opacity:1;stroke:#fefefe;stroke-width:1.24273252;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path4136"
        cx="6.5"
        cy="1045.8622"
-       r="4.5" />
+       r="3.5534382" />
   </g>
 </svg>

--- a/Plugins/org.blueberry.ui.qt/resources/dark/radiobutton-unchecked-disabled.svg
+++ b/Plugins/org.blueberry.ui.qt/resources/dark/radiobutton-unchecked-disabled.svg
@@ -9,12 +9,12 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="13"
-   height="13"
+   width="13.866667"
+   height="13.866667"
    viewBox="0 0 13 13"
    id="svg2"
    version="1.1"
-   inkscape:version="0.91 r13725"
+   inkscape:version="0.92.1 r15371"
    sodipodi:docname="radiobutton-unchecked-disabled.svg">
   <defs
      id="defs4" />
@@ -26,7 +26,7 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="32"
-     inkscape:cx="5.3660997"
+     inkscape:cx="5.2802086"
      inkscape:cy="1.9319291"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
@@ -34,9 +34,9 @@
      units="px"
      inkscape:showpageshadow="false"
      inkscape:window-width="1264"
-     inkscape:window-height="1361"
-     inkscape:window-x="1280"
-     inkscape:window-y="0"
+     inkscape:window-height="1027"
+     inkscape:window-x="654"
+     inkscape:window-y="24"
      inkscape:window-maximized="0" />
   <metadata
      id="metadata7">
@@ -56,10 +56,10 @@
      id="layer1"
      transform="translate(0,-1039.3622)">
     <circle
-       style="fill:#2d2d30;fill-opacity:1;stroke:#434346;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:#414141;fill-opacity:1;stroke:#696969;stroke-width:0.94218749;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path4134"
        cx="6.5"
        cy="1045.8622"
-       r="6" />
+       r="6.0278969" />
   </g>
 </svg>

--- a/Plugins/org.blueberry.ui.qt/resources/dark/radiobutton-unchecked-hover.svg
+++ b/Plugins/org.blueberry.ui.qt/resources/dark/radiobutton-unchecked-hover.svg
@@ -9,12 +9,12 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="13"
-   height="13"
+   width="13.866667"
+   height="13.866667"
    viewBox="0 0 13 13"
    id="svg2"
    version="1.1"
-   inkscape:version="0.91 r13725"
+   inkscape:version="0.92.1 r15371"
    sodipodi:docname="radiobutton-unchecked-hover.svg">
   <defs
      id="defs4" />
@@ -26,7 +26,7 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="32"
-     inkscape:cx="5.3660997"
+     inkscape:cx="7.3739586"
      inkscape:cy="1.9319291"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
@@ -34,9 +34,9 @@
      units="px"
      inkscape:showpageshadow="false"
      inkscape:window-width="1264"
-     inkscape:window-height="1361"
-     inkscape:window-x="1280"
-     inkscape:window-y="0"
+     inkscape:window-height="1027"
+     inkscape:window-x="654"
+     inkscape:window-y="24"
      inkscape:window-maximized="0" />
   <metadata
      id="metadata7">
@@ -46,7 +46,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -56,10 +56,10 @@
      id="layer1"
      transform="translate(0,-1039.3622)">
     <circle
-       style="fill:#3f3f46;fill-opacity:1;stroke:#434346;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:#263748;fill-opacity:1;stroke:#8fa0b1;stroke-width:0.93749999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path4134"
        cx="6.5"
        cy="1045.8622"
-       r="6" />
+       r="6.0278969" />
   </g>
 </svg>

--- a/Plugins/org.blueberry.ui.qt/resources/dark/radiobutton-unchecked.svg
+++ b/Plugins/org.blueberry.ui.qt/resources/dark/radiobutton-unchecked.svg
@@ -9,12 +9,12 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="13"
-   height="13"
+   width="13.866667"
+   height="13.866667"
    viewBox="0 0 13 13"
    id="svg2"
    version="1.1"
-   inkscape:version="0.91 r13725"
+   inkscape:version="0.92.1 r15371"
    sodipodi:docname="radiobutton-unchecked.svg">
   <defs
      id="defs4" />
@@ -26,7 +26,7 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="32"
-     inkscape:cx="5.3660997"
+     inkscape:cx="4.3583336"
      inkscape:cy="1.9319291"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
@@ -34,9 +34,9 @@
      units="px"
      inkscape:showpageshadow="false"
      inkscape:window-width="1264"
-     inkscape:window-height="1361"
-     inkscape:window-x="1280"
-     inkscape:window-y="0"
+     inkscape:window-height="1027"
+     inkscape:window-x="654"
+     inkscape:window-y="24"
      inkscape:window-maximized="0" />
   <metadata
      id="metadata7">
@@ -46,7 +46,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -56,10 +56,10 @@
      id="layer1"
      transform="translate(0,-1039.3622)">
     <circle
-       style="fill:#333337;fill-opacity:1;stroke:#434346;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:#333337;fill-opacity:1;stroke:#9b9b9b;stroke-width:0.94218749;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path4134"
        cx="6.5"
        cy="1045.8622"
-       r="6" />
+       r="6.0278969" />
   </g>
 </svg>

--- a/Plugins/org.blueberry.ui.qt/resources/darkstyle-activetab.qss
+++ b/Plugins/org.blueberry.ui.qt/resources/darkstyle-activetab.qss
@@ -1,8 +1,8 @@
 berry--QCTabBar::tab:selected {
-  background-color: #1c97ea;
-  border: 1px solid #1c97ea;
+  background-color: #1e7296;
+  border: 1px solid #1e7296;
 }
 
 #ViewFormContentFrame {
-  border: 1px solid #1c97ea;
+  border: 1px solid #1e7296;
 }

--- a/Plugins/org.blueberry.ui.qt/resources/darkstyle.qss
+++ b/Plugins/org.blueberry.ui.qt/resources/darkstyle.qss
@@ -19,6 +19,17 @@ See LICENSE.txt or http://www.mitk.org for details.
   iconAccentColor = #d4821e <- This line is parsed by MITK
 */
 
+* {
+  gridline-color: #2d2d30;
+  selection-background-color: rgba(16,180,248,96);
+  selection-color: #f1f1f1;
+}
+
+*:active {
+  selection-background-color: rgba(16,180,248,148);
+  selection-color: #f8f8f8;
+}
+
 QWidget {
   background-color: #2d2d30;
   border: none;
@@ -53,7 +64,7 @@ QPushButton:pressed {
 }
 
 QPushButton:checked, QToolButton:checked {
-  border: 1px solid #007acc;
+  border: 1px solid #0078a0;
 }
 
 QToolButton {
@@ -91,8 +102,8 @@ QToolBox::tab:hover {
 }
 
 QToolBox::tab:selected {
-  background-color: #1c97ea;
-  border: 1px solid #1c97ea;
+  background-color: #1e7296;
+  border: 1px solid #1e7296;
 }
 
 QTableView QTableCornerButton::section {
@@ -100,11 +111,11 @@ QTableView QTableCornerButton::section {
 }
 
 QTableView {
-  selection-background-color: #2d2d30;
+  selection-background-color: rgba(16,180,248,48);
 }
 
 QTableView:active {
-  selection-background-color: #1c97ea;
+  selection-background-color: rgba(16,180,248,74);
 }
 
 QAbstractItemView {
@@ -142,16 +153,16 @@ QComboBox QAbstractItemView {
   selection-background-color: #3f3f46;
 }
 
-QComboBox::drop-down {
+*::drop-down {
   image: url(:/org.blueberry.ui.qt/dark/down-arrow.svg);
   subcontrol-origin: margin;
   subcontrol-position: right;
   width: 12px;
 }
 
-QComboBox::drop-down:hover {
+*::drop-down:hover {
   background-color: #1f1f20;
-  border-left: 1px solid #007acc;
+  border-left: 1px solid #0078a0;
   image: url(:/org.blueberry.ui.qt/dark/down-arrow-pressed.svg);
 }
 
@@ -206,27 +217,27 @@ QCheckBox::indicator, QRadioButton::indicator, QGroupBox::indicator, QListWidget
   width: 13px;
 }
 
-QCheckBox::indicator:unchecked, QGroupBox::indicator:unchecked, QListWidget::indicator:unchecked {
+QCheckBox::indicator:unchecked, QGroupBox::indicator:unchecked, QListWidget::indicator:unchecked, QAbstractItemView::indicator:unchecked {
   image: url(:/org.blueberry.ui.qt/dark/checkbox-unchecked.svg);
 }
 
-QCheckBox::indicator:unchecked:hover, QGroupBox::indicator:hover, QListWidget::indicator:hover {
+QCheckBox::indicator:unchecked:hover, QGroupBox::indicator:hover, QListWidget::indicator:hover, QAbstractItemView::indicator:hover {
   image: url(:/org.blueberry.ui.qt/dark/checkbox-unchecked-hover.svg);
 }
 
-QCheckBox::indicator:unchecked:disabled, QGroupBox::indicator:disabled, QListWidget::indicator:disabled {
+QCheckBox::indicator:unchecked:disabled, QGroupBox::indicator:disabled, QListWidget::indicator:disabled, QAbstractItemView::indicator:disabled {
   image: url(:/org.blueberry.ui.qt/dark/checkbox-unchecked-disabled.svg);
 }
 
-QCheckBox::indicator:checked, QGroupBox::indicator:checked, QListWidget::indicator:checked {
+QCheckBox::indicator:checked, QGroupBox::indicator:checked, QListWidget::indicator:checked, QAbstractItemView::indicator:checked {
   image: url(:/org.blueberry.ui.qt/dark/checkbox-checked.svg);
 }
 
-QCheckBox::indicator:checked:hover, QGroupBox::indicator:checked:hover, QListWidget::indicator:checked:hover {
+QCheckBox::indicator:checked:hover, QGroupBox::indicator:checked:hover, QListWidget::indicator:checked:hover, QAbstractItemView::indicator:checked:hover {
   image: url(:/org.blueberry.ui.qt/dark/checkbox-checked-hover.svg);
 }
 
-QCheckBox::indicator:checked:disabled, QGroupBox::indicator:checked:disabled, QListWidget::indicator:checked:disabled {
+QCheckBox::indicator:checked:disabled, QGroupBox::indicator:checked:disabled, QListWidget::indicator:checked:disabled, QAbstractItemView::indicator:checked:disabled {
   image: url(:/org.blueberry.ui.qt/dark/checkbox-checked-disabled.svg);
 }
 
@@ -275,11 +286,11 @@ QSlider::handle {
 }
 
 QSlider::handle:hover {
-  background-color: #1c97ea;
+  background-color: #dc10b4f8;
 }
 
 QSlider::handle:pressed {
-  background-color: #007acc;
+  background-color: #0078a0;
 }
 
 QSlider::handle:horizontal {
@@ -344,11 +355,11 @@ QScrollBar::handle {
 }
 
 QScrollBar::handle:hover {
-  background-color: #9e9e9e;
+  background-color: #dc10b4f8;
 }
 
 QScrollBar::handle:pressed {
-  background-color: #efebef;
+  background-color: #0078a0;
 }
 
 QScrollBar::handle:horizontal {


### PR DESCRIPTION
Фон выделения сделан менее ярким, чтобы не резало глаз, и лучше были видны иконки на этом фоне.
Некоторые стили расширены на другие классы управляющих элементов.
https://jira.samsmu.net/browse/AUT-3945,
https://jira.samsmu.net/browse/AUT-3940,
https://jira.samsmu.net/browse/AUT-3926