### PR TITLE
Fix region growing crashes on 4D. AUT-4498

### DIFF
--- a/Modules/ContourModel/DataManagement/mitkContourModel.cpp
+++ b/Modules/ContourModel/DataManagement/mitkContourModel.cpp
@@ -572,7 +572,6 @@ void mitk::ContourModel::RedistributeControlVertices(int period, int timestep)
   }
 }
 
-
 void mitk::ContourModel::ClearData()
 {
   //call the superclass, this releases the data of BaseData

--- a/Modules/Segmentation/Interactions/mitkRegionGrowingTool.h
+++ b/Modules/Segmentation/Interactions/mitkRegionGrowingTool.h
@@ -149,6 +149,7 @@ class MITKSEGMENTATION_EXPORT RegionGrowingTool : public FeedbackContourTool
     int m_PaintingPixelValue;
     bool m_FillFeedbackContour;
     int m_ConnectedComponentValue;
+    ContourModel::Pointer m_Contour;
 };
 
 } // namespace


### PR DESCRIPTION
https://jira.smuit.ru/browse/AUT-4498

Исправляет падения в инструменте сегментирования Разрастание Области на 4д исследованиях

1. Открыть 4д исследование (138969)
2. Выбрать второй временной срез
3. Сделать сегментацию при помощи разрастания области
ER: Автоплан не упал