### PR TITLE
Улучшения отображения аннотаций

### DIFF
--- a/Modules/Core/files.cmake
+++ b/Modules/Core/files.cmake
@@ -274,6 +274,7 @@ set(CPP_FILES
   Rendering/mitkSurfaceVtkMapper2D.cpp
   Rendering/mitkSurfaceVtkMapper3D.cpp
   Rendering/mitkVtkEventProvider.cpp
+  Rendering/mitkVtkFont.cpp
   Rendering/mitkVtkMapper.cpp
   Rendering/mitkVtkOverlay2D.cpp
   Rendering/mitkVtkOverlay3D.cpp

--- a/Modules/Core/include/mitkVtkFont.h
+++ b/Modules/Core/include/mitkVtkFont.h
@@ -1,0 +1,12 @@
+#pragma once
+
+/// Utilities to use common unicode font in vtkTextProperty
+
+#include <vtkTextProperty.h>
+
+#include <MitkCoreExports.h>
+
+namespace mitk {
+  /// Configure vtkTextProperty object to use unicode font DejaVuSans from file
+  MITKCORE_EXPORT void setUnicodeFont(vtkTextProperty* prop);
+}

--- a/Modules/Core/src/Rendering/mitkVtkFont.cpp
+++ b/Modules/Core/src/Rendering/mitkVtkFont.cpp
@@ -1,0 +1,14 @@
+#include <mitkVtkFont.h>
+#include <PathUtilities.h>
+
+static std::string s_FontPath;
+
+void mitk::setUnicodeFont(vtkTextProperty* prop)
+{
+  prop->SetFontFamily(VTK_FONT_FILE);
+  if (s_FontPath.empty())
+  {
+    s_FontPath = Utilities::preferredPath(Utilities::absPath(std::string("Fonts\\DejaVuSans.ttf")));
+  }
+  prop->SetFontFile(s_FontPath.c_str());
+}

--- a/Modules/Overlays/mitkTextOverlay2D.cpp
+++ b/Modules/Overlays/mitkTextOverlay2D.cpp
@@ -15,7 +15,7 @@ See LICENSE.txt or http://www.mitk.org for details.
 ===================================================================*/
 
 #include "mitkTextOverlay2D.h"
-#include <vtkTextProperty.h>
+#include <mitkVtkFont.h>
 #include "vtkUnicodeString.h"
 #include <vtkTextActor.h>
 #include <vtkPropAssembly.h>
@@ -79,36 +79,7 @@ mitk::TextOverlay2D::LocalStorage::LocalStorage()
   m_STextActor = vtkSmartPointer<vtkTextActor>::New();
   m_STextProp = vtkSmartPointer<vtkTextProperty>::New();
 
-  std::string m_programPath;
-
-#ifndef _WIN32
-#include <unistd.h>
-#include <limits.h>
-
-  char buff[PATH_MAX];
-  ssize_t len = ::readlink("/proc/self/exe", buff, sizeof(buff) - 1);
-  if (len != -1) {
-    buff[len] = '\0';
-    m_programPath = std::string(buff);
-  }
-#else
-
-  m_programPath.resize(1024);
-  DWORD pathSize = GetModuleFileNameA(nullptr, &m_programPath[0], m_programPath.size());
-  m_programPath.resize(pathSize);
-
-  std::string::size_type pos = m_programPath.rfind("\\");
-  if (pos != std::string::npos) {
-    m_programPath.erase(pos + 1, m_programPath.size());
-  }
-
-#endif
-
-  std::string fontPath = m_programPath + std::string("Fonts\\DejaVuSans.ttf");
-
-  m_TextProp->SetFontFamily(VTK_FONT_FILE);
-  m_TextProp->SetFontFile(fontPath.c_str());
-  
+  setUnicodeFont(m_TextProp);
   m_TextProp->SetFontSize(FONT_SIZE);
   m_STextProp->SetFontSize(FONT_SIZE);
 
@@ -142,8 +113,9 @@ void mitk::TextOverlay2D::UpdateVtkOverlay2D(mitk::BaseRenderer *renderer)
     if ( GetStringProperty( "font.family", fontFamilyAsString ) == false || fontFamilyAsString.empty())
     {
       fontFamilyAsString = "Arial";
+    } else {
+      ls->m_TextProp->SetFontFamilyAsString( fontFamilyAsString.c_str() );
     }
-    ls->m_TextProp->SetFontFamilyAsString( fontFamilyAsString.c_str() );
     ls->m_STextProp->SetFontFamilyAsString( fontFamilyAsString.c_str() );
 
     bool boldFont(false);

--- a/Modules/QtWidgets/src/QmitkStdMultiWidget.cpp
+++ b/Modules/QtWidgets/src/QmitkStdMultiWidget.cpp
@@ -30,6 +30,8 @@ See LICENSE.txt or http://www.mitk.org for details.
 #include <QStringList>
 #include <QDir>
 
+#include <dcmtk/dcmdata/dcvrpn.h>
+
 #include <mitkProperties.h>
 #include <mitkPlaneGeometryDataMapper2D.h>
 #include <mitkPointSet.h>
@@ -1935,6 +1937,7 @@ void QmitkStdMultiWidget::HandleCrosshairPositionEventDelayed()
         sliceThickness, xrayTubeCurrent, kvp, imagePosition, windowCenter, windowWidth;
 
       imageProperties->GetStringProperty("dicom.patient.PatientsName", patient);
+      DcmPersonName::getFormattedNameFromString(patient, patient); // process '^' and '='
       imageProperties->GetStringProperty("dicom.patient.PatientID", patientId);
       imageProperties->GetStringProperty("dicom.patient.PatientsBirthDate", birthday);
       imageProperties->GetStringProperty("dicom.patient.PatientsSex", sex);
@@ -1947,6 +1950,7 @@ void QmitkStdMultiWidget::HandleCrosshairPositionEventDelayed()
       }
       imageProperties->GetStringProperty("dicom.study.StudyID", studiId);
       imageProperties->GetStringProperty("dicom.study.StudyDescription", studyDescription);
