### PR TITLE
Fix gradient table updates. AUT-4330 [clean]

### DIFF
--- a/CMakeExternals/VTK.cmake
+++ b/CMakeExternals/VTK.cmake
@@ -85,6 +85,7 @@ if(NOT DEFINED VTK_DIR)
     URL_MD5 692d09ae8fadc97b59d35cab429b261a
     PATCH_COMMAND ${PATCH_COMMAND} -N -p1 -i ${CMAKE_CURRENT_LIST_DIR}/VtkCornerAnnotation.patch
       COMMAND ${PATCH_COMMAND} -N -p1 -i ${CMAKE_CURRENT_LIST_DIR}/VtkContourRepresentation.patch
+      COMMAND ${PATCH_COMMAND} -N -p1 -i ${CMAKE_CURRENT_LIST_DIR}/VtkOpenGLVolumeGradientOpacityTable.patch
     CMAKE_GENERATOR ${gen}
     CMAKE_ARGS
         ${ep_common_args}

--- a/CMakeExternals/VtkOpenGLVolumeGradientOpacityTable.patch
+++ b/CMakeExternals/VtkOpenGLVolumeGradientOpacityTable.patch
@@ -1,0 +1,12 @@
+diff --git a/Rendering/VolumeOpenGL2/vtkOpenGLVolumeGradientOpacityTable.h b/Rendering/VolumeOpenGL2/vtkOpenGLVolumeGradientOpacityTable.h
+--- a/Rendering/VolumeOpenGL2/vtkOpenGLVolumeGradientOpacityTable.h
++++ b/Rendering/VolumeOpenGL2/vtkOpenGLVolumeGradientOpacityTable.h
+@@ -81,7 +81,7 @@
+ 
+     if(gradientOpacity->GetMTime() > this->BuildTime ||
+        this->TextureObject->GetMTime() > this->BuildTime ||
+-       this->LastSampleDistance != sampleDistance ||
++       //this->LastSampleDistance != sampleDistance ||
+        needUpdate || !this->TextureObject->GetHandle())
+     {
+       int const idealW = gradientOpacity->EstimateMinNumberOfSamples(this->LastRange[0],


### PR DESCRIPTION
https://jira.smuit.ru/browse/AUT-4330

Фискит баг в втк. 
`LastSampleDistance` никогда не обновляется. В схожем классе, для таблицы прозрачности, обновляется. Изза этого текстура для градиента всегда пересоздается каждый фрейм.
Проверка убрана, потому что `sampleDistance` нигде не используется, класс рассчитывает свой семпл рейт.

Срезает 150μs с гпу на фрейм