### PR TITLE
Исправления поворота, зеркалирования и учёт ошибок в теге ориентации

### DIFF
--- a/Modules/Core/include/mitkCameraRotationController.h
+++ b/Modules/Core/include/mitkCameraRotationController.h
@@ -51,6 +51,7 @@ public:
 
   //virtual bool ExecuteAction(Action* action, mitk::StateEvent const* stateEvent) override;
   void RotateCameraToTransformationAngles();
+  void RotateCameraBack();
   void Mirror(bool horizontal);
   void ResetTransformationAngles();
 
@@ -58,7 +59,6 @@ protected:
   CameraRotationController();
   virtual ~CameraRotationController();
 
-private:
   int m_LastStepperValue;
   int m_ElevateLastStepperValue;
 
@@ -68,7 +68,6 @@ private:
   Stepper::Pointer m_ElevationSlice;
 
   double m_Roll;
-  double m_RollMirror;
   double m_Azimuth;
 };
 

--- a/Modules/Core/src/Controllers/mitkCameraRotationController.cpp
+++ b/Modules/Core/src/Controllers/mitkCameraRotationController.cpp
@@ -48,7 +48,8 @@ mitk::CameraRotationController::CameraRotationController()
   m_Slice->AddObserver(itk::ModifiedEvent(), sliceStepperChangedCommand);
   m_ElevationSlice->AddObserver(itk::ModifiedEvent(), elevateSliceStepperChangedCommand);
 
-  ResetTransformationAngles();
+  m_Roll = 0.0;
+  m_Azimuth = 0.0;
 }
 
 mitk::CameraRotationController::~CameraRotationController()
@@ -100,7 +101,7 @@ void mitk::CameraRotationController::RotateToAngle(double angle)
   if (m_Camera)
   {
     m_Roll = fmod(m_Roll + angle, 360);
-    m_Camera->SetRoll(m_Camera->GetRoll() + angle);
+    m_Camera->Roll(angle);
     mitk::RenderingManager::GetInstance()->RequestUpdate(m_RenderWindow);
   }
 }
@@ -144,10 +145,9 @@ void mitk::CameraRotationController::Mirror(bool horizontal)
     this->AcquireCamera();
   }
   if (m_Camera) {
+    RotateCameraBack();
     m_Azimuth = fmod(m_Azimuth + 180, 360);
-    if (horizontal) {
-      m_RollMirror = fmod(m_RollMirror + 180, 360);
-    }
+    m_Roll = fmod(-m_Roll + horizontal*180, 360);
     RotateCameraToTransformationAngles();
   }
   //roll and azimuth are set in mitk::CameraRotationController::RotateCameraToTransformationAngles()
@@ -157,14 +157,22 @@ void mitk::CameraRotationController::Mirror(bool horizontal)
 void mitk::CameraRotationController::RotateCameraToTransformationAngles()
 {
   if (m_Camera) {
-    m_Camera->Roll(m_Roll + m_RollMirror);
     m_Camera->Azimuth(m_Azimuth);
+    m_Camera->Roll(m_Roll);
+  }
+}
+
+void mitk::CameraRotationController::RotateCameraBack()
+{
+  if (m_Camera) {
+    m_Camera->Roll(-m_Roll);
+    m_Camera->Azimuth(-m_Azimuth);
   }
 }
 
 void mitk::CameraRotationController::ResetTransformationAngles()
 {
+  RotateCameraBack();
   m_Roll = 0.0;
-  m_RollMirror = 0.0;
   m_Azimuth = 0.0;
 }

--- a/Modules/Core/src/IO/mitkDicomSeriesReader.cpp
+++ b/Modules/Core/src/IO/mitkDicomSeriesReader.cpp
@@ -391,22 +391,23 @@ DicomSeriesReader::DICOMStringToOrientationVectors(const std::string& s, Vector3
     }
   }
 
-  if (dim && dim != 6)
-  {
-    successful = false;
-    MITK_ERROR << "Reader implementation made wrong assumption on tag (0020,0037). Found " << dim << " instead of 6 values.";
-  }
-  else if (dim == 0)
-  {
-    // fill with defaults
-    right.Fill(0.0);
-    right[0] = 1.0;
-
-    up.Fill(0.0);
-    up[1] = 1.0;
-
+  if (dim == 6) {
+    // check for noncollinearity
+    if (std::abs(up[0]*right[1]-up[1]*right[0]) >= mitk::eps || std::abs(up[1]*right[2]-up[2]*right[1]) >= mitk::eps || std::abs(up[0]*right[2]-up[2]*right[0]) >= mitk::eps) {
+      return;
+    }
+    MITK_ERROR << "Tag ImageOrientationPatient(0020,0037) contains collinear vectors, so it is incorrect! Default orientation will be used.";
+  } else {
+    if (dim) {
+      MITK_ERROR << "Tag ImageOrientationPatient(0020,0037) contains only " << dim << " instead of 6 values. Default orientation will be used.";
+    }
     successful = false;
   }
+
+  right.Fill(0);
+  right[0] = 1.0;
+  up.Fill(0);
+  up[1] = 1.0;
 }
 
 


### PR DESCRIPTION
В старой версии в однооконном просмотре последовательность "поворот, зеркало, поворот, зеркало" работало неадекватно, сброс камеры чаще всего не срабатывал.
Пторой патч для некоторых не совсем корректных DICOMов.