### PR TITLE
Полностью удалил универсальный перехват исключений [clean]

### DIFF
--- a/CMakeExternals/CTK-catch.patch
+++ b/CMakeExternals/CTK-catch.patch
@@ -2,25 +2,23 @@ diff --git a/CTK-0/Libs/PluginFramework/ctkDefaultApplicationLauncher.cpp b/CTK/
 index fe37939..48a6fa1 100644
 --- a/Libs/PluginFramework/ctkDefaultApplicationLauncher.cpp
 +++ b/Libs/PluginFramework/ctkDefaultApplicationLauncher.cpp
-@@ -80,10 +80,13 @@ QVariant ctkDefaultApplicationLauncher::start(const QVariant& defaultContext)
+@@ -80,18 +80,7 @@ QVariant ctkDefaultApplicationLauncher::start(const QVariant& defaultContext)
    bool doRelaunch = false;
    do
    {
-+#ifdef NDEBUG
-     try
-+#endif
-     {
-       result = runApplication(defaultContext);
-     }
-+#ifdef NDEBUG
-     catch (const std::exception& e)
-     {
-       if (!relaunch || (context->getPlugin()->getState() != ctkPlugin::ACTIVE))
-@@ -92,6 +95,7 @@ QVariant ctkDefaultApplicationLauncher::start(const QVariant& defaultContext)
-       }
-       qWarning() << "Application error:" << e.what();
-     }
-+#endif
+-    try
+-    {
+-      result = runApplication(defaultContext);
++    result = runApplication(defaultContext);
+-    }
+-    catch (const std::exception& e)
+-    {
+-      if (!relaunch || (context->getPlugin()->getState() != ctkPlugin::ACTIVE))
+-      {
+-        throw;
+-      }
+-      qWarning() << "Application error:" << e.what();
+-    }
      doRelaunch = (relaunch && context->getPlugin()->getState() == ctkPlugin::ACTIVE) ||
                    ctkPluginFrameworkProperties::getProperty(ctkPluginFrameworkLauncher::PROP_OSGI_RELAUNCH).toBool();
    }
@@ -28,43 +26,54 @@ diff --git a/CTK-0/Libs/PluginFramework/ctkPluginFrameworkLauncher.cpp b/CTK/Lib
 index 9597088..7992ed1 100644
 --- a/Libs/PluginFramework/ctkPluginFrameworkLauncher.cpp
 +++ b/Libs/PluginFramework/ctkPluginFrameworkLauncher.cpp
-@@ -417,7 +417,9 @@ QVariant ctkPluginFrameworkLauncher::run(QRunnable* endSplashHandler, const QVar
+@@ -417,32 +417,12 @@ QVariant ctkPluginFrameworkLauncher::run(QRunnable* endSplashHandler, const QVar
      };
      Finalize finalizer;
      Q_UNUSED(finalizer)
-+#ifdef NDEBUG
-     try
-+#endif
-     {
-       startup(endSplashHandler);
-       if (ctkPluginFrameworkProperties::getProperty(PROP_IGNOREAPP).toBool() || d->isForcedRestart())
-@@ -426,6 +428,7 @@ QVariant ctkPluginFrameworkLauncher::run(QRunnable* endSplashHandler, const QVar
-       }
-       return run(argument);
-     }
-+#ifdef NDEBUG
-     catch (const std::exception& e)
-     {
-       // ensure the splash screen is down
-@@ -443,6 +446,7 @@ QVariant ctkPluginFrameworkLauncher::run(QRunnable* endSplashHandler, const QVar
-         qWarning() << "Startup error:" << e.what();
-       }
-     }
-+#endif
+-    try
+-    {
+-      startup(endSplashHandler);
+-      if (ctkPluginFrameworkProperties::getProperty(PROP_IGNOREAPP).toBool() || d->isForcedRestart())
+-      {
+-        return argument;
+-      }
+-      return run(argument);
++    startup(endSplashHandler);
++    if (ctkPluginFrameworkProperties::getProperty(PROP_IGNOREAPP).toBool() || d->isForcedRestart())
++    {
++      return argument;
++    }
++    return run(argument);
+-    }
+-    catch (const std::exception& e)
+-    {
+-      // ensure the splash screen is down
+-      if (endSplashHandler != NULL)
+-      {
+-        endSplashHandler->run();
+-      }
+-      // may use startupFailed to understand where the error happened
+-      if (const ctkException* ce = dynamic_cast<const ctkException*>(&e))
+-      {
+-        qWarning() << "Startup error:" << ce->printStackTrace();
+-      }
+-      else
+-      {
+-        qWarning() << "Startup error:" << e.what();
+-      }
+-    }
    }
  
    // we only get here if an error happened
