### PR TITLE
Fix importing itk images into mitk. AUT-4498

### DIFF
--- a/Modules/Core/include/mitkITKImageImport.txx
+++ b/Modules/Core/include/mitkITKImageImport.txx
@@ -80,7 +80,7 @@ void mitk::ITKImageImport<TInputImage>::GenerateData()
   InputImageConstPointer input  = this->GetInput();
   mitk::Image::Pointer output = this->GetOutput();
 
-  output->SetImportVolume((void*)input->GetBufferPointer(), 0, mitk::Image::ReferenceMemory);
+  output->SetImportVolume((void*)input->GetBufferPointer(), 0, 0, mitk::Image::ReferenceMemory);
 }
 
 template <class TInputImage>

--- a/Modules/Core/src/DataManagement/mitkImage.cpp
+++ b/Modules/Core/src/DataManagement/mitkImage.cpp
@@ -857,7 +857,10 @@ unsigned int* mitk::Image::GetDimensions() const
 
 bool mitk::Image::SetImportVolume(void *data, int t, int n, ImportMemoryManagementType importMemoryManagement)
 {
-  if (IsValidVolume(t, n) == false) return false;
+  if (!IsValidVolume(t, n)) {
+    MITK_WARN << "Can't import volume for time " << t << " and channel " << n;
+    return false;
+  }
 
   const size_t ptypeSize = this->m_ImageDescriptor->GetChannelTypeById(n).GetSize();
   ImageDataItemPointer vol;

--- a/Modules/DiffusionImaging/DiffusionCore/src/Algorithms/Registration/mitkDWIHeadMotionCorrectionFilter.cpp
+++ b/Modules/DiffusionImaging/DiffusionCore/src/Algorithms/Registration/mitkDWIHeadMotionCorrectionFilter.cpp
@@ -167,7 +167,7 @@ void mitk::DWIHeadMotionCorrectionFilter::GenerateData()
 
   mitk::Image::Pointer splittedImage = mitk::Image::New();
   splittedImage->InitializeByItk( split_filter->GetOutput() );
-  splittedImage->SetImportVolume( split_filter->GetOutput()->GetBufferPointer(),
+  splittedImage->SetImportVolume( split_filter->GetOutput()->GetBufferPointer(), 0, 0,
                                    mitk::Image::CopyMemory );
 
 

--- a/Modules/IpPicSupportIO/Internal/mitkPicFileReader.cpp
+++ b/Modules/IpPicSupportIO/Internal/mitkPicFileReader.cpp
@@ -200,7 +200,7 @@ void mitk::PicFileReader::FillImage(Image::Pointer output)
   // Copy the memory to avoid mismatches of malloc() and delete[].
   // mitkIpPicGet will always allocate a new memory block with malloc(),
   // but MITK Images delete the data via delete[].
-  output->SetImportVolume(pic->data, 0, Image::CopyMemory);
+  output->SetImportVolume(pic->data, 0, 0, Image::CopyMemory);
   pic->data = nullptr;
   mitkIpPicFree(pic);
 }

--- a/Modules/LegacyIO/mitkItkImageFileReader.cpp
+++ b/Modules/LegacyIO/mitkItkImageFileReader.cpp
@@ -121,7 +121,7 @@ void mitk::ItkImageFileReader::GenerateData()
   imageIO->Read( buffer );
 
   image->Initialize( MakePixelType(imageIO), ndim, dimensions );
-  image->SetImportVolume( buffer, 0, Image::ManageMemory );
+  image->SetImportVolume( buffer, 0, 0, Image::ManageMemory );
 
   // access direction of itk::Image and include spacing
   mitk::Matrix3D matrix;

--- a/Modules/SegmentationUI/Qmitk/QmitkAdaptiveRegionGrowingToolGUI.cpp
+++ b/Modules/SegmentationUI/Qmitk/QmitkAdaptiveRegionGrowingToolGUI.cpp
@@ -456,7 +456,7 @@ void QmitkAdaptiveRegionGrowingToolGUI::StartRegionGrowing(itk::Image<TPixel, VI
     return;
   }
 
-  mitk::Image::Pointer resultImage = mitk::ImportItkImage(regionGrower->GetOutput())->Clone();
+  mitk::Image::Pointer resultImage = mitk::ImportItkImage(regionGrower->GetOutput());
 
   m_RGMINIMUM = resultImage->GetStatistics()->GetScalarValueMin() != 0 ? resultImage->GetStatistics()->GetScalarValueMin() : 1;
   m_RGMAXIMUM = resultImage->GetStatistics()->GetScalarValueMax();


### PR DESCRIPTION
https://jira.smuit.ru/browse/AUT-4498

Исправляет ипортирование итк изображений в митк через `mitk::ImportItkImage`

1. Открыть исследование 138969
2. Создать сегментацию
2. Заполнить сегментацию при помощи Разрастания области 3Д на первом временном срезе
ER:  Сегментацию видно пока она создается, нет падений
3. Заполнить сегментацию при помощи Разрастания области 3Д на втором временном срезе
ER:  Сегментацию видно пока она создается, нет падений