### PR TITLE
Исправление падения при прокрутке по времени

### DIFF
--- a/Modules/Core/src/Rendering/vtkMitkLevelWindowFilter.cpp
+++ b/Modules/Core/src/Rendering/vtkMitkLevelWindowFilter.cpp
@@ -158,7 +158,7 @@ void vtkApplyLookupTableOnRGBA(vtkMitkLevelWindowFilter* self,
                                T*)
 {
   vtkImageIterator<T> inputIt(inData, outExt);
-  vtkImageIterator<T> outputIt(outData, outExt);
+  vtkImageIterator<unsigned char> outputIt(outData, outExt);
   vtkLookupTable* lookupTable;
   const int maxC = inData->GetNumberOfScalarComponents();
 
@@ -182,8 +182,8 @@ void vtkApplyLookupTableOnRGBA(vtkMitkLevelWindowFilter* self,
   while (!outputIt.IsAtEnd())
   {
     T* inputSI = inputIt.BeginSpan();
-    T* outputSI = outputIt.BeginSpan();
-    T* outputSIEnd = outputIt.EndSpan();
+    unsigned char* outputSI = outputIt.BeginSpan();
+    unsigned char* outputSIEnd = outputIt.EndSpan();
 
     if( y >= clippingBounds[2] && y < clippingBounds[3] )
     {

--- a/Modules/MapperExt/src/mitkVolumeMapperVtkSmart3D.cpp
+++ b/Modules/MapperExt/src/mitkVolumeMapperVtkSmart3D.cpp
@@ -120,10 +120,13 @@ void mitk::VolumeMapperVtkSmart3D::setClippingPlanes(vtkPlanes* planes)
 vtkImageData* mitk::VolumeMapperVtkSmart3D::GetInputImage()
 {
   mitk::Image *input = const_cast<mitk::Image *>(static_cast<const mitk::Image *>(this->GetDataNode()->GetData()));
-  vtkImageData* img = input->GetVtkImageData(this->GetTimestep());
-  img->SetSpacing(1,1,1);
-
   m_TimeStep = this->GetTimestep();
+  int maxTime = input->GetTimeSteps() - 1;
+  vtkImageData* img = input->GetVtkImageData(m_TimeStep < maxTime? m_TimeStep : maxTime);
+
+  if (img) {
+    img->SetSpacing(1,1,1);
+  }
 
   return img;
 }

--- a/Plugins/org.blueberry.ui.qt/resources/darkstyle.qss
+++ b/Plugins/org.blueberry.ui.qt/resources/darkstyle.qss
@@ -42,6 +42,12 @@ QWidget:disabled {
   color: #656565;
 }
 
+QWidget[overImage=true]{ /* For nubmer of slices */
+  color: #3cb7fa;
+  font-weight: bold;
+  background-color:rgba(0,0,0,0);
+}
+
 QStackedWidget {
   background-color: transparent;
 }

--- a/Plugins/org.blueberry.ui.qt/resources/lightstyle.qss
+++ b/Plugins/org.blueberry.ui.qt/resources/lightstyle.qss
@@ -74,3 +74,8 @@ QWidget#StandaloneViewForm {
 QWidget#PageCompositeControlWidget {
     margin: 3px;
 }
+
+QWidget[overImage=true]{ /* For nubmer of slices */
+  color: #ffffff;
+  background-color: rgba(0,0,0,100);
+}


### PR DESCRIPTION
Падение наблюдалось когда открыты серии с разным числом временных отсчётов
и большее из них прокручивается за пределы второго.
[AUT-4406](https://jira.smuit.ru/browse/AUT-4406)
Кроме того добавлены стили для числа срезов поверх картинки в списке серий в просмотре.
Использование стиля будет добавлено в Автоплан.
Также исправлена ошибка в фильтре преобразования цвета, приводящая к порче кучи с векторными изображениями.