### PR TITLE
Add localization for meta-data during reading dicoms. AUT-3733

### DIFF
--- a/Modules/Core/include/mitkDicomSeriesReader.h
+++ b/Modules/Core/include/mitkDicomSeriesReader.h
@@ -898,6 +898,11 @@ protected:
   };
 
   static void FixSpacingInformation( Image* image, const ImageBlockDescriptor& imageBlockDescriptor );
+  
+  static void FixMetaDataCharset( Image* image );
+
+  // Taken from dcmktk/dcmdata/dcspchrs
+  static std::string GetStandardCharSet(std::string dicomCharset);
 
   /**
    \brief Performs actual loading of a series and creates an image having the specified pixel type.

--- a/Modules/Core/include/mitkDicomTagsList.h
+++ b/Modules/Core/include/mitkDicomTagsList.h
@@ -788,4 +788,25 @@ namespace mitk {
     std::make_pair("0018|0060", "dicom.Kvp"),
     std::make_pair("0020|0032", "dicom.ImagePosition")
   };
+
+  static const std::vector<std::string> propertiesToLocalize = {
+    // Patient module
+    "dicom.patient.PatientsName",
+    "dicom.patient.PatientsBirthDate",
+    "dicom.patient.PatientsSex",
+    "dicom.patient.PatientsBirthTime",
+    "dicom.patient.OtherPatientNames",
+    "dicom.patient.EthnicGroup",
+    "dicom.patient.PatientComments",
+    "dicom.patient.PatientIdentityRemoved",
+    "dicom.patient.DeIdentificationMethod",
+
+    // General Study module
+    "dicom.study.InstitutionName",
+    "dicom.study.StudyDescription",
+
+    // General Series module
+    "dicom.series.SeriesDescription",
+    "dicom.series.BodyPartExamined"
+  };
 }


### PR DESCRIPTION
https://jira.smuit.ru/browse/AUT-3733

Добавляет локализацию некоторых мета данных в процесс чтения дайкома. Стандартные кодовые имена взяты из DCMTK.

1. Открыть исследование приложенное в AUT-3733 во вьювере
ER: Русские символы правильно отображаются