### PR TITLE
Fix itk contour filter. AUT-3683 [clean]

### DIFF
--- a/CMakeExternals/ITK.cmake
+++ b/CMakeExternals/ITK.cmake
@@ -114,6 +114,7 @@ if(NOT DEFINED ITK_DIR)
        COMMAND ${PATCH_COMMAND} -N -p1 -i ${CMAKE_CURRENT_LIST_DIR}/ITK_fixed_4D_progress.patch
        COMMAND ${PATCH_COMMAND} -N -p1 -i ${CMAKE_CURRENT_LIST_DIR}/ITK_rescaling_fix.patch
        COMMAND ${PATCH_COMMAND} -N -p1 -i ${CMAKE_CURRENT_LIST_DIR}/ITK-4.9-accurate-spacingZ.patch
+       COMMAND ${PATCH_COMMAND} -N -p1 -i ${CMAKE_CURRENT_LIST_DIR}/ITK_itkIsoContourDistanceImageFilter.patch
      CMAKE_GENERATOR ${gen}
      CMAKE_ARGS
        ${ep_common_args}

--- a/CMakeExternals/ITK_itkIsoContourDistanceImageFilter.patch
+++ b/CMakeExternals/ITK_itkIsoContourDistanceImageFilter.patch
@@ -1,0 +1,24 @@
+--- a/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.hxx	2016-01-30 01:39:15.000000000 +0400
++++ b/Modules/Filtering/DistanceMap/include/itkIsoContourDistanceImageFilter.hxx	2018-12-17 13:25:03.431650600 +0400
+@@ -389,7 +389,20 @@
+         }
+       else
+         {
+-        itkExceptionMacro(<< "Gradient norm is lower than pixel precision");
++        // -- AUTOPLAN start --
++        // Neighbours are pretty much equal. Take one of them as interpolated value
++        PixelRealType val = inNeigIt.GetNext(n, 1);
++        if (std::fabs(static_cast< double >(val)) < std::fabs(static_cast< double >(outNeigIt.GetNext(n, 0))))
++          {
++          outNeigIt.SetNext(n, 0, static_cast< PixelType >(val));
++          }
++        if (std::fabs(static_cast< double >(val)) < std::fabs(static_cast< double >(outNeigIt.GetNext(n, 1))))
++          {
++          outNeigIt.SetNext(n, 1, static_cast< PixelType >(val));
++          }
++        
++        //itkExceptionMacro(<< "Gradient norm is lower than pixel precision");
++        // -- AUTOPLAN end --
+         }
+       } // end if (sign != signNeigh)
+     }   //end for n


### PR DESCRIPTION
https://jira.smuit.ru/browse/AUT-3683

Фильтр из ITK падал при специфичных значениях в ядре, например:
```
0 1 0         0 0 0
1 C 0   или   1 С 1
0 1 0         0 1 0
```
После патча, вместо падения, берется значение соседа для интерполяции. Что может привести к неожиданным последствиям во всех алгоритмах, которые используют этот фильтр, так как не понятно ожидаемое поведение для ITK в такой ситуации.