### PR TITLE
New algo for surface 2d mapper. AUT-4330

### DIFF
--- a/Modules/Core/include/mitkSurfaceVtkMapper2D.h
+++ b/Modules/Core/include/mitkSurfaceVtkMapper2D.h
@@ -32,6 +32,7 @@ class vtkLookupTable;
 class vtkGlyph3D;
 class vtkArrowSource;
 class vtkReverseSense;
+class vtkSphereTree;
 
 namespace mitk {
 
@@ -94,55 +95,15 @@ public:
      */
     vtkSmartPointer<vtkActor> m_Actor;
     /**
-     * @brief m_NormalActor actor for the normals.
-     */
-    vtkSmartPointer<vtkActor> m_NormalActor;
-    /**
-     * @brief m_InverseNormalActor actor for the inverse normals.
-     */
-    vtkSmartPointer<vtkActor> m_InverseNormalActor;
-    /**
        * @brief m_Mapper VTK mapper for all types of 2D polydata e.g. werewolves.
        */
     vtkSmartPointer<vtkOpenGLPolyDataMapper> m_Mapper;
-    /**
-       * @brief m_Cutter Filter to cut out the 2D slice.
-       */
-    vtkSmartPointer<vtkCutter> m_Cutter;
+
+    vtkSmartPointer<vtkSphereTree> m_SphereTree;
     /**
        * @brief m_CuttingPlane The plane where to cut off the 2D slice.
        */
     vtkSmartPointer<vtkPlane> m_CuttingPlane;
-
-    /**
-     * @brief m_NormalMapper Mapper for the normals.
-     */
-    vtkSmartPointer<vtkOpenGLPolyDataMapper> m_NormalMapper;
-
-    /**
-     * @brief m_InverseNormalMapper Mapper for the inverse normals.
-     */
-    vtkSmartPointer<vtkOpenGLPolyDataMapper> m_InverseNormalMapper;
-
-    /**
-     * @brief m_NormalGlyph Glyph for creating normals.
-     */
-    vtkSmartPointer<vtkGlyph3D> m_NormalGlyph;
-
-    /**
-     * @brief m_InverseNormalGlyph Glyph for creating inverse normals.
-     */
-    vtkSmartPointer<vtkGlyph3D> m_InverseNormalGlyph;
-
-    /**
-     * @brief m_ArrowSource Arrow representation of the normals.
-     */
-    vtkSmartPointer<vtkArrowSource> m_ArrowSource;
-
-    /**
-     * @brief m_ReverseSense Filter to invert the normals.
-     */
-    vtkSmartPointer<vtkReverseSense> m_ReverseSense;
 
     /** \brief Default constructor of the local storage. */
     LocalStorage();


### PR DESCRIPTION
https://jira.smuit.ru/browse/AUT-4330

Меняет алгоритм резания моделей для отображения на 2д

Основное тело алгоритма взято из последней версии втк + модификации

Теперь используется специализированная функция для поиска пересечения, новое распараллеливание от втк и дерево сфер для ускорения поиска пересечения с плоскостью.

Также пр выкидывает отображение нормалей на 2д в виду их бесполезности. Они генерировались для сгенерированой информации и не несли никакой информации о модели

На сцене с 4 моделями
- 36776 треугольников
- 344200 треугольников
- 216056 треугольников
- 78280 треугольников

при отображении *только* моделей (без сегментаций) фпс вырастает c 1-2 фпса до ~20 фпс, что выглядит примерно гладко, но немного хуже, чем с выключенными моделями. 
С включенными сегментациями перемещение перекрестья за курсором заметно лагает.
