### PR TITLE
Optimizations for mappers. AUT-4330

### DIFF
--- a/Modules/Core/include/mitkImageVtkMapper2D.h
+++ b/Modules/Core/include/mitkImageVtkMapper2D.h
@@ -148,6 +148,8 @@ public:
   class MITKCORE_EXPORT LocalStorage : public mitk::Mapper::BaseLocalStorage
   {
   public:
+    bool m_RenderedBefore;
+
     /** \brief Actor of a 2D render window. */
     vtkSmartPointer<vtkActor> m_Actor;
 

--- a/Modules/Core/src/Rendering/mitkImageVtkMapper2D.cpp
+++ b/Modules/Core/src/Rendering/mitkImageVtkMapper2D.cpp
@@ -415,6 +415,7 @@ void mitk::ImageVtkMapper2D::GenerateDataForRenderer( mitk::BaseRenderer *render
 
   // We have been modified => save this for next Update()
   localStorage->m_LastUpdateTime.Modified();
+  localStorage->m_RenderedBefore = true;
 }
 
 void mitk::ImageVtkMapper2D::ApplyLevelWindow(mitk::BaseRenderer *renderer)
@@ -633,6 +634,7 @@ void mitk::ImageVtkMapper2D::Update(mitk::BaseRenderer* renderer)
   // since we have checked that nothing important has changed, we can set
   // m_LastUpdateTime to the current time
   m_LSH.GetLocalStorage(renderer)->m_LastUpdateTime.Modified();
+  m_LSH.GetLocalStorage(renderer)->m_RenderedBefore = true;
 }
 
 void mitk::ImageVtkMapper2D::SetDefaultProperties(mitk::DataNode* node, mitk::BaseRenderer* renderer, bool overwrite)
@@ -902,6 +904,7 @@ mitk::ImageVtkMapper2D::LocalStorage::LocalStorage()
   m_OutlineActor = vtkSmartPointer<vtkActor>::New();
   m_OutlineMapper = vtkSmartPointer<vtkOpenGLPolyDataMapper>::New();
   m_OutlineShadowActor = vtkSmartPointer<vtkActor>::New();
+  m_RenderedBefore = false;
 
   m_OutlineActor->SetMapper(m_OutlineMapper);
   m_OutlineShadowActor->SetMapper(m_OutlineMapper);

--- a/Modules/Core/src/Rendering/mitkPlaneGeometryDataVtkMapper3D.cpp
+++ b/Modules/Core/src/Rendering/mitkPlaneGeometryDataVtkMapper3D.cpp
@@ -484,9 +484,10 @@ namespace mitk
 
           if ( planeRenderer.IsNotNull() )
           {
-            // perform update of imagemapper if needed (maybe the respective 2D renderwindow is not rendered/update before)
-            imageMapper->Update(planeRenderer);
-
+            // Perform update of imagemapper if needed (maybe the respective 2D renderwindow is not rendered/update before)
+            if (!localStorage->m_RenderedBefore) {
+              imageMapper->Update(planeRenderer);
+            }
             // If it has not been initialized already in a previous pass,
             // generate an actor and a texture object to
             // render the image associated with the ImageVtkMapper2D.

--- a/Modules/Multilabel/mitkLabelSetImageVtkMapper2D.cpp
+++ b/Modules/Multilabel/mitkLabelSetImageVtkMapper2D.cpp
@@ -276,7 +276,7 @@ void mitk::LabelSetImageVtkMapper2D::GenerateDataForRenderer( mitk::BaseRenderer
     int pixelValue = image->GetActiveLabel()->GetValue();
     //MITK_INFO << "pixValue VTK " << pixelValue;
     //generate contours/outlines
-    localStorage->m_OutlinePolyData = this->CreateOutlinePolyData( renderer, localStorage->m_ReslicedImageVector[image->GetActiveLayer()], pixelValue );
+    localStorage->m_OutlinePolyData = localStorage->m_LayerMapperVector[image->GetActiveLayer()]->GetInput();
     localStorage->m_OutlineActor->SetVisibility(true);
     localStorage->m_OutlineShadowActor->SetVisibility(true);
     const mitk::Color& color = image->GetActiveLabel()->GetColor();


### PR DESCRIPTION
https://jira.smuit.ru/browse/AUT-4330

Исправления для маперов.

Срезает 20k μs с гпу фрейма на рендер мультилейбл сегментаций. Рендерится теперь так же быстро, как бинарные сегментации (90k - 100k μs). Фпс вырастает с 8-9 до 10-11 на i7.

Убирает обновление 2д маперов при обновлении 3д перекрестья.  Увеличивает на средней по нагрузке сцене фпс с 15 до 25 на 3д с включенным перекрестьем.