### PR TITLE
Правки в плагине "Жесткая регистрация"

### DIFF
--- a/Plugins/org.mitk.gui.qt.registration/src/internal/QmitkRigidRegistrationView.h
+++ b/Plugins/org.mitk.gui.qt.registration/src/internal/QmitkRigidRegistrationView.h
@@ -17,6 +17,8 @@ See LICENSE.txt or http://www.mitk.org for details.
 #ifndef QMITKRIGIDREGISTRATION_H
 #define QMITKRIGIDREGISTRATION_H
 
+#include <QTimer>
+
 #include "QmitkFunctionality.h"
 #include "ui_QmitkRigidRegistrationViewControls.h"
 
@@ -331,6 +333,7 @@ protected:
     bool m_PresetNotLoaded;
 
     QmitkStepperAdapter*      m_TimeStepperAdapter;
+    QTimer* m_Timer;
 };
 
 #endif //QMITKRigidREGISTRATION_H

--- a/Plugins/org.mitk.gui.qt.registration/src/internal/QmitkRigidRegistrationViewControls.ui
+++ b/Plugins/org.mitk.gui.qt.registration/src/internal/QmitkRigidRegistrationViewControls.ui
@@ -168,13 +168,6 @@
              <item row="7" column="0" colspan="2">
               <layout class="QHBoxLayout" name="_3">
                <item>
-                <widget class="QLabel" name="label">
-                 <property name="text">
-                  <string>0%</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
                 <widget class="QLabel" name="m_OpacityLabel">
                  <property name="text">
                   <string>Moving Image Opacity:</string>
@@ -689,12 +682,6 @@
                          <property name="toolTip">
                           <string/>
                          </property>
-                         <property name="minimum">
-                          <number>-10000</number>
-                         </property>
-                         <property name="maximum">
-                          <number>10000</number>
-                         </property>
                          <property name="orientation">
                           <enum>Qt::Horizontal</enum>
                          </property>
@@ -702,12 +689,6 @@
                        </item>
                        <item>
                         <widget class="QSlider" name="m_YTransSlider">
-                         <property name="minimum">
-                          <number>-10000</number>
-                         </property>
-                         <property name="maximum">
-                          <number>10000</number>
-                         </property>
                          <property name="orientation">
                           <enum>Qt::Horizontal</enum>
                          </property>
@@ -715,12 +696,6 @@
                        </item>
                        <item>
                         <widget class="QSlider" name="m_ZTransSlider">
-                         <property name="minimum">
-                          <number>-10000</number>
-                         </property>
-                         <property name="maximum">
-                          <number>10000</number>
-                         </property>
                          <property name="orientation">
                           <enum>Qt::Horizontal</enum>
                          </property>


### PR DESCRIPTION
1. Убрана надпись "0%", которая была рядом с надписью "Прозрачность движущегося изображения".
2. Процентное значение "Прозрачность движущегося изображения" теперь меняется.
3. Построение контура происходит при изменения значения слайдера и по таймеру для того, чтобы контур так же менялся с помощью колеса мыши и стрелок клавиатуры.
4. Диапазон для интерактивного перемещения изображения (в направлении x, y и z) берется как сумма параметров двух изображений, соответствующих каждому из направлений (высота, ширина, глубина).

https://jira.smuit.ru/browse/AUT-4267