### PR TITLE
Правки в геометрических инструментах

### DIFF
--- a/Plugins/org.mitk.gui.qt.geometrytools/src/internal/QmitkGeometryToolsView.h
+++ b/Plugins/org.mitk.gui.qt.geometrytools/src/internal/QmitkGeometryToolsView.h
@@ -107,6 +107,8 @@ protected:
     Ui::QmitkGeometryToolsViewControls m_Controls;
 
     mitk::TimeGeometry::Pointer m_CurrentGeometry;
+
+    std::map<std::string, bool> m_Pickables;
 };
 
 #endif // QmitkGeometryToolsView_h


### PR DESCRIPTION
Убрана реинициализация ноды при переключении, теперь при переключении ноды в datamanager через свойство "pickable" устанавливается активная геометрия.
https://jira.smuit.ru/browse/AUT-4426