### PR TITLE
Fix always reacting interactor

### DIFF
--- a/Modules/Core/resource/Interactions/DisplayConfigMITK.xml
+++ b/Modules/Core/resource/Interactions/DisplayConfigMITK.xml
@@ -12,7 +12,7 @@
   <!-- Zoom either by moving mouse leftright or updown -->
   <param name="zoomDirection" value="updown"/>
   <!-- react to an event, even tough is was already processed by a DataInteractor-->
-  <param name="alwaysReact" value="true"/>
+  <param name="alwaysReact" value="false"/>
   <!-- reverse levelWindow reaction -->
   <param name="levelWindowDirection" value="updown"/>
 


### PR DESCRIPTION
https://jira.smuit.ru/browse/AUT-4193
https://jira.smuit.ru/browse/AUT-4197

Отключает свойство дисплей интерактора alwaysReact, которое приводило к проблемам с другими интеракторами.

Связан с https://github.com/samsmu/MITK/pull/550 
Фикс для баги описанной в этом ПР:  https://github.com/samsmu/AutoplanApplication/pull/2696

1. Запустить инкрементальную сегментацию
2. Попытаться удалить сегментацию с зажатым ctrl
ER: Срезы не меняются