### PR TITLE
Fix resect crash on legacy models. AUT-4234

### DIFF
--- a/Modules/Segmentation/DataManagement/mitkSurfaceUtils.cpp
+++ b/Modules/Segmentation/DataManagement/mitkSurfaceUtils.cpp
@@ -244,7 +244,7 @@ DataNode::Pointer SurfaceCreator::recreateModel()
 
   BaseProperty* surfTypeProp = m_Input->GetProperty("Surface Type");
 
-  if (surfTypeProp == nullptr) {
+  if (surfTypeProp == nullptr || dynamic_cast<SurfaceCreationTypeProperty*>(surfTypeProp) == nullptr) {
     // Fallback for models generated the old way
     SurfaceCreationArgs args;
     args.creationType = SurfaceCreationType::AGTK;


### PR DESCRIPTION
https://jira.smuit.ru/browse/AUT-4234

Некоторые способы создания модели раньше писали в свойство Surface Type. При пересоздании модели это не учитывалось.

1. Открыть исследование 1009
2. Сделать резекцию
ER: Автоплан не упал