### PR TITLE
Add zshift to prevent artefacts from overlapping geometries. AUT-4352 [clean]

### DIFF
--- a/CMakeExternals/VTK.cmake
+++ b/CMakeExternals/VTK.cmake
@@ -85,6 +85,7 @@ if(NOT DEFINED VTK_DIR)
     URL_MD5 692d09ae8fadc97b59d35cab429b261a
     PATCH_COMMAND ${PATCH_COMMAND} -N -p1 -i ${CMAKE_CURRENT_LIST_DIR}/VtkCornerAnnotation.patch
       COMMAND ${PATCH_COMMAND} -N -p1 -i ${CMAKE_CURRENT_LIST_DIR}/VtkContourRepresentation.patch
+      COMMAND ${PATCH_COMMAND} -N -p1 -i ${CMAKE_CURRENT_LIST_DIR}/VtkZShiftFix.patch
       COMMAND ${PATCH_COMMAND} -N -p1 -i ${CMAKE_CURRENT_LIST_DIR}/VtkOpenGLVolumeGradientOpacityTable.patch
     CMAKE_GENERATOR ${gen}
     CMAKE_ARGS

--- a/CMakeExternals/VtkZShiftFix.patch
+++ b/CMakeExternals/VtkZShiftFix.patch
@@ -1,0 +1,89 @@
+diff --git a/Rendering/Core/vtkDataSetMapper.cxx b/Rendering/Core/vtkDataSetMapper.cxx
+--- a/Rendering/Core/vtkDataSetMapper.cxx
++++ b/Rendering/Core/vtkDataSetMapper.cxx
+@@ -96,6 +96,7 @@ void vtkDataSetMapper::Render(vtkRenderer *ren, vtkActor *act)
+     vtkDataSetSurfaceFilter *gf = vtkDataSetSurfaceFilter::New();
+     vtkPolyDataMapper *pm = vtkPolyDataMapper::New();
+     pm->SetInputConnection(gf->GetOutputPort());
++    pm->SetRelativeCoincidentTopologyZShift(this->RelativeCoincidentTopologyZShift);
+ 
+     this->GeometryExtractor = gf;
+     this->PolyDataMapper = pm;
+diff --git a/Rendering/Core/vtkMapper.cxx b/Rendering/Core/vtkMapper.cxx"
+index 919f8ce..9f869c4 100644
+--- a/Rendering/Core/vtkMapper.cxx
++++ b/Rendering/Core/vtkMapper.cxx
+@@ -87,6 +87,7 @@ vtkMapper::vtkMapper()
+   this->CoincidentLineFactor = 0.0;
+   this->CoincidentLineOffset = 0.0;
+   this->CoincidentPointOffset = 0.0;
++  this->RelativeCoincidentTopologyZShift = 0.0;
+ }
+ 
+ vtkMapper::~vtkMapper()
+@@ -192,11 +193,16 @@ void vtkMapper::SetResolveCoincidentTopologyZShift(double val)
+   vtkMapperGlobalResolveCoincidentTopologyZShift = val;
+ }
+ 
+-double vtkMapper::GetResolveCoincidentTopologyZShift()
++double vtkMapper::GetGlobalResolveCoincidentTopologyZShift()
+ {
+   return vtkMapperGlobalResolveCoincidentTopologyZShift;
+ }
+ 
++double vtkMapper::GetResolveCoincidentTopologyZShift()
++{
++  return vtkMapperGlobalResolveCoincidentTopologyZShift + this->RelativeCoincidentTopologyZShift;
++}
++
+ void vtkMapper::SetResolveCoincidentTopologyPolygonOffsetParameters(
+                                             double factor, double units)
+ {
+@@ -235,6 +241,14 @@ void vtkMapper::GetRelativeCoincidentTopologyPolygonOffsetParameters(
+   units = this->CoincidentPolygonOffset;
+ }
+ 
++void vtkMapper::SetRelativeCoincidentTopologyZShift(double shift) {
++  this->RelativeCoincidentTopologyZShift = shift;
++}
++
++void vtkMapper::GetRelativeCoincidentTopologyZShift(double& shift) {
++  shift = this->RelativeCoincidentTopologyZShift;
++}
++
+ void vtkMapper::GetCoincidentTopologyPolygonOffsetParameters(
+                            double& factor, double& units)
+ {
+diff --git a/Rendering/Core/vtkMapper.h b/Rendering/Core/vtkMapper.h
+index e33c1dc..3175f24 100644
+--- a/Rendering/Core/vtkMapper.h
++++ b/Rendering/Core/vtkMapper.h
+@@ -446,6 +446,9 @@ public:
+   void GetCoincidentTopologyPointOffsetParameter(double& units);
+   //@}
+ 
++  void SetRelativeCoincidentTopologyZShift(double shift);
++  void GetRelativeCoincidentTopologyZShift(double& shift);
++
+   //@{
+   /**
+    * Used when ResolveCoincidentTopology is set to PolygonOffset. The polygon
+@@ -464,7 +467,8 @@ public:
+    * ShiftZBuffer. This is a global variable.
+    */
+   static void SetResolveCoincidentTopologyZShift(double val);
+-  static double GetResolveCoincidentTopologyZShift();
++  static double GetGlobalResolveCoincidentTopologyZShift();
++  double GetResolveCoincidentTopologyZShift();
+   //@}
+ 
+   /**
+@@ -634,6 +638,8 @@ protected:
+   double CoincidentLineOffset;
+   double CoincidentPointOffset;
+ 
++  double RelativeCoincidentTopologyZShift;
++
+ private:
+   vtkMapper(const vtkMapper&) VTK_DELETE_FUNCTION;
+   void operator=(const vtkMapper&) VTK_DELETE_FUNCTION;

--- a/Modules/Core/src/Rendering/mitkPlaneGeometryDataVtkMapper3D.cpp
+++ b/Modules/Core/src/Rendering/mitkPlaneGeometryDataVtkMapper3D.cpp
@@ -126,6 +126,9 @@ namespace mitk
     m_ImageMapperDeletedCommand = MemberCommandType::New();
     m_ImageMapperDeletedCommand->SetCallbackFunction(
         this, &PlaneGeometryDataVtkMapper3D::ImageMapperDeletedCallback );
+
+    // Use zbuffer shift for resolving plane geometries
+    vtkMapper::SetResolveCoincidentTopology(VTK_RESOLVE_SHIFT_ZBUFFER);
   }
 
   PlaneGeometryDataVtkMapper3D::~PlaneGeometryDataVtkMapper3D()
@@ -527,8 +530,13 @@ namespace mitk
 
             // Set poly data new each time its object changes (e.g. when
             // switching between planar and curved geometries)
-            if ( (dataSetMapper != NULL) && (dataSetMapper->GetInput() != surface->GetVtkPolyData()) )
-            {
+            if ( (dataSetMapper != NULL) && (dataSetMapper->GetInput() != surface->GetVtkPolyData()) ) {
+              // Offset binary planes in front of images
+              bool binary = true;
+              imageMapper->GetDataNode()->GetBoolProperty("binary", binary);
+              dataSetMapper->SetResolveCoincidentTopologyPolygonOffsetParameters(1.0, 0.0);
+              dataSetMapper->SetRelativeCoincidentTopologyZShift(binary ? -.001 : 0.0);
+
               dataSetMapper->SetInputData( surface->GetVtkPolyData() );
             }
 


### PR DESCRIPTION
https://jira.smuit.ru/browse/AUT-4352

Включает и исправляет з шифт в втк

1. Открыть исследование с сегметациями
2. Включить перекрестье на 3д
ER: При вращении камеры нет артефактов на сегментации на перекрестье на 3д