### PR TITLE
Change picking mode to support opacity. AUT-4225

### DIFF
--- a/Modules/Core/include/mitkBaseRenderer.h
+++ b/Modules/Core/include/mitkBaseRenderer.h
@@ -85,6 +85,14 @@ namespace mitk
       };
     };
 
+    enum PickingMode {
+      WorldPointPicking,
+      PointPicking,
+      CellPicking,
+    };
+    itkSetEnumMacro(PickingMode, PickingMode);
+    itkGetEnumMacro(PickingMode, PickingMode);
+
     typedef std::map<vtkRenderWindow*, BaseRenderer*> BaseRendererMapType;
     static BaseRendererMapType baseRendererMap;
 
@@ -337,7 +345,8 @@ namespace mitk
     //## @warning Has to be overwritten in subclasses for the 3D-case.
     //##
     //## Implemented here only for 2D-rendering
-    virtual void PickWorldPoint(const Point2D& diplayPosition, Point3D& worldPosition) const = 0;
+    virtual void PickWorldPoint(const Point2D& displayPosition, Point3D& worldPosition) const = 0;
+    virtual void PickWorldPoint(const Point2D& displayPosition, Point3D& worldPosition, PickingMode mode) const = 0;
 
     /** \brief Determines the object (mitk::DataNode) closest to the current
     * position by means of picking
@@ -479,6 +488,8 @@ namespace mitk
     //##Documentation
     //## @brief MapperSlotId to use. Defines which kind of mapper (e.g., 2D or 3D) shoud be used.
     MapperSlotId m_MapperID;
+
+    PickingMode m_PickingMode;
 
     //##Documentation
     //## @brief The DataStorage that is used for rendering.

--- a/Modules/Core/include/mitkVtkPropRenderer.h
+++ b/Modules/Core/include/mitkVtkPropRenderer.h
@@ -91,22 +91,8 @@ public:
   virtual void InitSize(int w, int h) override;
   virtual void Resize(int w, int h) override;
 
-  // Picking
-  enum PickingMode{ WorldPointPicking, PointPicking, CellPicking};
-  /** \brief  Set the picking mode.
-  This method is used to set the picking mode for 3D object picking. The user can select one of
-  the three options WorldPointPicking, PointPicking and CellPicking. The first option uses the zBuffer
-  from graphics rendering, the second uses the 3D points from the closest surface mesh, and the third
-  option uses the cells   of that mesh. The last option is the slowest, the first one the fastest.
-  However, the first option cannot use transparent data object and the tolerance of the picked position
-  to the selected point should be considered. PointPicking also need a tolerance around the picking
-  position to select the closest point in the mesh. The CellPicker performs very well, if the
-  foreground surface part (i.e. the surfacepart that is closest to the scene's cameras) needs to be
-  picked. */
-  itkSetEnumMacro( PickingMode, PickingMode );
-  itkGetEnumMacro( PickingMode, PickingMode );
-
   virtual void PickWorldPoint(const Point2D& displayPoint, Point3D& worldPoint) const override;
