### PR TITLE
Fix crash in interpolation. AUT-4523

### DIFF
--- a/Modules/SurfaceInterpolation/mitkComputeContourSetNormalsFilter.cpp
+++ b/Modules/SurfaceInterpolation/mitkComputeContourSetNormalsFilter.cpp
@@ -156,7 +156,7 @@ void mitk::ComputeContourSetNormalsFilter::GenerateData()
           bool validIndex = true;
           m_SegmentationBinaryImage->GetGeometry()->WorldToIndex(worldCoord, idx);
           for (int d = 0; d < 3; d++) {
-            if (idx[d] < 0 || idx[d] > m_SegmentationBinaryImage->GetDimensions()[i]) {
+            if (idx[d] < 0 || idx[d] > m_SegmentationBinaryImage->GetDimensions()[d]) {
               validIndex = false;;
               break;
             }


### PR DESCRIPTION
https://jira.smuit.ru/browse/AUT-4523

Частичный фикс.
Исправляет падение в интерполяции. Не исправляет не работающую интерполяцию на малом количестве вокселей на срез.