### PR TITLE
Half-ass fix for transparency. AUT-4178 [skip-ci]

### DIFF
--- a/Plugins/org.mitk.gui.qt.stdmultiwidgeteditor/src/QmitkStdMultiWidgetEditor.cpp
+++ b/Plugins/org.mitk.gui.qt.stdmultiwidgeteditor/src/QmitkStdMultiWidgetEditor.cpp
@@ -274,7 +274,7 @@ void QmitkStdMultiWidgetEditor::CreateQtPartControl(QWidget* parent)
 
     berry::IPreferences::Pointer prefs = this->GetPreferences();
 
-    mitk::BaseRenderer::RenderingMode::Type renderingMode = static_cast<mitk::BaseRenderer::RenderingMode::Type>(prefs->GetInt( "Rendering Mode" , 0 ));
+    mitk::BaseRenderer::RenderingMode::Type renderingMode = static_cast<mitk::BaseRenderer::RenderingMode::Type>(prefs->GetInt( "Rendering Mode" , 2 ));
 
     QString planeProperty("Plane Visibility 3D");
     bool planeVisibility3D = prefs->GetBool(planeProperty, true);

--- a/Plugins/org.mitk.gui.qt.stdmultiwidgeteditor/src/internal/QmitkStdMultiWidgetEditorPreferencePage.cpp
+++ b/Plugins/org.mitk.gui.qt.stdmultiwidgeteditor/src/internal/QmitkStdMultiWidgetEditorPreferencePage.cpp
@@ -150,7 +150,7 @@ void QmitkStdMultiWidgetEditorPreferencePage::Update()
   m_Ui->m_DisplayMetaInfo->setChecked(m_Preferences->GetBool("Display metainfo", true));
   m_Ui->m_SelectionMode->setChecked(m_Preferences->GetBool("Selection on 3D View", false));
   //m_Ui->m_PACSLikeMouseMode->setChecked(m_Preferences->GetBool("PACS like mouse interaction", false));
-  int mode= m_Preferences->GetInt("Rendering Mode",0);
+  int mode= m_Preferences->GetInt("Rendering Mode", 2);
   m_Ui->m_RenderingMode->setCurrentIndex(mode);
   m_Ui->m_CrosshairGapSize->setValue(m_Preferences->GetInt("crosshair gap size", 32));
   m_Ui->m_RotationStep->setValue(m_Preferences->GetInt("Rotation Step", 90));


### PR DESCRIPTION
https://jira.smuit.ru/browse/AUT-4178

Выставляет Depth Peeling режим рендеринга дефолтным. Можно вернуть обратно в Editors -> Standard Multi Widget -> Rendering Mode.
Временные изменения, дальше предполагается переход на Dual Depth Peeling алгоритм.

1. Открыть 3д модель
2. Сделать ее прозрачной
ER; Нет визуального артефакта выворачивания модели