### PR TITLE
Закрашивание фона редактора при смене вкладки 

### DIFF
--- a/Plugins/org.blueberry.ui.qt/src/internal/berryEditorSashContainer.cpp
+++ b/Plugins/org.blueberry.ui.qt/src/internal/berryEditorSashContainer.cpp
@@ -100,7 +100,9 @@ PartStack::Pointer EditorSashContainer::NewEditorWorkbook()
 QWidget* EditorSashContainer::CreateParent(QWidget* parentWidget)
 {
   //return Tweaklets::Get(GuiWidgetsTweaklet::KEY)->CreateComposite(parentWidget);
-  return new QtDnDControlWidget(static_cast<QWidget*>(parentWidget));
+  auto p = new QtDnDControlWidget(static_cast<QWidget*>(parentWidget));
+  p->setAutoFillBackground(true);
+  return p;
 }
 
 void EditorSashContainer::DisposeParent()


### PR DESCRIPTION
При открытии редактора на месте изображений на короткое время показывалась первая вкладка (Открыть). Теперь окно закрашивается цветом фона.
[AUT-4068](https://jira.smuit.ru/browse/AUT-4068)