+  virtual void PickWorldPoint(const Point2D& displayPoint, Point3D& worldPoint, PickingMode mode) const override;
   virtual mitk::DataNode *PickObject( const Point2D &displayPosition, Point3D &worldPosition ) const override;
 
   /**
@@ -196,8 +182,6 @@ private:
   vtkWorldPointPicker     * m_WorldPointPicker;
   vtkPointPicker          * m_PointPicker;
   vtkCellPicker           * m_CellPicker;
-
-  PickingMode               m_PickingMode;
 
   // Explicit use of SmartPointer to avoid circular #includes
   itk::SmartPointer< mitk::Mapper > m_CurrentWorldPlaneGeometryMapper;

--- a/Modules/Core/src/Rendering/mitkBaseRenderer.cpp
+++ b/Modules/Core/src/Rendering/mitkBaseRenderer.cpp
@@ -708,7 +708,7 @@ void mitk::BaseRenderer::DisplayToWorld(const Point2D& displayPoint, Point3D& wo
   }
   else if (m_MapperID == BaseRenderer::Standard3D)
   {
-    PickWorldPoint(displayPoint, worldIndex); //Seems to be the same code as above, but subclasses may contain different implementations.
+    PickWorldPoint(displayPoint, worldIndex, PickingMode::CellPicking); //Seems to be the same code as above, but subclasses may contain different implementations.
   }
 
   return;

--- a/Modules/Core/src/Rendering/mitkVtkPropRenderer.cpp
+++ b/Modules/Core/src/Rendering/mitkVtkPropRenderer.cpp
@@ -398,32 +398,32 @@ void mitk::VtkPropRenderer::MakeCurrent()
 
 void mitk::VtkPropRenderer::PickWorldPoint(const mitk::Point2D& displayPoint, mitk::Point3D& worldPoint) const
 {
-  if (this->GetRenderWindow()->GetNeverRendered() != 0)
-      return; // somebody called picking before we ever rendered; cannot have enough information yet
+  PickWorldPoint(displayPoint, worldPoint, m_PickingMode);
 
-  switch (m_PickingMode)
-  {
-  case (WorldPointPicking) :
-  {
-    m_WorldPointPicker->Pick(displayPoint[0], displayPoint[1], 0, m_VtkRenderer);
-    vtk2itk(m_WorldPointPicker->GetPickPosition(), worldPoint);
-    break;
-  }
-  case (PointPicking) :
-  {
-    m_PointPicker->Pick(displayPoint[0], displayPoint[1], 0, m_VtkRenderer);
-    vtk2itk(m_PointPicker->GetPickPosition(), worldPoint);
-    break;
-  }
-  case(CellPicking) :
-  {
-    m_CellPicker->Pick(displayPoint[0], displayPoint[1], 0, m_VtkRenderer);
-    vtk2itk(m_CellPicker->GetPickPosition(), worldPoint);
-    break;
-  }
-  }
   //todo: is this picking in 2D renderwindows?
   //    Superclass::PickWorldPoint(displayPoint, worldPoint);
+}
+
+void mitk::VtkPropRenderer::PickWorldPoint(const mitk::Point2D& displayPoint, mitk::Point3D& worldPoint, PickingMode mode) const
+{
+  if (this->GetRenderWindow()->GetNeverRendered() != 0) {
+      return; // somebody called picking before we ever rendered; cannot have enough information yet
+  }
+
+  switch (mode) {
+    case WorldPointPicking:
+      m_WorldPointPicker->Pick(displayPoint[0], displayPoint[1], 0, m_VtkRenderer);
+      vtk2itk(m_WorldPointPicker->GetPickPosition(), worldPoint);
+      break;
+    case PointPicking:
+      m_PointPicker->Pick(displayPoint[0], displayPoint[1], 0, m_VtkRenderer);
+      vtk2itk(m_PointPicker->GetPickPosition(), worldPoint);
+      break;
+    case CellPicking:
+      m_CellPicker->Pick(displayPoint[0], displayPoint[1], 0, m_VtkRenderer);
+      vtk2itk(m_CellPicker->GetPickPosition(), worldPoint);
+      break;
+  }
 }
 
 mitk::DataNode *


### PR DESCRIPTION
https://jira.smuit.ru/browse/AUT-4225

Меняет способ расчета точки с буфера глубины на цпу рейкаст в полигоны. Преимущество в расчете только когда нужно, гораздо более высокой точностью по сравнению с гпу буфером и с доп информацией, если она будет когда-нибудь нужна.  Из минусов, может хуже скалироваться на слабых цпу и большом количестве полигонов. Но добавление дополнительного паса на глубину тоже скалировалось бы плохо на слабых машинах.

1. Открыть прозрачную модель
2. Дважды щелкнуть по ней в 3д вьюпорте
ER: Перекрестье переместилось в кликнутую точку