### PR TITLE
Reduce peak memory in agtk surface creation. AUT-4222

### DIFF
--- a/Modules/Segmentation/Algorithms/mitkShowSegmentationAsAgtkSurface.cpp
+++ b/Modules/Segmentation/Algorithms/mitkShowSegmentationAsAgtkSurface.cpp
@@ -103,12 +103,14 @@ void ShowSegmentationAsAgtkSurface::PreProcessing()
   m_ProgressAccumulator->RegisterInternalFilter(add, m_ProgressWeight);
   add->SetInput1(distanceToForeground->GetOutput());
   add->SetInput2(distanceToBackground->GetOutput());
+  add->InPlaceOn();
 
   typedef itk::MultiplyImageFilter<FloatImage> MultiplyImageFilterType;
   MultiplyImageFilterType::Pointer multiply = MultiplyImageFilterType::New();
   m_ProgressAccumulator->RegisterInternalFilter(multiply, m_ProgressWeight);
   multiply->SetInput(add->GetOutput());
   multiply->SetConstant(.5);
+  multiply->InPlaceOn();
 
   typedef itk::DiscreteGaussianImageFilter<FloatImage, FloatImage> BlurImageFilterType;
   typename BlurImageFilterType::Pointer smoothingImage = BlurImageFilterType::New();
@@ -161,8 +163,13 @@ void ShowSegmentationAsAgtkSurface::ComputeSurface()
   itkToVtk->Update();
   vtkSmartPointer<vtkImageData> vtkImage = itkToVtk->GetOutput();
 
-
   m_CurrentProgress = m_ProgressAccumulator->GetAccumulatedProgress();
+  m_ProgressAccumulator->UnregisterAllFilters();
+
+  itk::Matrix<double, DIM, DIM> tmpDirection = m_FloatTmpImage->GetDirection();
+  itk::Vector<double, DIM> tmpOrigin = m_FloatTmpImage->GetOrigin().GetDataPointer();
+  m_FloatTmpImage->DisconnectPipeline();
+  m_FloatTmpImage = nullptr;
 
   typedef vtkSmartPointer<vtkFlyingEdges3D> FlyingEdges;
   FlyingEdges flyingEdges = FlyingEdges::New();
@@ -172,13 +179,11 @@ void ShowSegmentationAsAgtkSurface::ComputeSurface()
   flyingEdges->ComputeNormalsOff();
   flyingEdges->ComputeGradientsOn();
   flyingEdges->ComputeScalarsOn();
-  
+
   flyingEdges->Update();
   m_Output = flyingEdges->GetOutput();
 
   vtkSmartPointer<vtkPoints> points = m_Output->GetPoints();
-  itk::Matrix<double, DIM, DIM> tmpDirection = m_FloatTmpImage->GetDirection();
-  itk::Vector<double, DIM> tmpOrigin = m_FloatTmpImage->GetOrigin().GetDataPointer();
 
   for (size_t n = 0; n < points->GetNumberOfPoints(); ++n) {
     itk::Vector<double, DIM> point = points->GetPoint(n);
@@ -259,7 +264,7 @@ void ShowSegmentationAsAgtkSurface::PostProcessing()
       break;
     }
   }
-  
+
   // Compute normals
   typedef vtkSmartPointer<vtkPolyDataNormals> PolyDataNormals;
   PolyDataNormals normals = PolyDataNormals::New();


### PR DESCRIPTION
https://jira.smuit.ru/browse/AUT-4222

Предположительно происходило переполнение памяти на больших исследованиях. 

Изменения снижают пиковое количество требуемой памяти для процесса построения AGTK модели. Это достигается за счет очищения временной информации во время работы фильтра и переиспользования буферов для фильтров, которым позволяет это делать алгоритм.

По сценарию описанному ниже пиковая память снижается с 14.4 GB -> 11.2 GB

1. Открыть исследование 3357 (1276 срезов)
2. Петелькой заполнить все 8 углов дайкома
3. Включить смарт браш
4. Построить AGTK модель
ER: Автоплан не упал