### PR TITLE
Правки по планарным фигурам AUT-3969, AUT-3828

### DIFF
--- a/Modules/ImageStatistics/mitkImageStatisticsCalculator.cpp
+++ b/Modules/ImageStatistics/mitkImageStatisticsCalculator.cpp
@@ -2159,11 +2159,6 @@ namespace mitk
       mitkThrow() << "Figure has a zero area and cannot be used for masking.";
     }
 
-    if ( outOfBounds )
-    {
-      throw std::runtime_error( "Figure at least partially outside of image bounds!" );
-    }
-
     // create a vtkLassoStencilSource and set the points of the Polygon
     vtkSmartPointer<vtkLassoStencilSource> lassoStencil = vtkSmartPointer<vtkLassoStencilSource>::New();
     lassoStencil->SetShapeToPolygon();

--- a/Modules/PlanarFigure/src/DataManagement/mitkPlanarCircle.cpp
+++ b/Modules/PlanarFigure/src/DataManagement/mitkPlanarCircle.cpp
@@ -68,12 +68,6 @@ mitk::Point2D mitk::PlanarCircle::ApplyControlPointConstraints(unsigned int inde
   Point2D indexPoint;
   this->GetPlaneGeometry()->WorldToIndex( point, indexPoint );
 
-  const BoundingBox::BoundsArrayType bounds = this->GetPlaneGeometry()->GetBounds();
-  if ( indexPoint[0] < bounds[0] ) { indexPoint[0] = bounds[0]; }
-  if ( indexPoint[0] > bounds[1] ) { indexPoint[0] = bounds[1]; }
-  if ( indexPoint[1] < bounds[2] ) { indexPoint[1] = bounds[2]; }
-  if ( indexPoint[1] > bounds[3] ) { indexPoint[1] = bounds[3]; }
-
   Point2D constrainedPoint;
   this->GetPlaneGeometry()->IndexToWorld( indexPoint, constrainedPoint );
 

--- a/Modules/QtWidgets/src/mitkCrosshairManager.cpp
+++ b/Modules/QtWidgets/src/mitkCrosshairManager.cpp
@@ -410,8 +410,3 @@ void mitkCrosshairManager::updateSwivelColors(QmitkRenderWindow* updatedWindow)
     window->GetRenderer()->RequestUpdate();
   }
 }
-
-bool mitkCrosshairManager::getShowPlanesIn3D()
-{
-  return m_ShowPlanesIn3d;
-}


### PR DESCRIPTION
https://jira.smuit.ru/browse/AUT-3969
При выходе за пределы изображения теперь производится расчет статистики, но при этом не учитываются точки, которые не принадлежат изображению.   

https://jira.smuit.ru/browse/AUT-3828
Удалено переопределение контрольных точек планарной фигуры ("круг") при выходе за пределы изображения 