### PR TITLE
Get actual nodes from datamanager AUT-4341

### DIFF
--- a/Plugins/org.mitk.gui.qt.basicimageprocessing/src/internal/QmitkBasicImageProcessingView.cpp
+++ b/Plugins/org.mitk.gui.qt.basicimageprocessing/src/internal/QmitkBasicImageProcessingView.cpp
@@ -289,8 +289,10 @@ void QmitkBasicImageProcessing::SetFocus()
 }
 
 //datamanager selection changed
-void QmitkBasicImageProcessing::OnSelectionChanged(berry::IWorkbenchPart::Pointer, const QList<mitk::DataNode::Pointer>& nodes)
+void QmitkBasicImageProcessing::OnSelectionChanged(berry::IWorkbenchPart::Pointer, const QList<mitk::DataNode::Pointer>& /*nodes*/)
 {
+  auto nodes = this->GetDataManagerSelection();
+
   //any nodes there?
   if (!nodes.empty())
   {

--- a/Plugins/org.mitk.gui.qt.properties/src/internal/QmitkPropertyTreeView.cpp
+++ b/Plugins/org.mitk.gui.qt.properties/src/internal/QmitkPropertyTreeView.cpp
@@ -333,8 +333,10 @@ void QmitkPropertyTreeView::OnPropertyNameChanged(const itk::EventObject&)
   }
 }
 
-void QmitkPropertyTreeView::OnSelectionChanged(berry::IWorkbenchPart::Pointer, const QList<mitk::DataNode::Pointer>& nodes)
+void QmitkPropertyTreeView::OnSelectionChanged(berry::IWorkbenchPart::Pointer, const QList<mitk::DataNode::Pointer>& /*nodes*/)
 {
+  auto nodes = this->GetDataManagerSelection();
+
   mitk::PropertyList* propertyList = m_Model->GetPropertyList();
 
   if (propertyList != NULL)
@@ -444,10 +446,10 @@ void QmitkPropertyTreeView::OnPropertyListChanged(int index)
     : NULL;
 
   QList<mitk::DataNode::Pointer> nodes;
-
+  /*
   if (m_SelectedNode.IsNotNull())
     nodes << m_SelectedNode;
-
+  */
   berry::IWorkbenchPart::Pointer workbenchPart;
 
   this->OnSelectionChanged(workbenchPart, nodes);

--- a/Plugins/org.mitk.gui.qt.volumevisualization/src/internal/QmitkVolumeVisualizationView.cpp
+++ b/Plugins/org.mitk.gui.qt.volumevisualization/src/internal/QmitkVolumeVisualizationView.cpp
@@ -142,8 +142,10 @@ void QmitkVolumeVisualizationView::OnMitkInternalPreset( int mode )
 }
 
 
-void QmitkVolumeVisualizationView::OnSelectionChanged(berry::IWorkbenchPart::Pointer /*part*/, const QList<mitk::DataNode::Pointer>& nodes)
+void QmitkVolumeVisualizationView::OnSelectionChanged(berry::IWorkbenchPart::Pointer /*part*/, const QList<mitk::DataNode::Pointer>& /*nodes*/)
 {
+  auto nodes = this->GetDataManagerSelection();
+
   bool weHadAnImageButItsNotThreeDeeOrFourDee = false;
 
   mitk::DataNode::Pointer node;


### PR DESCRIPTION
Выбранные ноды onSelectionChanged получает из ISelectionProvider, но возникает проблема:
   при переоткрытии исследования во вкладке "Редактор" и при этом не выбрать ноду/ноды в 
   плагине "Управление данных", то получаем предыдущие выбранные ноды.

https://jira.smuit.ru/browse/AUT-4341