### PR TITLE
Improve logic for rendering on crosshair change. AUT-4353

### DIFF
--- a/Modules/Core/src/Interactions/mitkDisplayInteractor.cpp
+++ b/Modules/Core/src/Interactions/mitkDisplayInteractor.cpp
@@ -524,13 +524,6 @@ void mitk::DisplayInteractor::SetCrosshair(mitk::StateMachineAction *, mitk::Int
       BaseRenderer::GetInstance(renWin)->GetSliceNavigationController()->SelectSliceByPoint(pos);
     }
   }
-
-  // TODO: Get crosshair manager, which is not available in MitkCore
-  //if (crosshairManager->getShowPlanesIn3D()) {
-  RenderingManager::GetInstance()->RequestUpdateAll();
-  //} else {
-  //  RenderingManager::GetInstance()->RequestUpdateAll(RenderingManager::RequestType::REQUEST_UPDATE_2DWINDOWS);
-  //}
 }
 
 void mitk::DisplayInteractor::Zoom(StateMachineAction*, InteractionEvent* interactionEvent)

--- a/Modules/QtWidgets/src/mitkCrosshairManager.cpp
+++ b/Modules/QtWidgets/src/mitkCrosshairManager.cpp
@@ -404,7 +404,14 @@ void mitkCrosshairManager::updateCrosshairsPositions()
   // Only recreate point mode
   if (m_CrosshairMode != CrosshairMode::POINT) {
     for (auto& window : m_ManagedWindows) {
-      window->GetRenderer()->RequestUpdate();
+      if (mitk::BaseRenderer::GetInstance(window->GetVtkRenderWindow())->GetMapperID() == mitk::BaseRenderer::Standard2D) {
+        window->GetRenderer()->RequestUpdate();
+        continue;
+      }
+      
+      if (m_ShowPlanesIn3d) {
+        window->GetRenderer()->RequestUpdate();
+      }
     }
     return;
   }


### PR DESCRIPTION
https://jira.smuit.ru/browse/AUT-4353

При перемещении перекрестья 3д окно не обновляется, если перекрестья не видно на нем.