### PR TITLE
Настройка яркости в 2D окнах

### DIFF
--- a/Modules/AppUtil/src/QmitkSafeNotify.h
+++ b/Modules/AppUtil/src/QmitkSafeNotify.h
@@ -26,10 +26,13 @@ template<class A>
 bool QmitkSafeNotify(A* app, QObject* receiver, QEvent* event)
 {
   QString msg;
+#ifdef NDEBUG
   try
+#endif
   {
     return app->A::notify(receiver, event);
   }
+#ifdef NDEBUG
   catch (mitk::Exception& e)
   {
     msg = QString("MITK Exception:\n\n")
@@ -71,6 +74,7 @@ bool QmitkSafeNotify(A* app, QObject* receiver, QEvent* event)
   }
 
   return false;
+#endif /*NDEBUG*/
 }
 
 #endif // QMITKSAFENOTIFY_H

--- a/Modules/Core/resource/Interactions/DisplayConfigMITK.xml
+++ b/Modules/Core/resource/Interactions/DisplayConfigMITK.xml
@@ -12,7 +12,7 @@
   <!-- Zoom either by moving mouse leftright or updown -->
   <param name="zoomDirection" value="updown"/>
   <!-- react to an event, even tough is was already processed by a DataInteractor-->
-  <param name="alwaysReact" value="false"/>
+  <param name="alwaysReact" value="true"/>
   <!-- reverse levelWindow reaction -->
   <param name="levelWindowDirection" value="updown"/>
 


### PR DESCRIPTION
* 3D-окно мешало настраивать яркость по движению Alt+ЛКМ.
* Убрал обработку исключений по-умолчанию (пусть лучше падает), если не определён макрос NDEBUG