### PR TITLE
Исправления в фильтрации загружаемых тэгов

### DIFF
--- a/Modules/Core/src/Rendering/mitkVtkFont.cpp
+++ b/Modules/Core/src/Rendering/mitkVtkFont.cpp
@@ -8,7 +8,7 @@ void mitk::setUnicodeFont(vtkTextProperty* prop)
   prop->SetFontFamily(VTK_FONT_FILE);
   if (s_FontPath.empty())
   {
-    s_FontPath = Utilities::preferredPath(Utilities::absPath(std::string("Fonts\\DejaVuSans.ttf")));
+    s_FontPath = Utilities::preferredPath(Utilities::absPath(std::string("Fonts/DejaVuSans.ttf")));
   }
   prop->SetFontFile(s_FontPath.c_str());
 }


### PR DESCRIPTION
Не загружаем тэги неизвестные для gdcm, чтобы не было ошибок при экспорте. AUT-4449
