### PR TITLE
Добавлена блокировка при загрузке нод

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,7 +186,7 @@ endmacro()
 # -----------------------------------------
 # General build options
 env_option(MITK_USE_TOF_KINECTV2 "Enable support for Kinect V2 camera" OFF)
-env_option(MITK_PDB "Enable debug information for windows" ON)
+env_option(MITK_PDB "Enable debug information for windows" OFF)
 
 option(BUILD_SHARED_LIBS "Build MITK with shared libraries" ON)
 option(WITH_COVERAGE "Enable/Disable coverage" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,7 +186,7 @@ endmacro()
 # -----------------------------------------
 # General build options
 env_option(MITK_USE_TOF_KINECTV2 "Enable support for Kinect V2 camera" OFF)
-env_option(MITK_PDB "Enable debug information for windows" OFF)
+env_option(MITK_PDB "Enable debug information for windows" ON)
 
 option(BUILD_SHARED_LIBS "Build MITK with shared libraries" ON)
 option(WITH_COVERAGE "Enable/Disable coverage" OFF)

--- a/Modules/SceneSerialization/src/mitkSceneReaderV1.cpp
+++ b/Modules/SceneSerialization/src/mitkSceneReaderV1.cpp
@@ -99,6 +99,8 @@ bool mitk::SceneReaderV1::LoadScene(TiXmlDocument& document, const std::string& 
         }
 
         bool localError =false;
+        static std::recursive_mutex mutex;
+        std::lock_guard<std::recursive_mutex> lock(mutex);
         auto result = LoadBaseDataFromDataTag(dataElement, workingDirectory, localError);
         if (localError) {
           error = true;


### PR DESCRIPTION
Пока временное решение.
Внутри функции "load" используется общие данные, и при параллельной загрузки портятся ноды. 

https://jira.smuit.ru/browse/AUT-3842