### PR TITLE
Fix initial window size. AUT-4572

### DIFF
--- a/Plugins/org.blueberry.ui.qt/src/berryShell.h
+++ b/Plugins/org.blueberry.ui.qt/src/berryShell.h
@@ -138,6 +138,7 @@ public:
 
   virtual void SetBounds(const QRect& bounds) = 0;
   virtual QRect GetBounds() const = 0;
+  virtual int GetTitleBarHeight() const = 0;
 
   virtual void SetLocation(int x, int y) = 0;
 

--- a/Plugins/org.blueberry.ui.qt/src/berryWindow.cpp
+++ b/Plugins/org.blueberry.ui.qt/src/berryWindow.cpp
@@ -359,6 +359,15 @@ QRect Window::GetConstrainedShellBounds(const QRect& preferredSize)
   int screenNum = guiTweaklet->GetClosestScreenNumber(result);
   QRect bounds(guiTweaklet->GetAvailableScreenSize(screenNum));
 
+  int titleBarHeight = shell->GetTitleBarHeight();
+  
+  bounds.setTop(bounds.y() + titleBarHeight);
+
+  result.setLeft(std::max<int>(bounds.x(), std::min<int>(result.x(), bounds.x()
+    + bounds.width() - result.width())));
+  result.setTop(std::max<int>(bounds.y(), std::min<int>(result.y(), bounds.y()
+    + bounds.height() - result.height())));
+
   if (result.height() > bounds.height()) {
     result.setHeight(bounds.height());
   }
@@ -366,11 +375,6 @@ QRect Window::GetConstrainedShellBounds(const QRect& preferredSize)
   if (result.width() > bounds.width()) {
     result.setWidth(bounds.width());
   }
-
-  result.moveLeft( std::max<int>(bounds.x(), std::min<int>(result.x(), bounds.x()
-    + bounds.width() - result.width())));
-  result.moveTop(std::max<int>(bounds.y(), std::min<int>(result.y(), bounds.y()
-    + bounds.height() - result.height())));
 
   return result;
 }

--- a/Plugins/org.blueberry.ui.qt/src/internal/berryQtShell.cpp
+++ b/Plugins/org.blueberry.ui.qt/src/internal/berryQtShell.cpp
@@ -68,6 +68,11 @@ QRect QtShell::GetBounds() const
   return widget->geometry();
 }
 
+int QtShell::GetTitleBarHeight() const
+{
+  return widget->geometry().y() - widget->pos().y();
+}
+
 void QtShell::SetLocation(int x, int y)
 {
   widget->move(x, y);

--- a/Plugins/org.blueberry.ui.qt/src/internal/berryQtShell.h
+++ b/Plugins/org.blueberry.ui.qt/src/internal/berryQtShell.h
@@ -38,6 +38,7 @@ public:
   // berry::Shell
   void SetBounds(const QRect& bounds) override;
   QRect GetBounds() const override;
+  int GetTitleBarHeight() const override;
 
   void SetLocation(int x, int y) override;
 


### PR DESCRIPTION
https://jira.smuit.ru/browse/AUT-4572

Исправляет ограничения размера для первой инициализации окна. Баг воспроизводится на всех разрешениях экрана меньше ~1200 в высоту, но по подозрительному магическому совпадению в математике берри ошибка составляет только 2 пикселя за пределы экрана при высоте 1080 пикселей

1. Прочистить профиль
2. Выставить разрешение основного экрана меньше 1080
3. Открыть автоплан
ER: Окно автоплана правильно заполняет вертикальное пространство экрана, не выходя за пределы