### PR TITLE
Fix ul and otsu on binary segmentations. AUT-4364

### DIFF
--- a/Modules/Segmentation/Interactions/mitkBinaryThresholdULTool.cpp
+++ b/Modules/Segmentation/Interactions/mitkBinaryThresholdULTool.cpp
@@ -55,11 +55,7 @@ mitk::BinaryThresholdULTool::BinaryThresholdULTool()
   m_CurrentUpperThresholdValue(1)
 {
   m_ThresholdFeedbackNode = DataNode::New();
-  m_ThresholdFeedbackNode->SetProperty( "color", ColorProperty::New(0.0, 1.0, 0.0) );
-  m_ThresholdFeedbackNode->SetProperty( "name", StringProperty::New("Thresholding feedback") );
-  m_ThresholdFeedbackNode->SetProperty( "opacity", FloatProperty::New(0.3) );
-  m_ThresholdFeedbackNode->SetProperty("binary", BoolProperty::New(true));
-  m_ThresholdFeedbackNode->SetProperty( "helper object", BoolProperty::New(true) );
+  SetupPreviewProperties();
 }
 
 mitk::BinaryThresholdULTool::~BinaryThresholdULTool()
@@ -148,6 +144,15 @@ void mitk::BinaryThresholdULTool::CancelThresholding()
   m_ToolManager->ActivateTool(-1);
 }
 
+void mitk::BinaryThresholdULTool::SetupPreviewProperties()
+{
+  m_ThresholdFeedbackNode->SetProperty("color", ColorProperty::New(0.0, 1.0, 0.0) );
+  m_ThresholdFeedbackNode->SetProperty("name", StringProperty::New("Thresholding feedback") );
+  m_ThresholdFeedbackNode->SetProperty("opacity", FloatProperty::New(0.3) );
+  m_ThresholdFeedbackNode->SetProperty("binary", BoolProperty::New(true));
+  m_ThresholdFeedbackNode->SetProperty("helper object", BoolProperty::New(true) );
+}
+
 void mitk::BinaryThresholdULTool::SetupPreviewNode()
 {
   if (m_NodeForThresholding.IsNotNull())
@@ -162,10 +167,12 @@ void mitk::BinaryThresholdULTool::SetupPreviewNode()
       if (workingimage)
       {
         m_ThresholdFeedbackNode->SetData(workingimage->Clone());
+        // Set properties again. Props are cleared on data type change
+        SetupPreviewProperties();
 
         //Let's paint the feedback node green...
         mitk::LabelSetImage::Pointer previewImage = dynamic_cast<mitk::LabelSetImage*> (m_ThresholdFeedbackNode->GetData());
-        if (previewImage) 
+        if (previewImage)
         {
           itk::RGBPixel<float> pixel;
           pixel[0] = 0.0f;

--- a/Modules/Segmentation/Interactions/mitkBinaryThresholdULTool.h
+++ b/Modules/Segmentation/Interactions/mitkBinaryThresholdULTool.h
@@ -77,6 +77,7 @@ namespace mitk
     void UpdatePreview();
     void CreateNewSegmentationFromThreshold(DataNode* node);
     void OnRoiDataChanged();
+    void SetupPreviewProperties();
 
     DataNode::Pointer m_ThresholdFeedbackNode;
     DataNode::Pointer m_OriginalImageNode;

--- a/Modules/Segmentation/Interactions/mitkOtsuTool3D.cpp
+++ b/Modules/Segmentation/Interactions/mitkOtsuTool3D.cpp
@@ -175,8 +175,29 @@ void mitk::OtsuTool3D::ConfirmSegmentation()
 {
   mitk::LabelSetImage::Pointer resultImage = mitk::LabelSetImage::New();
   resultImage->InitializeByLabeledImage(dynamic_cast<mitk::Image*>(m_BinaryPreviewNode->GetData()));
-  GetTargetSegmentationNode()->SetData(resultImage);
 
+  auto targetSeg = GetTargetSegmentationNode();
+  if (0 == strcmp(targetSeg->GetData()->GetNameOfClass(), resultImage->GetNameOfClass())) {
+    targetSeg->SetData(resultImage);
+  } else {
+    auto propList = targetSeg->GetPropertyList();
+    
+    std::string name = "No Name!", caption = "No Name!";
+    mitk::ColorProperty::Pointer color;
+    float opacity = 1.f;
+    propList->GetStringProperty("name", name);
+    propList->GetStringProperty("caption", caption);
+    propList->GetFloatProperty("opacity", opacity);
+    color = dynamic_cast<mitk::ColorProperty*>(propList->GetProperty("color"));
+
+    targetSeg->SetData(resultImage);
+
+    targetSeg->SetStringProperty("name", name.c_str());
+    targetSeg->SetStringProperty("caption", caption.c_str());
+    targetSeg->SetFloatProperty("opactity", opacity);
+    targetSeg->SetProperty("color", color);
+  }
+   
   m_ToolManager->ActivateTool(-1);
 }
 


### PR DESCRIPTION
https://jira.smuit.ru/browse/AUT-4364

Исправляет:
* Некорректный предпросмотр трешхолда если использовать его на бинарную и мультилейбл сегментацию.
* Утерю свойств бинарной сегментации в отсу