### PR TITLE
Fix crush in vtk contour. AUT-4240 [clean]

### DIFF
--- a/CMakeExternals/VTK.cmake
+++ b/CMakeExternals/VTK.cmake
@@ -87,6 +87,7 @@ if(NOT DEFINED VTK_DIR)
     URL ${VTK_URL}
     URL_MD5 ${VTK_URL_MD5}
     PATCH_COMMAND ${PATCH_COMMAND} -N -p1 -i ${CMAKE_CURRENT_LIST_DIR}/VtkCornerAnnotation.patch
+      COMMAND ${PATCH_COMMAND} -N -p1 -i ${CMAKE_CURRENT_LIST_DIR}/VtkContourRepresentation.patch
     CMAKE_GENERATOR ${gen}
     CMAKE_ARGS
         ${ep_common_args}

--- a/CMakeExternals/VtkContourRepresentation.patch
+++ b/CMakeExternals/VtkContourRepresentation.patch
@@ -1,0 +1,12 @@
+diff --git a/Interaction/Widgets/vtkContourRepresentation.cxx b/Interaction/Widgets/vtkContourRepresentation.cxx
+--- a/Interaction/Widgets/vtkContourRepresentation.cxx
++++ b/Interaction/Widgets/vtkContourRepresentation.cxx
+@@ -140,6 +140,8 @@
+ 
+   this->UpdateLines( static_cast<int>(this->Internal->Nodes.size())-1);
+   this->NeedToRender = 1;
++
++  this->BuildRepresentation();
+ }
+ 
+ //----------------------------------------------------------------------


### PR DESCRIPTION
https://jira.smuit.ru/browse/AUT-4240

Проблема возникала из-за пересоздания контура в плагине резекции. Во время создания можно было получить момент, когда контур был в неверном состоянии и крашился при получении интеракционного события.

Баг происходил изза того что не успевал вызваться метод `BuildRepresentation` у контура, изза чего `FocalPoint` контейнер был с размером 0. В втк предполагается вызов `BuildRepresentation` из метода `RenderOpaqueGeometry`. Рендер запрашивается при добавлении точек, но выполняется не сразу. Это вызывает описанную проблему и к возможным графическим артефактам при добавлении точек в контур. 

Теперь при добавлении точки вызывается `BuildRepresentation` и автоплан не падает во время инициализации контура.

1. Запустить плагин резекции
2. Создать контур
3. После завершения работы резекции быстро начать создавать новый контур
4. Пока Автоплан лагает, быстро начать рисовать контур
ER: Автоплан не упал

Можно достигнуть 100% саксес рейта, если поставить брекпоинт в `BuildRepresentation`, нажать на окно рендора во время паузы и продолжить работу программы.