-@@ -492,11 +492,13 @@ QVariant ctkPluginFrameworkLauncher::run(const QVariant& argument)
+@@ -492,11 +472,6 @@ QVariant ctkPluginFrameworkLauncher::run(const QVariant& argument)
      qWarning() << "Application launch failed:" << e.printStackTrace();
      throw;
    }
-+#ifdef NDEBUG
-   catch (const std::exception& e)
-   {
-     qWarning() << "Application launch failed:" << e.what();
-     throw;
-   }
-+#endif
+-  catch (const std::exception& e)
+-  {
+-    qWarning() << "Application launch failed:" << e.what();
+-    throw;
+-  }
  }
  
  //----------------------------------------------------------------------------

--- a/CMakeExternals/Poco.patch
+++ b/CMakeExternals/Poco.patch
@@ -2,19 +2,18 @@ diff --git a/Poco0/Util/src/Application.cpp b/Poco/Util/src/Application.cpp
 index 6f60ff9..107ec11 100644
 --- a/Util/src/Application.cpp
 +++ b/Util/src/Application.cpp
-@@ -336,6 +336,7 @@ int Application::run()
+@@ -336,14 +336,6 @@ int Application::run()
  	{
  		logger().log(exc);
  	}
-+#ifdef NDEBUG
- 	catch (std::exception& exc)
- 	{
- 		logger().error(exc.what());
-@@ -344,6 +345,7 @@ int Application::run()
- 	{
- 		logger().fatal("system exception");
- 	}
-+#endif
+-	catch (std::exception& exc)
+-	{
+-		logger().error(exc.what());
+-	}
+-	catch (...)
+-	{
+-		logger().fatal("system exception");
+-	}
  
  	uninitialize();
  	return rc;

--- a/Modules/Core/src/Interactions/mitkEventStateMachine.cpp
+++ b/Modules/Core/src/Interactions/mitkEventStateMachine.cpp
@@ -147,24 +147,7 @@ bool mitk::EventStateMachine::HandleEvent(InteractionEvent* event, DataNode* dat
     const ActionVectorType actions = transition->GetActions();
     for (ActionVectorType::const_iterator it = actions.cbegin(); it != actions.cend(); ++it)
     {
-#ifdef NDEBUG
-      try
-#endif
-      {
-        ExecuteAction(*it, event);
-      }
-#ifdef NDEBUG
-      catch( const std::exception& e )
-      {
-        MITK_ERROR << "Unhandled exception caught in ExecuteAction(): " << e.what();
-        return false;
-      }
-      catch( ... )
-      {
-        MITK_ERROR << "Unhandled exception caught in ExecuteAction()";
-        return false;
-      }
-#endif
+      ExecuteAction(*it, event);
     }
 
     return true;
@@ -280,27 +263,8 @@ mitk::StateMachineTransition* mitk::EventStateMachine::GetExecutableTransition( 
       {
         // if the condition has not been evaluated yet, do it now and store
         // the result in the map
-#ifdef NDEBUG
-        try
-#endif
-        {
-          currentConditionFulfilled = CheckCondition( (*conditionIter), event );
-          conditionsMap.insert( std::pair<std::string, bool>(conditionName, currentConditionFulfilled) );
-        }
-#ifdef NDEBUG
-        catch (const std::exception& e)
-        {
-          MITK_ERROR << "Unhandled excaption caught in CheckCondition(): " << e.what();
-          currentConditionFulfilled = false;
-          break;
-        }
-        catch (...)
-        {
-          MITK_ERROR << "Unhandled excaption caught in CheckCondition()";
-          currentConditionFulfilled = false;
-          break;
-        }
-#endif
+        currentConditionFulfilled = CheckCondition( (*conditionIter), event );
+        conditionsMap.insert( std::pair<std::string, bool>(conditionName, currentConditionFulfilled) );
       }
       else
       {


### PR DESCRIPTION
Удалённые обработчики не решали проблемы и делали невозможным дальнейший анализ стека при неожидаемых исключениях.
