### PR TITLE
Возврат состояния курсора при выходе за пределы окна

### DIFF
--- a/Modules/Core/resource/Interactions/DisplayInteraction.xml
+++ b/Modules/Core/resource/Interactions/DisplayInteraction.xml
@@ -182,6 +182,9 @@ TODO Std move to abort interaction of scroll/pan/zoom
         <condition name="check_can_rotate" inverted="true" />
         <action name="endRotation"/>
       </transition>
+      <transition event_class="InternalEvent" event_variant="LeaveRenderWindow" target="start">
+        <action name="endRotation"/>
+      </transition>
       <transition event_class="InteractionEvent" event_variant="PlaneUP" target="rotationPossible">
         <action name="ScrollOneUp"/>
         <action name="updateStatusbar"/>


### PR DESCRIPTION
В состянии "возможно вращение осей" отслеживается выход мыши из окна и делается возврат в начальное состояние.
[AUT-4145](https://jira.smuit.ru/browse/AUT-4164)