### PR TITLE
Add legacy ways to get models

### DIFF
--- a/Modules/Segmentation/DataManagement/mitkSurfaceUtils.h
+++ b/Modules/Segmentation/DataManagement/mitkSurfaceUtils.h
@@ -98,6 +98,10 @@ public:
     m_Args = args;
   }
 
+  // Deprecated methods for dumdums
+  vtkSmartPointer<vtkPolyData> getPolyData();
+  void populateCreationProperties(mitk::DataNode::Pointer segNode);
+
 protected:
   SurfaceCreator();
   virtual ~SurfaceCreator() {}


### PR DESCRIPTION
Добавляет методы для поддержки старой логики создания модели

Используется в ПР к автоплану: https://github.com/samsmu/AutoplanApplication/pull/2693