### PR TITLE
Чтения DicomDir при загрузки исследования с CD

### DIFF
--- a/Modules/Core/include/mitkDicomSeriesReader.txx
+++ b/Modules/Core/include/mitkDicomSeriesReader.txx
@@ -139,9 +139,13 @@ Image::Pointer DicomSeriesReader::LoadDICOMByITK4D( std::list<StringContainer>& 
     image = preLoadedImageBlock;
   }
 
-  gdcm::Scanner scanner;
-  ScanForSliceInformation(imageBlockDescriptor.GetFilenames(), scanner);
-  CopyMetaDataToImageProperties( imageBlocks, scanner.GetMappings(), io, imageBlockDescriptor, image);
+  if (imageBlockDescriptor.GetSlicesInfo().empty()) {
+    gdcm::Scanner scanner;
+    ScanForSliceInformation(imageBlockDescriptor.GetFilenames(), scanner);
+    CopyMetaDataToImageProperties( imageBlocks, scanner.GetMappings(), io, imageBlockDescriptor, image);
+  } else {
+    CopyMetaDataToImageProperties( imageBlocks, io, imageBlockDescriptor, image);
+  }
 
   MITK_DEBUG << "Volume dimension: [" << image->GetDimension(0) << ", "
     << image->GetDimension(1) << ", "

--- a/Modules/Core/src/IO/mitkDicomSR_ImageBlockDescriptor.cpp
+++ b/Modules/Core/src/IO/mitkDicomSR_ImageBlockDescriptor.cpp
@@ -228,6 +228,7 @@ void DicomSeriesReader::ImageBlockDescriptor::SetNumberOfFrames(const std::strin
   } catch (...) {
   }
 
+  m_NumberOfFrames = numberOfFramesInt;
   m_IsMultiFrameImage = (numberOfFramesInt > 1);
 }
 
@@ -277,4 +278,33 @@ void DicomSeriesReader::ImageBlockDescriptor::SetPhotometricInterpretation(std::
   m_PhotometricInterpretation = interpretation;
 }
 
+std::map<std::string, DicomSeriesReader::SliceInfo> DicomSeriesReader::ImageBlockDescriptor::GetSlicesInfo() const
+{
+  return m_SlicesInfo;
+}
+
+void DicomSeriesReader::ImageBlockDescriptor::SetSlicesInfo(const std::map<std::string, SliceInfo>& slicesInfo)
+{
+  m_SlicesInfo = slicesInfo;
+}
+
+std::string DicomSeriesReader::ImageBlockDescriptor::GetNumberOfFrames() const
+{
+  return m_NumberOfFrames;
+}
+
+void DicomSeriesReader::ImageBlockDescriptor::SetFileNames(const StringContainer& files)
+{
+  m_Filenames = files;
+}
+
+std::string DicomSeriesReader::ImageBlockDescriptor::GetPixelSpacing()
+{
+  return m_PixelSpacing;
+}
+
+std::string DicomSeriesReader::ImageBlockDescriptor::GetImagerPixelSpacing()
+{
+  return m_ImagerPixelSpacing;
+}
 } // end namespace mitk

--- a/Modules/Core/src/IO/mitkDicomSeriesReader.cpp
+++ b/Modules/Core/src/IO/mitkDicomSeriesReader.cpp
@@ -926,7 +926,6 @@ DicomSeriesReader::GetSeriesFromDescriptors(std::map<std::string, mitk::DicomSer
 
     gdcm::Scanner::TagToValue& tagMap = const_cast<gdcm::Scanner::TagToValue&>(fileIter->second);
     const char* seriesInstanceUid = tagMap[tagSeriesInstanceUID];
-    std::cout << "SeriesUid " << seriesInstanceUid << " Name " << fileIter->first << std::endl;
     if (!seriesInstanceUid) {
       continue;
     }


### PR DESCRIPTION
При наличии dicomdir в корне выбранной папки читается следующая информация:
 - кол-во серий и файлы, принадлежащие этой серии;
 - позиция изображений;
 - ориентация;
 - время получения изображения (при его наличии);
иначе эта информация читается пофайлово из каждого дайкома.

https://jira.smuit.ru/browse/AUT-4171
Зависимый PR
https://github.com/samsmu/AutoplanApplication/pull/2724