### PR TITLE
Fix contour after global reinit. AUT-4288

### DIFF
--- a/Modules/Segmentation/Interactions/mitkFeedbackContourTool.h
+++ b/Modules/Segmentation/Interactions/mitkFeedbackContourTool.h
@@ -100,11 +100,16 @@ class MITKSEGMENTATION_EXPORT FeedbackContourTool : public SegTool2D
     */
     void FillContourInSlice( ContourModel* projectedContour, unsigned int timeStep, Image* sliceImage, int paintingPixelValue = 1 );
 
+    void resampleDecomposition(Image* image, Image* plane);
+    Vector3D::ValueType projectRatio(Vector3D a, Vector3D b);
+    void offsetPointForContour(Point3D& worldPoint, Point3D planeOffset);
+
     ContourModel::Pointer      m_FeedbackContour;
     DataNode::Pointer m_FeedbackContourNode;
     bool                  m_FeedbackContourVisible;
 
-
+    Vector3D m_PlaneRightDecomposition;
+    Vector3D m_PlaneUpDecomposition;
 };
 
 } // namespace

--- a/Modules/Segmentation/Interactions/mitkSegTool2D.cpp
+++ b/Modules/Segmentation/Interactions/mitkSegTool2D.cpp
@@ -237,6 +237,7 @@ mitk::Image::Pointer mitk::SegTool2D::GetAffectedImageSliceAs2DImage(const Plane
   extractor->SetWorldGeometry( planeGeometry );
   extractor->SetVtkOutputRequest(false);
   extractor->SetResliceTransformByGeometry( image->GetTimeGeometry()->GetGeometryForTimeStep( timeStep ) );
+  extractor->SetInPlaneResampleExtentByGeometry(true);
 
   extractor->Modified();
   extractor->Update();
@@ -368,6 +369,7 @@ void mitk::SegTool2D::WriteSliceToVolume(mitk::SegTool2D::SliceInformation slice
   extractor->SetWorldGeometry( sliceInfo.plane );
   extractor->SetVtkOutputRequest(false);
   extractor->SetResliceTransformByGeometry( image->GetGeometry( sliceInfo.timestep ) );
+  extractor->SetInPlaneResampleExtentByGeometry(true);
 
   extractor->Modified();
   extractor->Update();

--- a/Modules/Segmentation/Interactions/mitkSmartBrushTool.cpp
+++ b/Modules/Segmentation/Interactions/mitkSmartBrushTool.cpp
@@ -381,12 +381,17 @@ void mitk::SmartBrushTool::MouseMovedImpl(const mitk::PlaneGeometry* planeGeomet
 
   auto planeSpacing = planeGeometry->GetSpacing();
 
+  Point3D roundedWorldPoint;
+  m_WorkingSlice->GetGeometry()->IndexToWorld(indexCoordinates, roundedWorldPoint);
+
   while (it != end) {
     Point3D point = (*it)->Coordinates;
     point[0] /= planeSpacing[0] / m_MinSpacing;
     point[1] /= planeSpacing[1] / m_MinSpacing;
-    point[0] += indexCoordinates[0];
-    point[1] += indexCoordinates[1];
+
+    Point3D worldPoint = roundedWorldPoint;
+    offsetPointForContour(worldPoint, point);
+    m_WorkingSlice->GetGeometry()->WorldToIndex(worldPoint, point);
 
     contour->AddVertex(point);
     it++;
@@ -633,6 +638,7 @@ void mitk::SmartBrushTool::CheckIfCurrentSliceHasChanged(const mitk::PlaneGeomet
   if (m_CurrentPlane.IsNull() || m_WorkingSlice.IsNull()) {
     m_CurrentPlane = const_cast<PlaneGeometry*>(planeGeometry);
     m_WorkingSlice = SegTool2D::GetAffectedImageSliceAs2DImage(planeGeometry, image, m_LastTimeStep)->Clone();
+    resampleDecomposition(m_WorkingImage, m_WorkingSlice);
     m_WorkingNode->ReplaceProperty("color", workingNode->GetProperty("color"));
     m_WorkingNode->SetData(m_WorkingSlice);
   } else {
@@ -652,6 +658,7 @@ void mitk::SmartBrushTool::CheckIfCurrentSliceHasChanged(const mitk::PlaneGeomet
 
       m_CurrentPlane = const_cast<PlaneGeometry*>(planeGeometry);
       m_WorkingSlice = SegTool2D::GetAffectedImageSliceAs2DImage(planeGeometry, image, m_LastTimeStep)->Clone();
+      resampleDecomposition(m_WorkingImage, m_WorkingSlice);
 
       m_WorkingNode = mitk::DataNode::New();
       m_WorkingNode->SetProperty("levelwindow", mitk::LevelWindowProperty::New(mitk::LevelWindow(0, 1)));


### PR DESCRIPTION
https://jira.smuit.ru/browse/AUT-4288

Контур работает после глобальной реинициализации

1. Открыть проект в 1009
2. Выбрать инструмент стерка
3. Реиницилизировать глобально
ER: Контуры остались как были