### PR TITLE
Deleted aicpregistration, igttracking and tofutil

### DIFF
--- a/Plugins/PluginList.cmake
+++ b/Plugins/PluginList.cmake
@@ -45,7 +45,7 @@ set(MITK_PLUGINS
   #org.mitk.gui.qt.segmentation:ON
   org.mitk.gui.qt.viewnavigator:ON
   org.mitk.gui.qt.registration:OFF
-  org.mitk.gui.qt.toftutorial:OFF
+  #org.mitk.gui.qt.toftutorial:OFF
   org.mitk.gui.qt.volumevisualization:OFF
   org.mitk.gui.qt.pointsetinteraction:OFF
   org.mitk.core.services:ON
@@ -72,8 +72,8 @@ set(MITK_PLUGINS
   org.mitk.gui.qt.imagenavigator:ON
   org.mitk.gui.qt.remeshing:ON
   org.mitk.gui.qt.imagestatistics:ON
-  org.mitk.gui.qt.tofutil:OFF
-  org.mitk.gui.qt.igttracking:OFF
+  #org.mitk.gui.qt.tofutil:OFF
+  #org.mitk.gui.qt.igttracking:OFF
 )
 
 IF(MITK_USE_TOF_KINECTV2)

--- a/Plugins/PluginList.cmake
+++ b/Plugins/PluginList.cmake
@@ -74,14 +74,5 @@ set(MITK_PLUGINS
   org.mitk.gui.qt.imagestatistics:ON
   #org.mitk.gui.qt.tofutil:OFF
   #org.mitk.gui.qt.igttracking:OFF
+  #org.mitk.gui.qt.aicpregistration:OFF
 )
-
-IF(MITK_USE_TOF_KINECTV2)
-  list(APPEND MITK_PLUGINS
-    org.mitk.gui.qt.aicpregistration:ON
-  )
-ELSE(MITK_USE_TOF_KINECTV2)
-  list(APPEND MITK_PLUGINS
-    org.mitk.gui.qt.aicpregistration:OFF
-  )
-ENDIF(MITK_USE_TOF_KINECTV2)


### PR DESCRIPTION
Удалены из сборки следующие плагины:
 - org.mitk.gui.qt.aicpregistration;
 - org.mitk.gui.qt.igttracking;
 - org.mitk.gui.qt.tofutil.

https://jira.smuit.ru/browse/AUT-4081