### PR TITLE
Fix vtk resolution for sphere trees. AUT-4478 [clean]

### DIFF
--- a/CMakeExternals/VTK.cmake
+++ b/CMakeExternals/VTK.cmake
@@ -89,6 +89,7 @@ if(NOT DEFINED VTK_DIR)
       COMMAND ${PATCH_COMMAND} -N -p1 -i ${CMAKE_CURRENT_LIST_DIR}/VtkOpenGLVolumeGradientOpacityTable.patch
       COMMAND ${PATCH_COMMAND} -N -p1 -i ${CMAKE_CURRENT_LIST_DIR}/VtkJittering.patch
       COMMAND ${PATCH_COMMAND} -N -p1 -i ${CMAKE_CURRENT_LIST_DIR}/VtkRotatedVolumes.patch
+      COMMAND ${PATCH_COMMAND} -N -p1 -i ${CMAKE_CURRENT_LIST_DIR}/VtkSphereTree.patch
     CMAKE_GENERATOR ${gen}
     CMAKE_ARGS
         ${ep_common_args}

--- a/CMakeExternals/VtkSphereTree.patch
+++ b/CMakeExternals/VtkSphereTree.patch
@@ -1,0 +1,11 @@
+diff --git a/Common/ExecutionModel/vtkSphereTree.cxx b/Common/ExecutionModel/vtkSphereTree.cxx
+--- a/Common/ExecutionModel/vtkSphereTree.cxx
++++ b/Common/ExecutionModel/vtkSphereTree.cxx
+@@ -1366,6 +1366,7 @@
+   // radius (in each direction).
+   double spacing[3], r=this->AverageRadius, *bds=this->SphereBounds;
+   int dims[3], res=this->Resolution;
++  r = std::max(r, .5);
+   for (int i=0; i<3; ++i)
+   {
+     dims[i] = static_cast<int>( (bds[2*i+1]-bds[2*i])/(res*r) );


### PR DESCRIPTION
https://jira.smuit.ru/browse/AUT-4478

Исправляет падение при создании мега мелкой решетки для сферического дерева. Такое происходило если все полигоны на получившейся модели были очень маленького размера. Патч регулирует минимальное разрешение решетки.

1. Создать сегментацию
2. Инструментом сегментирования Кисть выделить 3 вокселя, 2 на аксиальной, 1 на сагитальной проекции. Важно чтобы они находились на трехмерной дистанции друг от друга
3. Построить сглаженную модель
ER: Автоплан не завис или не упал (зависит от дистанции)

Важно иметь больше одного вокселя, потому что иначе решетка с супер разрешением будет на очень маленьком объеме (микро части одного вокселя).
В теории это неправильная реализация дерева и было бы лучше хранить его без решетки, например в графе? Скорее всего решетка используется для быстрой обработки модификаций меша, но митк пересоздает все маперы на любое изменение все равно.
В случае васкуляра из задачи, не успешная сегментация заливает один воксель. Две не успешных сегментации приводили к этому багу при заполнении модели.