### PR TITLE
Disable z test for contour tool in 3D. AUT-4286

### DIFF
--- a/Modules/Segmentation/Interactions/mitkContourTool.cpp
+++ b/Modules/Segmentation/Interactions/mitkContourTool.cpp
@@ -104,7 +104,20 @@ void mitk::ContourTool::OnMouseMoved( StateMachineAction*, InteractionEvent* int
   ContourModel* contour = FeedbackContourTool::GetFeedbackContour();
   mitk::Point3D point;
   if (interactionEvent->GetSender()->GetMapperID() == mitk::BaseRenderer::Standard3D) {
-    point = positionEvent->GetPositionInWorld();
+    Point2D mousePosition = positionEvent->GetPointerPositionOnScreen();
+    double displayPoint[3];
+
+    displayPoint[0] = mousePosition[0];
+    displayPoint[1] = mousePosition[1];
+    displayPoint[2] = 0.0;
+
+    vtkRenderer* renderer = positionEvent->GetSender()->GetVtkRenderer();
+    renderer->SetDisplayPoint(displayPoint);
+    renderer->DisplayToWorld();
+    double* world = renderer->GetWorldPoint();
+    for (int i = 0; i < 3; i++) {
+      point[i] = world[i] / world[3];
+    }
   }
   else {
     point = positionEvent->GetPlanePositionInWorld();

--- a/Modules/Segmentation/Testing/mitkContourMapper2DTest.cpp
+++ b/Modules/Segmentation/Testing/mitkContourMapper2DTest.cpp
@@ -63,7 +63,7 @@ int mitkContourMapper2DTest(int /*argc*/, char* /*argv*/[])
 
   vtkRenderWindow* renWin = vtkRenderWindow::New();
 
-  mitk::VtkPropRenderer::Pointer renderer = mitk::VtkPropRenderer::New( "ContourRenderer",renWin, mitk::RenderingManager::GetInstance(),mitk::BaseRenderer::RenderingMode::Standard );
+  mitk::VtkPropRenderer::Pointer renderer = mitk::VtkPropRenderer::New("ContourRenderer", renWin, mitk::RenderingManager::GetInstance(), mitk::BaseRenderer::RenderingMode::Standard, false);
 
   std::cout<<"Testing mitk::BaseRenderer::SetData()"<<std::endl;
 


### PR DESCRIPTION
https://jira.smuit.ru/browse/AUT-4286

Проблема в том, что дефолтный метод из втк пытается использовать глубину из буфера глубины. Но так как точка за пределами размеров буфера, что-то происходит и все становится плохо. Метод заменен на расчет позиции точки в мире вручную.

1. Начать резать 3д катом на 3д
2. Вывести курсор за пределы вьюпорта во время рисования контура
ER: Контур продолжает работать правильно