### PR TITLE
Однократное обновление изображения в Геометрических инструментах

### DIFF
--- a/Plugins/org.mitk.gui.qt.geometrytools/src/internal/QmitkGeometryToolsView.cpp
+++ b/Plugins/org.mitk.gui.qt.geometrytools/src/internal/QmitkGeometryToolsView.cpp
@@ -46,6 +46,11 @@ QmitkGeometryToolsView::~QmitkGeometryToolsView()
   }
 }
 
+QmitkGeometryToolsView::QmitkGeometryToolsView() :
+  m_CurrentGeometry(nullptr)
+{
+}
+
 void QmitkGeometryToolsView::SetFocus()
 {
   m_Controls.m_AddInteractor->setFocus();
@@ -88,9 +93,10 @@ void QmitkGeometryToolsView::OnSelectionChanged( berry::IWorkbenchPart::Pointer 
     if( node.IsNotNull() )
     {
       mitk::BaseData::Pointer basedata = node->GetData();
-      if (basedata.IsNotNull() && basedata->GetTimeGeometry()->IsValid())
+      if (basedata.IsNotNull() && basedata->GetTimeGeometry()->IsValid() && m_CurrentGeometry != basedata->GetTimeGeometry())
       {
-        mitk::RenderingManager::GetInstance()->InitializeViews(basedata->GetTimeGeometry());
+        m_CurrentGeometry = basedata->GetTimeGeometry();
+        mitk::RenderingManager::GetInstance()->InitializeViews(m_CurrentGeometry, mitk::RenderingManager::REQUEST_UPDATE_ALL, true);
       }
       m_Controls.m_AddInteractor->setEnabled( true );
       return;

--- a/Plugins/org.mitk.gui.qt.geometrytools/src/internal/QmitkGeometryToolsView.h
+++ b/Plugins/org.mitk.gui.qt.geometrytools/src/internal/QmitkGeometryToolsView.h
@@ -44,7 +44,7 @@ class QmitkGeometryToolsView : public QmitkAbstractView
   Q_OBJECT
 
   public:
-
+    QmitkGeometryToolsView();
     ~QmitkGeometryToolsView();
 
     static const std::string VIEW_ID;
@@ -105,6 +105,8 @@ protected:
                                      const QList<mitk::DataNode::Pointer>& nodes ) override;
 
     Ui::QmitkGeometryToolsViewControls m_Controls;
+
+    mitk::TimeGeometry::Pointer m_CurrentGeometry;
 };
 
 #endif // QmitkGeometryToolsView_h


### PR DESCRIPTION
Для корректной работы плагина был добавлен reinit() в задаче https://jira.smuit.ru/browse/AUT-4388, но multilabel сегментации при этой операции посылает сигнал seleceted_node_changed, тем самым получается бесконечная рекурсия.

https://jira.smuit.ru/browse/AUT-4427
https://jira.smuit.ru/browse/AUT-4428