### PR TITLE
Выделил форматирование DICOM-тегов типа Person Name в отдельную функцию

### DIFF
--- a/Modules/Core/include/mitkDicomSeriesReader.h
+++ b/Modules/Core/include/mitkDicomSeriesReader.h
@@ -608,7 +608,8 @@ public:
    Parse a list of files for images of DICOM series.
    For each series, an enumeration of the files contained in it is created.
 
-   \return The resulting maps UID-like keys (based on Series Instance UID and slice properties) to sorted lists of file names.
+   \param result The resulting maps UID-like keys (based on Series Instance UID and slice properties)
+   to smart pointer to ImageBlockDescriptor ready to load tags and the image.
 
    SeriesInstanceUID will be enhanced to be unique for each set of file names
    that is later loadable as a single mitk::Image. This implies that
@@ -619,12 +620,20 @@ public:
    it will follow the same logic as itk::GDCMSeriesFileNames to enhance the UID with
    more digits and dots.
 
-   Optionally, more tags can be used to separate files into different logical series by setting
-   the restrictions parameter.
-
-   \warning Adding restrictions is not yet implemented!
    */
   static void GetSeries(FileNamesGrouping& result, const StringContainer& files, volatile bool* interrupt = nullptr);
+
+  /**
+   \brief Same as the preferred version but returns the result instead of add to the first argument (see other GetSeries())
+
+   \return The resulting maps UID-like keys (based on Series Instance UID and slice properties) to sorted lists of file names.
+   */
+  static FileNamesGrouping GetSeries(const StringContainer& files, volatile bool* interrupt = nullptr)
+  {
+    FileNamesGrouping result;
+    GetSeries(result, files, interrupt);
+    return result;
+  }
 
   /**
    Loads a DICOM series composed by the file names enumerated in the file names container.

--- a/Modules/Core/test/mitkDicomSeriesReaderTest.cpp
+++ b/Modules/Core/test/mitkDicomSeriesReaderTest.cpp
@@ -80,17 +80,14 @@ int mitkDicomSeriesReaderTest(int argc, char* argv[])
        seriesIter != seriesInFiles.end();
        ++seriesIter)
   {
-    mitk::DicomSeriesReader::StringContainer files = seriesIter->second.GetFilenames();
+    mitk::Image::Pointer image = seriesIter->second->GetImage();
 
-    mitk::DataNode::Pointer node = mitk::DicomSeriesReader::LoadDicomSeries( files );
-    MITK_TEST_CONDITION_REQUIRED(node.IsNotNull(),"Testing node")
+    MITK_TEST_CONDITION_REQUIRED(image.IsNotNull(),"Testing image")
 
-    if (node.IsNotNull())
+    if (image.IsNotNull())
     {
-      mitk::Image::Pointer image = dynamic_cast<mitk::Image*>( node->GetData() );
-
       images.push_back( image );
-      fileMap.insert( std::pair<mitk::Image::Pointer, mitk::DicomSeriesReader::StringContainer>(image,files));
+      fileMap.insert( std::pair<mitk::Image::Pointer, mitk::DicomSeriesReader::StringContainer>(image, seriesIter->second->GetFilenames()) );
     }
   }
 

--- a/Modules/DCMTesting/src/mitkTestDCMLoading.cpp
+++ b/Modules/DCMTesting/src/mitkTestDCMLoading.cpp
@@ -76,18 +76,10 @@ mitk::TestDCMLoading::ImageList mitk::TestDCMLoading::LoadFiles( const StringCon
        seriesIter != seriesInFiles.end();
        ++seriesIter)
   {
-    StringContainer files = seriesIter->second.GetFilenames();
-
-    DataNode::Pointer node = DicomSeriesReader::LoadDicomSeries( files, true, true, true, nullptr, nullptr, preLoadedVolume ); // true, true, true ist just a copy of the default values
-
-    if (node.IsNotNull())
+    Image::Pointer image = seriesIter->second->GetImage();
+    if (image.IsNotNull())
     {
-      Image::Pointer image = dynamic_cast<mitk::Image*>( node->GetData() );
-
       result.push_back( image );
-    }
-    else
-    {
     }
   }
 

--- a/Modules/QtWidgets/src/QmitkStdMultiWidget.cpp
+++ b/Modules/QtWidgets/src/QmitkStdMultiWidget.cpp
@@ -30,8 +30,7 @@ See LICENSE.txt or http://www.mitk.org for details.
 #include <QStringList>
 #include <QDir>
 
-#include <dcmtk/dcmdata/dcvrpn.h>
-
+#include <StringUtilities.h>
 #include <mitkProperties.h>
 #include <mitkPlaneGeometryDataMapper2D.h>
 #include <mitkPointSet.h>
@@ -1937,7 +1936,7 @@ void QmitkStdMultiWidget::HandleCrosshairPositionEventDelayed()
         sliceThickness, xrayTubeCurrent, kvp, imagePosition, windowCenter, windowWidth;
 
       imageProperties->GetStringProperty("dicom.patient.PatientsName", patient);
-      DcmPersonName::getFormattedNameFromString(patient, patient); // process '^' and '='
+      patient = Utilities::formatPersonName(patient); // process '^' and '='
       imageProperties->GetStringProperty("dicom.patient.PatientID", patientId);
       imageProperties->GetStringProperty("dicom.patient.PatientsBirthDate", birthday);
       imageProperties->GetStringProperty("dicom.patient.PatientsSex", sex);
@@ -1950,7 +1949,7 @@ void QmitkStdMultiWidget::HandleCrosshairPositionEventDelayed()
       }
       imageProperties->GetStringProperty("dicom.study.StudyID", studiId);
       imageProperties->GetStringProperty("dicom.study.StudyDescription", studyDescription);
-      DcmPersonName::getFormattedNameFromString(studyDescription, studyDescription); // '^' appears in some studies
+      studyDescription = Utilities::formatPersonName(studyDescription); // '^' appears in some studies
       //imageProperties->GetStringProperty("dicom.series.SeriesDescription", seriesDescription);
       imageProperties->GetStringProperty("dicom.ExInfo", exInfo);
       imageProperties->GetStringProperty("dicom.MagneticFieldStrength", magneticFieldStrength);

--- a/Modules/Utilities/CMakeLists.txt
+++ b/Modules/Utilities/CMakeLists.txt
@@ -1,6 +1,6 @@
 MITK_CREATE_MODULE(
   PACKAGE_DEPENDS
-    PUBLIC Boost Qt5|Core
+    PUBLIC Boost Qt5|Core DCMTK
 )
 
 if (UNIX)

--- a/Modules/Utilities/include/StringUtilities.h
+++ b/Modules/Utilities/include/StringUtilities.h
@@ -15,4 +15,12 @@ namespace Utilities
 #endif
 
   MITKUTILITIES_EXPORT bool isValidUtf8(const char* str);
+
+  /// Convert text from DICOM Person Name form to readable
+  /// \param pn a tag source value in the PN form (<Alphabetic representation,>[=<Ideographic representation>[=<Phonetic representation>]).
+  ///   Where each representation consists of up to 5 name components (Last Name(s)[^First Name(s)[^Middle Name(s)[^Prefix[^Postfix]]]]).
+  /// \param group index of component group (0..2) to be extracted.
+  /// \return the specified group in readable form or the source string if the conversion fails.
+  /// UTF-8 is assumed for input and output strings.
+  MITKUTILITIES_EXPORT std::string formatPersonName(const std::string& pn, int group=0);
 }

--- a/Modules/Utilities/src/StringUtilities.cpp
+++ b/Modules/Utilities/src/StringUtilities.cpp
@@ -1,5 +1,7 @@
 #include "StringUtilities.h"
 
+#include <dcmtk/dcmdata/dcvrpn.h>
+
 #ifdef _WIN32
 #include <Windows.h>
 #endif
@@ -122,4 +124,20 @@ namespace Utilities
 
     return true;
   }
+
+  std::string formatPersonName(const std::string& pn, int group)
+  {
+    std::string r;
+    for (int i = 0; i < 3; i++) {
+      if (DcmPersonName::getFormattedNameFromString(pn, r, group).good() && !r.empty()) {
+        return r;
+      }
+      // search for any informative group
+      if (--group < 0) {
+        group = 2;
+      }
+    }
+    return pn;
+  }
+
 }


### PR DESCRIPTION
Это касается символов ^ и = в именах пациентов и в описаниях исследований (хотя последнее не в стандарте DICOM, но многие исследования их содержат).
Новая функция Utilities::formatPersonName будет использована в Автоплане.
AUT-4594