### PR TITLE
Random optimizations

### DIFF
--- a/Modules/ContourModel/Rendering/mitkContourModelGLMapper2DBase.cpp
+++ b/Modules/ContourModel/Rendering/mitkContourModelGLMapper2DBase.cpp
@@ -189,6 +189,8 @@ void mitk::ContourModelGLMapper2DBase::InternalDrawContour(mitk::ContourModel* r
 
     mitk::ScalarType maxDiff = 0.25;
 
+    std::vector<float> linePoints;
+
     while ( pointsIt != renderingContour->IteratorEnd(timestep) )
     {
       lastPt2d = pt2d;
@@ -224,11 +226,11 @@ void mitk::ContourModelGLMapper2DBase::InternalDrawContour(mitk::ContourModel* r
          if (showSegments)
          {
             //lastPt2d is not valid in first step
-            if( !(pointsIt == renderingContour->IteratorBegin(timestep)) )
-            {
-              this->m_Context->GetPen()->SetWidth(lineWidth);
-              this->m_Context->DrawLine(pt2d[0], pt2d[1], lastPt2d[0], lastPt2d[1]);
-              this->m_Context->GetPen()->SetWidth(1);
+            if( !(pointsIt == renderingContour->IteratorBegin(timestep)) ) {
+              linePoints.push_back(pt2d[0]);
+              linePoints.push_back(pt2d[1]);
+              linePoints.push_back(lastPt2d[0]);
+              linePoints.push_back(lastPt2d[1]);
             }
          }
 
@@ -348,10 +350,17 @@ void mitk::ContourModelGLMapper2DBase::InternalDrawContour(mitk::ContourModel* r
       vtk2itk(vtkp,p);
       renderer->WorldToDisplay(p, pt2d);
 
-      this->m_Context->GetPen()->SetWidth(lineWidth);
-      this->m_Context->DrawLine(lastPt2d[0], lastPt2d[1], pt2d[0], pt2d[1]);
-      this->m_Context->GetPen()->SetWidth(1);
+      linePoints.push_back(lastPt2d[0]);
+      linePoints.push_back(lastPt2d[1]);
+      linePoints.push_back(pt2d[0]);
+      linePoints.push_back(pt2d[1]);
     }
+
+    // TODO: Move to line strip, which is not supported by vtk by default
+    // Draw lines
+    this->m_Context->GetPen()->SetWidth(lineWidth);
+    this->m_Context->DrawLines(linePoints.data(), linePoints.size() / 2);
+    this->m_Context->GetPen()->SetWidth(1);
 
     //draw selected vertex if exists
     if(renderingContour->GetSelectedVertex())

--- a/Modules/Core/src/Controllers/mitkSliceNavigationController.cpp
+++ b/Modules/Core/src/Controllers/mitkSliceNavigationController.cpp
@@ -419,9 +419,6 @@ SliceNavigationController::SendSlice()
 
       // send crosshair event
       crosshairPositionEvent.Send();
-
-      // Request rendering update for all views
-      this->GetRenderingManager()->RequestUpdateAll();
     }
   }
 }

--- a/Modules/Core/src/Interactions/mitkDisplayInteractor.cpp
+++ b/Modules/Core/src/Interactions/mitkDisplayInteractor.cpp
@@ -518,9 +518,17 @@ void mitk::DisplayInteractor::SetCrosshair(mitk::StateMachineAction *, mitk::Int
   for(auto renWin : renWindows)
   {
     if (BaseRenderer::GetInstance(renWin)->GetMapperID() == BaseRenderer::Standard2D
-        && renWin != sender->GetRenderWindow())
+        && renWin != sender->GetRenderWindow()) {
       BaseRenderer::GetInstance(renWin)->GetSliceNavigationController()->SelectSliceByPoint(pos);
+    }
   }
+
+  // TODO: Get crosshair manager, which is not available in MitkCore
+  //if (crosshairManager->getShowPlanesIn3D()) {
+  RenderingManager::GetInstance()->RequestUpdateAll();
+  //} else {
+  //  RenderingManager::GetInstance()->RequestUpdateAll(RenderingManager::RequestType::REQUEST_UPDATE_2DWINDOWS);
+  //}
 }
 
 void mitk::DisplayInteractor::Zoom(StateMachineAction*, InteractionEvent* interactionEvent)


### PR DESCRIPTION
https://jira.smuit.ru/browse/AUT-4330

* Оптимизирует рисование контуров
100μs -> 1μs
Значительно ускоряет время фрейма перемещения контура
Контур не отстает теперь от курсора, если быстро вести мышку в смарт браше или просто браше

* Убирает лишние апдейты на смену курсора.
При смене среза слайс навигатор требовал обновления во всех окнах.
Теперь происходит только одно обновление, когда все слайс навигаторы поменяли позиции.