### PR TITLE
Fix smart brush size overflow. AUT-4136

### DIFF
--- a/Modules/Segmentation/Interactions/mitkSmartBrushTool.cpp
+++ b/Modules/Segmentation/Interactions/mitkSmartBrushTool.cpp
@@ -422,6 +422,13 @@ void mitk::SmartBrushTool::MouseMovedImpl(const mitk::PlaneGeometry* planeGeomet
     brushStart[2] = globalIndexCoordinates[2] - m_Radius;
 
     itk::Image<float, 3>::SizeType imageSize = m_OriginalImage->GetLargestPossibleRegion().GetSize();
+
+    for (int i = 0; i < 3; i++) {
+      if (brushStart[i] >= imageSize[i]) {
+        return; // Brush outside of image
+      }
+    }
+
     // Clamp region in image
     for (int i = 0; i < 3; i++) {
       if (brushStart[i] < 0) {


### PR DESCRIPTION
https://jira.smuit.ru/browse/AUT-4136

Исправляет переполнение памяти, когда кисть оказывалась за пределами изображения в положительном направлении осей.

1. Открыть исследование зверева
2. Нажать смарт брашом справа от исследования
ER: Автоплан не выделил большое количество памяти / упал