### PR TITLE
Fix model smoothness

### DIFF
--- a/CMakeExternals/VTK.cmake
+++ b/CMakeExternals/VTK.cmake
@@ -99,6 +99,7 @@ if(NOT DEFINED VTK_DIR)
         -DVTK_MAKE_INSTANTIATORS:BOOL=ON
         -DVTK_USE_CXX11_FEATURES:BOOL=ON
         -DVTK_RENDERING_BACKEND:STRING=OpenGL
+        -DVTK_SMP_IMPLEMENTATION_TYPE=OpenMP
         ${additional_cmake_args}
     CMAKE_CACHE_ARGS
       ${ep_common_cache_args}

--- a/Modules/Segmentation/Algorithms/mitkShowSegmentationAsAgtkSurface.h
+++ b/Modules/Segmentation/Algorithms/mitkShowSegmentationAsAgtkSurface.h
@@ -1,13 +1,5 @@
 #include <MitkSegmentationExports.h>
 
-#include <vtkCallbackCommand.h>
-#include <vtkDecimatePro.h>
-#include <vtkMarchingCubes.h>
-#include <vtkPolyDataNormals.h>
-#include <vtkQuadricDecimation.h>
-#include <vtkSmoothPolyDataFilter.h>
-#include <vtkWindowedSincPolyDataFilter.h>
-
 #include <itkAddImageFilter.h>
 #include <itkConstantPadImageFilter.h>
 #include <itkDiscreteGaussianImageFilter.h>
@@ -65,7 +57,7 @@ public:
     SurfaceDecimationType decimationType = SurfaceDecimationType::DecimatePro;
     float reduction = .25f;
     bool isResampling = true;
-    float spacing = 1.f;
+    mitk::Vector3D spacing = 1.f;
     bool isFillHoles = true;
   };
 

--- a/Modules/Segmentation/DataManagement/mitkSurfaceUtils.cpp
+++ b/Modules/Segmentation/DataManagement/mitkSurfaceUtils.cpp
@@ -268,7 +268,7 @@ vtkSmartPointer<vtkPolyData> SurfaceCreator::createModelAgtk(DataNode::Pointer s
   }
 
   surfaceParams.decimationType = ShowSegmentationAsAgtkSurface::SurfaceDecimationType::None;
-  surfaceParams.isResampling = true;
+  surfaceParams.isResampling = false;
 
   if (args.decimation) {
     surfaceParams.decimationType = ShowSegmentationAsAgtkSurface::SurfaceDecimationType::DecimatePro;
@@ -290,6 +290,8 @@ vtkSmartPointer<vtkPolyData> SurfaceCreator::createModelAgtk(DataNode::Pointer s
     surfaceParams.smoothingType = ShowSegmentationAsAgtkSurface::SurfaceSmoothingType::None;
     surfaceParams.decimationType = ShowSegmentationAsAgtkSurface::SurfaceDecimationType::None;
   }
+
+  surfaceParams.spacing = image->GetGeometry()->GetSpacing();
 
   ShowSegmentationAsAgtkSurface::Pointer surfaceBuilder = ShowSegmentationAsAgtkSurface::New();
   surfaceBuilder->setArgs(args, surfaceParams);


### PR DESCRIPTION
https://jira.smuit.ru/browse/AUT-4196

Исправляет регресс с переразмазыванием модели. 
В качестве фикса проблемы с бороздкой заменяет алгоритм генерации полигонов с vtkMarchingCubes на более новый vtkFlyingEdges.
Стоит отметить, что результат работы не совпадает 100% с предыдущим алгоритмом, но незначительно.

Новые алгоритмы используют vtkSMPTools для распаралеливания алгоритмов. Включает OpenMP бекэнд для vtkSMPTools (раньше был без распаралеливания)

1. Открыть 1062/segmentation/archive/1062-v3.mitk
2. Перепостроить модель
ER: Модель поменялась незначительно.
