### PR TITLE
Правки в плагине "Геометрические инструменты"

### DIFF
--- a/Plugins/org.mitk.gui.qt.geometrytools/src/internal/QmitkGeometryToolsView.h
+++ b/Plugins/org.mitk.gui.qt.geometrytools/src/internal/QmitkGeometryToolsView.h
@@ -45,6 +45,8 @@ class QmitkGeometryToolsView : public QmitkAbstractView
 
   public:
 
+    ~QmitkGeometryToolsView();
+
     static const std::string VIEW_ID;
     static const char* PART_NAME;
 


### PR DESCRIPTION
При выборе ноды в менеджере данных делается реинициализация для корректного расчета попадания курсора в область интереса, так же добавлено удаление всех интеракторов, связанных с этим плагином, при его закрытии.

Плагин работает КОРРЕКТНО в том случае, если действия по выбору нод производятся только в datamanager (так как логика завязана именно на datamanager и не учитывает изменения, сделанные в segmanager).

https://jira.smuit.ru/browse/AUT-4388