### PR TITLE
Падение при отключении перекрестия AUT-4118

### DIFF
--- a/Modules/QtWidgets/src/mitkCrosshairManager.cpp
+++ b/Modules/QtWidgets/src/mitkCrosshairManager.cpp
@@ -251,6 +251,7 @@ void mitkCrosshairManager::addCrosshair(QmitkRenderWindow* window)
       if (m_ShowPlanesIn3d) {
         addPlaneCrosshair(window, false, m_ShowPlanesIn3d);
       }
+      break;
     default:
       if (m_ShowPlanesIn3dWithoutCursor) {
         addPlaneCrosshair(window, false, true);


### PR DESCRIPTION
Происходило повторное добавление crosshair.

https://jira.smuit.ru/browse/AUT-4118