### PR TITLE
Fix vr crash on flat dicoms. AUT-4408 [clean]

### DIFF
--- a/CMakeExternals/VTK.cmake
+++ b/CMakeExternals/VTK.cmake
@@ -90,6 +90,7 @@ if(NOT DEFINED VTK_DIR)
       COMMAND ${PATCH_COMMAND} -N -p1 -i ${CMAKE_CURRENT_LIST_DIR}/VtkJittering.patch
       COMMAND ${PATCH_COMMAND} -N -p1 -i ${CMAKE_CURRENT_LIST_DIR}/VtkRotatedVolumes.patch
       COMMAND ${PATCH_COMMAND} -N -p1 -i ${CMAKE_CURRENT_LIST_DIR}/VtkSphereTree.patch
+      COMMAND ${PATCH_COMMAND} -N -p1 -i ${CMAKE_CURRENT_LIST_DIR}/VtkVrStepFix.patch
     CMAKE_GENERATOR ${gen}
     CMAKE_ARGS
         ${ep_common_args}

--- a/CMakeExternals/VtkVrStepFix.patch
+++ b/CMakeExternals/VtkVrStepFix.patch
@@ -1,0 +1,11 @@
+diff --git a/Rendering/VolumeOpenGL2/vtkVolumeShaderComposer.h b/Rendering/VolumeOpenGL2/vtkVolumeShaderComposer.h
+--- a/Rendering/VolumeOpenGL2/vtkVolumeShaderComposer.h
++++ b/Rendering/VolumeOpenGL2/vtkVolumeShaderComposer.h
+@@ -1634,6 +1634,7 @@
+       \n\
+       \n  g_terminatePointMax = length(terminatePoint.xyz - g_dataPos.xyz) /\
+       \n                        length(g_dirStep);\
++      \n  if (isnan(g_terminatePointMax)) g_terminatePointMax = 0.;\
+       \n  g_currentT = 0.0;");
+   }
+ 


### PR DESCRIPTION
https://jira.smuit.ru/browse/AUT-4408

Исправляет падение при включении вр на плоском изображении.

1. Отркрыть 0569
2. Включить VR на плоском снимке через плагин свойств
3. Повернуть камеру в окне с VR
ER: Автоплан не упал