### PR TITLE
Separate crosshair control in 2D and 3D AUT-3673

### DIFF
--- a/Modules/Core/src/Rendering/mitkPlaneGeometryDataVtkMapper3D.cpp
+++ b/Modules/Core/src/Rendering/mitkPlaneGeometryDataVtkMapper3D.cpp
@@ -219,12 +219,6 @@ namespace mitk
     bool render3d = true;
 
     GetDataNode()->GetVisibility(visible, renderer, "visible");
-    GetDataNode()->GetBoolProperty("Crosshair.Render 3D", render3d, renderer);
-
-    if (!render3d) {
-      return;
-    }
-
     if ( !visible )
     {
       // visibility has explicitly to be set in the single actors
@@ -248,6 +242,11 @@ namespace mitk
     bool drawEdges = true;
     this->GetDataNode()->GetBoolProperty("draw edges", drawEdges, renderer);
     m_EdgeActor->SetVisibility(drawEdges);
+
+    GetDataNode()->GetBoolProperty("Crosshair.Render 3D", render3d, renderer);
+    if (!render3d) {
+      return;
+    }
 
     PlaneGeometryData::Pointer input = const_cast< PlaneGeometryData * >(this->GetInput());
 

--- a/Modules/QtWidgets/include/QmitkRenderWindow.h
+++ b/Modules/QtWidgets/include/QmitkRenderWindow.h
@@ -109,6 +109,8 @@ public:
   void setTwoDimensionalViewState(bool state);
   bool isTwoDimensionalViewState();
 
+  void updateAllWindows();
+
 protected:
   // overloaded move handler
   virtual void moveEvent(QMoveEvent* event) override;

--- a/Modules/QtWidgets/include/QmitkRenderWindowMenu.h
+++ b/Modules/QtWidgets/include/QmitkRenderWindowMenu.h
@@ -96,6 +96,8 @@ public:
 
   void NotifyNewWidgetPlanesMode( int mode );
 
+  void updateWindows();
+
 protected:
 
   /*! Create menu widget. The menu contains five QPushButtons (hori-split, verti-split, full-screen, settings and close button)

--- a/Modules/QtWidgets/include/QmitkStdMultiWidget.h
+++ b/Modules/QtWidgets/include/QmitkStdMultiWidget.h
@@ -60,7 +60,7 @@ private:
   void UpdateAnnotationFonts();
 
 public:
-  QmitkStdMultiWidget(QWidget* parent = 0, Qt::WindowFlags f = 0, mitk::RenderingManager* renderingManager = 0, mitk::BaseRenderer::RenderingMode::Type renderingMode = mitk::BaseRenderer::RenderingMode::Standard, const QString& name = "stdmulti");
+  QmitkStdMultiWidget(QWidget* parent = 0, Qt::WindowFlags f = 0, mitk::RenderingManager* renderingManager = 0, mitk::BaseRenderer::RenderingMode::Type renderingMode = mitk::BaseRenderer::RenderingMode::Standard, const QString& name = "stdmulti", bool crosshairVisibility3D = true);
   virtual ~QmitkStdMultiWidget();
 
   mitk::SliceNavigationController*
@@ -105,7 +105,7 @@ public:
 
   bool IsDepartmentLogoEnabled() const;
 
-  void InitializeWidget();
+  void InitializeWidget(bool showPlanesIn3d);
 
   /// called when the StdMultiWidget is closed to remove the 3 widget planes and the helper node from the DataStorage
   void RemovePlanesFromDataStorage();
@@ -288,6 +288,8 @@ signals:
   void WidgetPlaneModeChange(int);
   void WidgetNotifyNewCrossHairMode(int);
   void Moved();
+
+  void savePlaneVisibility3D(bool visibility);
 
 public:
 

--- a/Modules/QtWidgets/include/mitkCrosshairManager.h
+++ b/Modules/QtWidgets/include/mitkCrosshairManager.h
@@ -39,6 +39,7 @@ class MITKQTWIDGETS_EXPORT mitkCrosshairManager : public QObject {
   Q_OBJECT
 public:
   mitkCrosshairManager(const QString& parentWidget);
+  ~mitkCrosshairManager();
 
   // Changes crosshair mode for selected windows
   void setCrosshairMode(CrosshairMode mode);
@@ -95,8 +96,11 @@ public:
 
   std::function<bool(QmitkRenderWindow*, QmitkRenderWindow*)>* checkWindowsShareCrosshair;
 
+  bool getShowPlanesIn3D();
+
 signals:
   void crosshairModeChanged(CrosshairMode mode);
+  void savePlaneVisibilityIn3D(bool visibility);
 
 private:
   bool hasWindow(QmitkRenderWindow* window);

--- a/Modules/QtWidgets/src/QmitkRenderWindow.cpp
+++ b/Modules/QtWidgets/src/QmitkRenderWindow.cpp
@@ -615,3 +615,10 @@ bool QmitkRenderWindow::isTwoDimensionalViewState()
 {
   return m_IsTwoDimensionalView;
 }
+
+void QmitkRenderWindow::updateAllWindows()
+{
+  if (m_MenuWidget) {
+    m_MenuWidget->updateWindows();
+  }
+}

--- a/Modules/QtWidgets/src/QmitkRenderWindowMenu.cpp
+++ b/Modules/QtWidgets/src/QmitkRenderWindowMenu.cpp
@@ -800,6 +800,17 @@ void QmitkRenderWindowMenu::OnCrossHairMenuAboutToShow()
 
   crosshairModesMenu->clear();
 
+  // Show/hide crosshair
+  {
+    QAction* showHideCrosshairAction = crosshairModesMenu->addAction(tr("Show Crosshair"));
+    showHideCrosshairAction->setCheckable(true);
+    showHideCrosshairAction->setChecked(m_MultiWidget->crosshairManager->getShowPlanesIn3D());
+    connect(showHideCrosshairAction, &QAction::triggered, this, [this] (bool state) {
+      m_MultiWidget->crosshairManager->setShowPlanesIn3d(state);
+      updateWindows();
+    });
+  }
+
   // Rotation mode
   {
     QAction* rotationGroupSeparator = new QAction(crosshairModesMenu);
@@ -949,4 +960,11 @@ void QmitkRenderWindowMenu::SetFullScreenMode(bool state)
   //change icon
   this->ChangeFullScreenIcon();
   DeferredShowMenu();
+}
+
+void QmitkRenderWindowMenu::updateWindows()
+{
+  if (m_MultiWidget && m_MultiWidget->crosshairManager) {
+    m_MultiWidget->crosshairManager->updateAllWindows();
+  }
 }

--- a/Modules/QtWidgets/src/QmitkStdMultiWidget.cpp
+++ b/Modules/QtWidgets/src/QmitkStdMultiWidget.cpp
@@ -64,7 +64,7 @@ void QmitkStdMultiWidget::UpdateAnnotationFonts()
   }
 }
 
-QmitkStdMultiWidget::QmitkStdMultiWidget(QWidget* parent, Qt::WindowFlags f, mitk::RenderingManager* renderingManager, mitk::BaseRenderer::RenderingMode::Type renderingMode, const QString& name)
+QmitkStdMultiWidget::QmitkStdMultiWidget(QWidget* parent, Qt::WindowFlags f, mitk::RenderingManager* renderingManager, mitk::BaseRenderer::RenderingMode::Type renderingMode, const QString& name, bool crosshairVisibility3D)
   : QWidget(parent, f),
   mitkWidget1(NULL),
   mitkWidget2(NULL),
@@ -237,7 +237,7 @@ QmitkStdMultiWidget::QmitkStdMultiWidget(QWidget* parent, Qt::WindowFlags f, mit
   this->resize( QSize(364, 477).expandedTo(minimumSizeHint()) );
 
   //Initialize the widgets.
-  this->InitializeWidget();
+  this->InitializeWidget(crosshairVisibility3D);
 
   //Activate Widget Menu
   this->ActivateMenuWidget( true );
@@ -250,13 +250,12 @@ QmitkStdMultiWidget::QmitkStdMultiWidget(QWidget* parent, Qt::WindowFlags f, mit
   connect(mitkWidget4, &QmitkRenderWindow::resized, this, &QmitkStdMultiWidget::OnWindowResized);
 }
 
-void QmitkStdMultiWidget::InitializeWidget()
+void QmitkStdMultiWidget::InitializeWidget(bool showPlanesIn3d)
 {
   crosshairManager = new mitkCrosshairManager(m_Name);
   crosshairManager->removeAll();
   crosshairManager->setShowSelectedOnly(false);
-  crosshairManager->setShowSelectedOnly(false);
-  crosshairManager->setShowPlanesIn3d(true);
+  crosshairManager->setShowPlanesIn3d(showPlanesIn3d);
   crosshairManager->setShowPlanesIn3dWithoutCursor(false);
   crosshairManager->setUseWindowsColors(true);
   crosshairManager->setUseCrosshairGap(true);
@@ -362,6 +361,8 @@ void QmitkStdMultiWidget::InitializeWidget()
   for (unsigned int i = 0; i < 4; i++) {
     crosshairManager->addWindow(GetRenderWindow(i));
   }
+
+  connect(crosshairManager, &mitkCrosshairManager::savePlaneVisibilityIn3D, this, &QmitkStdMultiWidget::savePlaneVisibility3D);
 }
 
 void QmitkStdMultiWidget::FillGradientBackgroundWithBlack()

--- a/Modules/QtWidgets/src/mitkCrosshairManager.cpp
+++ b/Modules/QtWidgets/src/mitkCrosshairManager.cpp
@@ -24,6 +24,11 @@ mitkCrosshairManager::mitkCrosshairManager(const QString& parentWidget) :
   m_CrosshairMode = crosshairModeController->getMode();
 }
 
+mitkCrosshairManager::~mitkCrosshairManager()
+{
+  emit savePlaneVisibilityIn3D(m_ShowPlanesIn3d);
+}
+
 void mitkCrosshairManager::setCrosshairMode(CrosshairMode mode)
 {
   if (mode == m_CrosshairMode) {
@@ -92,12 +97,14 @@ void mitkCrosshairManager::updateAllWindows()
   }
 }
 
-void mitkCrosshairManager::setDefaultProperties(mitk::DataNode::Pointer crosshair) {
+void mitkCrosshairManager::setDefaultProperties(mitk::DataNode::Pointer crosshair)
+{
   crosshair->SetIntProperty("layer", 1000);
   crosshair->SetBoolProperty("crosshair", true);
   crosshair->SetBoolProperty("includeInBoundingBox", false);
   crosshair->SetBoolProperty("helper object", true);
   crosshair->SetProperty("parentWidget", mitk::StringProperty::New(m_ParentWidget.toStdString()));
+  crosshair->SetBoolProperty("draw edges", true);
 }
 
 void mitkCrosshairManager::addPlaneCrosshair(QmitkRenderWindow* window, bool render2d, bool render3d)
@@ -114,6 +121,7 @@ void mitkCrosshairManager::addPlaneCrosshair(QmitkRenderWindow* window, bool ren
     crosshair->SetIntProperty("Crosshair.Gap Size", m_UseCrosshairGap ? m_CrosshairGap : 0);
     crosshair->SetBoolProperty("Crosshair.Render 2D", render2d);
     crosshair->SetBoolProperty("Crosshair.Render 3D", render3d);
+    crosshair->SetBoolProperty("draw edges", render3d);
     dataStorage->Add(crosshair);
   } else {
     // Display all planes from other windows
@@ -134,6 +142,7 @@ void mitkCrosshairManager::addPlaneCrosshair(QmitkRenderWindow* window, bool ren
       crosshair->SetIntProperty("Crosshair.Gap Size", m_UseCrosshairGap ? m_CrosshairGap : 0);
       crosshair->SetBoolProperty("Crosshair.Render 2D", render2d);
       crosshair->SetBoolProperty("Crosshair.Render 3D", render3d);
+      crosshair->SetBoolProperty("draw edges", render3d);
       dataStorage->Add(crosshair);
     }
   }
@@ -234,10 +243,13 @@ void mitkCrosshairManager::addCrosshair(QmitkRenderWindow* window)
     case CrosshairMode::POINT:
       addPointCrosshair(window);
       if (m_ShowPlanesIn3d) {
-        addPlaneCrosshair(window, false, true);
+        addPlaneCrosshair(window, false, m_ShowPlanesIn3d);
       }
       break;
     case CrosshairMode::NONE:
+      if (m_ShowPlanesIn3d) {
+        addPlaneCrosshair(window, false, m_ShowPlanesIn3d);
+      }
     default:
       if (m_ShowPlanesIn3dWithoutCursor) {
         addPlaneCrosshair(window, false, true);
@@ -394,4 +406,9 @@ void mitkCrosshairManager::updateSwivelColors(QmitkRenderWindow* updatedWindow)
     }
     window->GetRenderer()->RequestUpdate();
   }
+}
+
+bool mitkCrosshairManager::getShowPlanesIn3D()
+{
+  return m_ShowPlanesIn3d;
 }

--- a/Plugins/org.mitk.gui.qt.stdmultiwidgeteditor/src/QmitkStdMultiWidgetEditor.cpp
+++ b/Plugins/org.mitk.gui.qt.stdmultiwidgeteditor/src/QmitkStdMultiWidgetEditor.cpp
@@ -267,15 +267,19 @@ void QmitkStdMultiWidgetEditor::CreateQtPartControl(QWidget* parent)
 
     if (d->m_MouseModeToolbar == NULL)
     {
-      d->m_MouseModeToolbar = new QmitkMouseModeSwitcher(parent); // delete by Qt via parent
+      d->m_MouseModeToolbar = new QmitkMouseModeSwitcher(); // delete by Qt via parent
       layout->addWidget(d->m_MouseModeToolbar);
+      d->m_MouseModeToolbar->setParent(d->m_StdMultiWidget);
     }
 
     berry::IPreferences::Pointer prefs = this->GetPreferences();
 
     mitk::BaseRenderer::RenderingMode::Type renderingMode = static_cast<mitk::BaseRenderer::RenderingMode::Type>(prefs->GetInt( "Rendering Mode" , 0 ));
 
-    d->m_StdMultiWidget = new QmitkStdMultiWidget(parent,0,0,renderingMode);
+    QString planeProperty("Plane Visibility 3D");
+    bool planeVisibility3D = prefs->GetBool(planeProperty, true);
+
+    d->m_StdMultiWidget = new QmitkStdMultiWidget(parent, 0, 0, renderingMode, "stdmulti", planeVisibility3D);
     d->m_RenderWindows.insert("axial", d->m_StdMultiWidget->GetRenderWindow1());
     d->m_RenderWindows.insert("sagittal", d->m_StdMultiWidget->GetRenderWindow2());
     d->m_RenderWindows.insert("coronal", d->m_StdMultiWidget->GetRenderWindow3());
@@ -318,6 +322,12 @@ void QmitkStdMultiWidgetEditor::CreateQtPartControl(QWidget* parent)
     this->OnPreferencesChanged(berryprefs);
 
     this->RequestUpdate();
+
+    d->m_StdMultiWidget->GetRenderWindow4()->updateAllWindows();
+
+    connect(d->m_StdMultiWidget, &QmitkStdMultiWidget::savePlaneVisibility3D, this, [berryprefs, planeProperty] (bool state) {
+      berryprefs->PutBool(planeProperty, state);
+    });
   }
 }
 


### PR DESCRIPTION
Добавлено раздельное управление перекрестием в 2D (через классическое меню вверху) и 3D (через меню 3D окна) на вкладке Editor, так же при закрытии Автоплана сохраняется текущее состояние видимости перекрестия в 3D.

https://jira.smuit.ru/browse/AUT-3673