+      DcmPersonName::getFormattedNameFromString(studyDescription, studyDescription); // '^' appears in some studies
       //imageProperties->GetStringProperty("dicom.series.SeriesDescription", seriesDescription);
       imageProperties->GetStringProperty("dicom.ExInfo", exInfo);
       imageProperties->GetStringProperty("dicom.MagneticFieldStrength", magneticFieldStrength);

--- a/Modules/QtWidgets/src/QmitkStdMultiWidget.cpp
+++ b/Modules/QtWidgets/src/QmitkStdMultiWidget.cpp
@@ -48,14 +48,12 @@ See LICENSE.txt or http://www.mitk.org for details.
 #include <mitkDataNodePickingEventObserver.h>
 #include <mitkStandaloneDataStorage.h>
 #include <mitkResliceMethodProperty.h>
+#include <mitkVtkFont.h>
 
 #include <vtkRendererCollection.h>
-#include <vtkTextProperty.h>
 #include <vtkCornerAnnotation.h>
 #include <vtkMitkRectangleProp.h>
 #include "mitkPixelTypeMultiplex.h"
-
-#include <PathUtilities.h>
 
 void QmitkStdMultiWidget::UpdateAnnotationFonts()
 {
@@ -355,6 +353,7 @@ void QmitkStdMultiWidget::InitializeWidget(bool showPlanesIn3d)
   for(int i = 0; i < 4; i++) {
     cornerText[i] = vtkCornerAnnotation::New();
     textProp[i] = vtkTextProperty::New();
+    mitk::setUnicodeFont(textProp[i]);
     ren[i] = vtkRenderer::New();
     ren[i]->AddActor(cornerText[i]);
     ren[i]->InteractiveOff();
@@ -659,13 +658,10 @@ void QmitkStdMultiWidget::SetDecorationProperties( std::string text, mitk::Color
     return;
   }
 
-  std::string fontPath = Utilities::preferredPath(Utilities::absPath(std::string("Fonts\\DejaVuSans.ttf")));
-
   vtkSmartPointer<vtkCornerAnnotation> annotation = m_CornerAnnotations[widgetNumber];
   annotation->SetText(0, text.c_str());
   annotation->SetMaximumFontSize(12);
-  annotation->GetTextProperty()->SetFontFamily(VTK_FONT_FILE);
-  annotation->GetTextProperty()->SetFontFile(fontPath.c_str());
+  mitk::setUnicodeFont(annotation->GetTextProperty());
   annotation->GetTextProperty()->SetColor( color[0],color[1],color[2] );
 
   if(!renderer->HasViewProp(annotation))
@@ -1756,8 +1752,6 @@ mitk::DataNode::Pointer QmitkStdMultiWidget::GetTopLayerNode(mitk::DataStorage::
 
 void QmitkStdMultiWidget::setCornerAnnotation(int corner, int i, const char* text)
 {
-  std::string fontPath = Utilities::preferredPath(Utilities::absPath(std::string("Fonts\\DejaVuSans.ttf")));
-
   // empty or NULL string breaks renderer
   // and white square appears
   if ((text == NULL) || (text[0] == 0)) {
@@ -1766,8 +1760,6 @@ void QmitkStdMultiWidget::setCornerAnnotation(int corner, int i, const char* tex
 
   cornerText[i]->SetText(corner, text);
   cornerText[i]->SetMaximumFontSize(15);
-  textProp[i]->SetFontFamily(VTK_FONT_FILE);
-  textProp[i]->SetFontFile(fontPath.c_str());
   textProp[i]->SetColor(1.0, 1.0, 7.0);
   cornerText[i]->SetTextProperty(textProp[i]);
 }

--- a/Modules/Utilities/CMakeLists.txt
+++ b/Modules/Utilities/CMakeLists.txt
@@ -1,7 +1,6 @@
 MITK_CREATE_MODULE(
   PACKAGE_DEPENDS
-    PUBLIC Boost
-    PRIVATE Qt5|Core
+    PUBLIC Boost Qt5|Core
 )
 
 if (UNIX)


### PR DESCRIPTION
* Создана отдельная функция для установки уникодового шрифта в VTK
* В именах пациентов и описаниях исследований убираются символы "^", и если есть "=", показывается текст только до первого  такого знака (знак равно разделяет три возможных представления имени)
AUT-3733, AUT-4594