### PR TITLE
Add try catch to QApplication notify

### DIFF
--- a/Modules/AppUtil/src/QmitkSafeApplication.cpp
+++ b/Modules/AppUtil/src/QmitkSafeApplication.cpp
@@ -21,18 +21,26 @@ See LICENSE.txt or http://www.mitk.org for details.
 #include <mitkException.h>
 #include <mitkLogMacros.h>
 
+#include <iostream>
+
 QmitkSafeApplication::QmitkSafeApplication(int& argc, char** argv)
   : QApplication(argc, argv)
 {}
 
 bool QmitkSafeApplication::notify(QObject* receiver, QEvent* event)
 {
-  if (!m_SafeMode)
-  {
-    return QApplication::notify(receiver, event);
-  }
+  bool result = false;
+  try {
+    if (!m_SafeMode)
+    {
+      result = QApplication::notify(receiver, event);
+    }
 
-  return QmitkSafeNotify<QApplication>(this, receiver, event);
+    result = QmitkSafeNotify<QApplication>(this, receiver, event);
+  } catch (const std::exception& ex) {
+    std::cout << ex.what() << std::endl;
+  }
+  return result;
 }
 
 void QmitkSafeApplication::setSafeMode(bool safeMode)

--- a/Modules/AppUtil/src/QmitkSingleApplication.cpp
+++ b/Modules/AppUtil/src/QmitkSingleApplication.cpp
@@ -18,6 +18,8 @@ See LICENSE.txt or http://www.mitk.org for details.
 
 #include "QmitkSafeNotify.h"
 
+#include <iostream>
+
 QmitkSingleApplication::QmitkSingleApplication(int& argc, char** argv, bool safeMode)
   : QtSingleApplication(argc, argv)
   , m_SafeMode(safeMode)
@@ -26,12 +28,18 @@ QmitkSingleApplication::QmitkSingleApplication(int& argc, char** argv, bool safe
 
 bool QmitkSingleApplication::notify(QObject* receiver, QEvent* event)
 {
-  if (!m_SafeMode)
-  {
-    return QtSingleApplication::notify(receiver, event);
-  }
+  bool result = false;
+  try {
+    if (!m_SafeMode)
+    {
+      result = QtSingleApplication::notify(receiver, event);
+    }
 
-  return QmitkSafeNotify<QtSingleApplication>(this, receiver, event);
+    result = QmitkSafeNotify<QtSingleApplication>(this, receiver, event);
+  } catch (const std::exception& ex) {
+    std::cout << ex.what() << std::endl;
+  }
+  return result;
 }
 
 void QmitkSingleApplication::setSafeMode(bool safeMode)


### PR DESCRIPTION
Helps with

```
Qt has caught an exception thrown from an event handler. Throwing
exceptions from an event handler is not supported in Qt.
You must not let any exception whatsoever propagate through Qt code.
If that is not possible, in Qt 5 you must at least reimplement
QCoreApplication::notify() and catch all exceptions there.
```