### PR TITLE
Change restriction for reduction filter in interpolation. AUT-4523

### DIFF
--- a/Modules/SurfaceInterpolation/mitkReduceContourSetFilter.cpp
+++ b/Modules/SurfaceInterpolation/mitkReduceContourSetFilter.cpp
@@ -182,7 +182,9 @@ void mitk::ReduceContourSetFilter::ReduceNumberOfPointsByDouglasPeucker(vtkIdTyp
                                                                         vtkPolygon* reducedPolygon, vtkPoints* reducedPoints)
 {
   //If the cell is too small to obtain a reduced polygon with the given stepsize return
-  if (cellSize <= static_cast<vtkIdType>(m_StepSize*3))return;
+  if (cellSize <= vtkIdType(3)) {
+    return;
+  }
 
   /*
   What we do now is (see the Douglas Peucker Algorithm):


### PR DESCRIPTION
https://jira.smuit.ru/browse/AUT-4523

Исправляет ограничения в алгоритме фильтра сжатия, использующегося в интерполяции. Раньше он ограничивал минимальное количество точек `(3 * m_StepSize)=30`. Но алгоритм никак не использует `m_StepSize` и прекрасно работает на количестве точек до 3 (даже 2 но считание линии за полигон возможно может сломать логику втк\митк).  Скорее артефакт от другого алгоритма, который активно использует `m_StepSize`.
Изменение на 3 расширяет работу интерполяции, для сегментаций с маленьким количеством вокселей, как описано в комментариях к задаче.

1. Создать сегментацию
2. Включить интерполяцию
3. Сделать большую заполненную сегментацию на одной из проекций
4. Сделать небольшой контур на другой
ER: 3Д интерполяция построилась