### PR TITLE
Fix transfer function for segmentation. AUT-4351

### DIFF
--- a/Modules/MapperExt/include/mitkVolumeMapperVtkSmart3D.h
+++ b/Modules/MapperExt/include/mitkVolumeMapperVtkSmart3D.h
@@ -70,6 +70,9 @@ namespace mitk
     
     void UpdateTransferFunctions(mitk::BaseRenderer *renderer);
     void UpdateRenderMode(mitk::BaseRenderer *renderer);
+
+    vtkSmartPointer<vtkPiecewiseFunction> m_BinaryOpacityTransferFunction;
+    vtkSmartPointer<vtkPiecewiseFunction> m_BinaryGradientTransferFunction;
   };
 
 } // namespace mitk

--- a/Modules/MapperExt/src/mitkVolumeMapperVtkSmart3D.cpp
+++ b/Modules/MapperExt/src/mitkVolumeMapperVtkSmart3D.cpp
@@ -158,8 +158,8 @@ void mitk::VolumeMapperVtkSmart3D::UpdateTransferFunctions(mitk::BaseRenderer *r
     colorTransferFunction->AddRGBPoint(0, rgb[0], rgb[1], rgb[2]);
     colorTransferFunction->Modified();
 
-    opacityTransferFunction = vtkSmartPointer<vtkPiecewiseFunction>::New();
-    gradientTransferFunction = vtkSmartPointer<vtkPiecewiseFunction>::New();
+    opacityTransferFunction = m_BinaryOpacityTransferFunction;
+    gradientTransferFunction = m_BinaryGradientTransferFunction;
   }
   else
   {
@@ -244,6 +244,13 @@ mitk::VolumeMapperVtkSmart3D::VolumeMapperVtkSmart3D()
   m_SmartVolumeMapper->SetBlendModeToComposite();
   m_VolumeProperty = vtkSmartPointer<vtkVolumeProperty>::New();
   m_Volume = vtkSmartPointer<vtkVolume>::New();
+
+  m_BinaryOpacityTransferFunction = vtkSmartPointer<vtkPiecewiseFunction>::New();
+  m_BinaryOpacityTransferFunction->AddPoint(0, 0.0);
+  m_BinaryOpacityTransferFunction->AddPoint(1, 1.0);
+
+  m_BinaryGradientTransferFunction = vtkSmartPointer<vtkPiecewiseFunction>::New();
+  m_BinaryGradientTransferFunction->AddPoint(0.0, 1.0);
 }
 
 mitk::VolumeMapperVtkSmart3D::~VolumeMapperVtkSmart3D()


### PR DESCRIPTION
https://jira.smuit.ru/browse/AUT-4351

Добавляет инициализацию трансфер функции для сегментаций. Трансфер функции создаются по тому же принципу, что и до перехода на vtkOpengl2

1. Выбрать в настройках "Показывать объемную визуализацию сегментации"
2. Создать новую сегментацию
ER: На 3д нет черного куба