### PR TITLE
MouseModeSwitcher redone to singleton AUT-4694

### DIFF
--- a/Modules/Core/TestingHelper/include/mitkInteractionTestHelper.h
+++ b/Modules/Core/TestingHelper/include/mitkInteractionTestHelper.h
@@ -141,7 +141,6 @@ protected:
 
   RenderWindowListType m_RenderWindowList;
   mitk::DataStorage::Pointer m_DataStorage;
-  mitk::MouseModeSwitcher::Pointer m_MouseModeSwitcher;
 
 };
 }//namespace mitk

--- a/Modules/Core/TestingHelper/src/mitkInteractionTestHelper.cpp
+++ b/Modules/Core/TestingHelper/src/mitkInteractionTestHelper.cpp
@@ -173,10 +173,8 @@ void mitk::InteractionTestHelper::Initialize(const std::string &interactionXmlFi
 
     //########### register display interactor to handle scroll events ##################
     //use MouseModeSwitcher to ensure that the statemachine of DisplayInteractor is loaded correctly
-    m_MouseModeSwitcher = mitk::MouseModeSwitcher::New();
-
     for (const auto& window : m_RenderWindowList) {
-      m_MouseModeSwitcher->AddRenderer(window->GetRenderer());
+      mitk::MouseModeSwitcher::GetInstance().AddRenderer(window->GetRenderer());
     }
   }
   else

--- a/Modules/Core/include/mitkMouseModeSwitcher.h
+++ b/Modules/Core/include/mitkMouseModeSwitcher.h
@@ -64,6 +64,9 @@ namespace mitk {
   {
   public:
 
+    static MouseModeSwitcher& GetInstance();
+    static void DestroyInstance();
+
 #pragma GCC visibility push(default)
     /**
       \brief Can be observed by GUI class to update button states when mode is changed programatically.
@@ -72,8 +75,8 @@ namespace mitk {
 #pragma GCC visibility pop
 
     mitkClassMacroItkParent( MouseModeSwitcher, itk::Object );
-    mitkNewMacro1Param(Self, BaseRenderer::Pointer);
-    itkNewMacro(Self);
+    //mitkNewMacro1Param(Self, BaseRenderer::Pointer);
+    //itkNewMacro(Self);
 
     // enum of the different interaction schemes that are available
     enum InteractionScheme
@@ -125,10 +128,11 @@ namespace mitk {
     */
     void AddRenderer(BaseRenderer::Pointer renderer);
 
+    virtual ~MouseModeSwitcher();
+
   protected:
     MouseModeSwitcher(BaseRenderer::Pointer renderer);
     MouseModeSwitcher();
-    virtual ~MouseModeSwitcher();
   private:
 
     InteractionScheme m_ActiveInteractionScheme;

--- a/Modules/Core/include/mitkMouseModeSwitcher.h
+++ b/Modules/Core/include/mitkMouseModeSwitcher.h
@@ -132,9 +132,9 @@ namespace mitk {
   protected:
     MouseModeSwitcher(BaseRenderer::Pointer renderer);
     MouseModeSwitcher();
-    MouseModeSwitcher(const MouseModeSwitcher&) = delete;
-    MouseModeSwitcher& operator=(const MouseModeSwitcher&) = delete;
   private:
+    MouseModeSwitcher& operator=(const MouseModeSwitcher&) = delete;
+    MouseModeSwitcher(const MouseModeSwitcher&) = delete;
 
     InteractionScheme m_ActiveInteractionScheme;
     MouseMode         m_ActiveMouseMode;

--- a/Modules/Core/include/mitkMouseModeSwitcher.h
+++ b/Modules/Core/include/mitkMouseModeSwitcher.h
@@ -65,7 +65,6 @@ namespace mitk {
   public:
 
     static MouseModeSwitcher& GetInstance();
-    static void DestroyInstance();
 
 #pragma GCC visibility push(default)
     /**
@@ -133,6 +132,8 @@ namespace mitk {
   protected:
     MouseModeSwitcher(BaseRenderer::Pointer renderer);
     MouseModeSwitcher();
+    MouseModeSwitcher(const MouseModeSwitcher&) = delete;
+    MouseModeSwitcher& operator=(const MouseModeSwitcher&) = delete;
   private:
 
     InteractionScheme m_ActiveInteractionScheme;

--- a/Modules/Core/include/mitkMouseModeSwitcher.h
+++ b/Modules/Core/include/mitkMouseModeSwitcher.h
@@ -133,8 +133,8 @@ namespace mitk {
     MouseModeSwitcher(BaseRenderer::Pointer renderer);
     MouseModeSwitcher();
   private:
-    MouseModeSwitcher& operator=(const MouseModeSwitcher&) = delete;
-    MouseModeSwitcher(const MouseModeSwitcher&) = delete;
+    MouseModeSwitcher& operator=(const MouseModeSwitcher&);
+    MouseModeSwitcher(const MouseModeSwitcher&);
 
     InteractionScheme m_ActiveInteractionScheme;
     MouseMode         m_ActiveMouseMode;
@@ -149,6 +149,8 @@ namespace mitk {
     std::unordered_set<std::string> m_RegisteredRendererNames;
 
     MouseModeMap m_ActiveMouseModes;
+
+    friend itk::SmartPointer<mitk::MouseModeSwitcher>;
   };
 } // namespace mitk
 

--- a/Modules/Core/src/Interactions/mitkMouseModeSwitcher.cpp
+++ b/Modules/Core/src/Interactions/mitkMouseModeSwitcher.cpp
@@ -232,3 +232,13 @@ mitk::MouseModeSwitcher::MouseModeMap& mitk::MouseModeSwitcher::GetActiveMouseMo
 {
   return m_ActiveMouseModes;
 }
+
+mitk::MouseModeSwitcher& mitk::MouseModeSwitcher::operator=(const MouseModeSwitcher&)
+{
+  throw std::logic_error("mitk::MouseModeSwitcher must be singleton.");
+}
+
+mitk::MouseModeSwitcher::MouseModeSwitcher(const MouseModeSwitcher&)
+{
+  throw std::logic_error("mitk::MouseModeSwitcher must be singleton.");
+}

--- a/Modules/Core/src/Interactions/mitkMouseModeSwitcher.cpp
+++ b/Modules/Core/src/Interactions/mitkMouseModeSwitcher.cpp
@@ -14,6 +14,8 @@
 
  ===================================================================*/
 
+#include <boost/scoped_ptr.hpp>
+
 #include "mitkMouseModeSwitcher.h"
 // us
 #include "usGetModuleContext.h"
@@ -22,6 +24,8 @@
 #include "mitkInteractionEventObserver.h"
 
 namespace {
+  boost::scoped_ptr<mitk::MouseModeSwitcher> s_impl;
+
   std::string getNameButton(const unsigned int& button)
   {
     std::string buttonName;
@@ -54,6 +58,19 @@ namespace {
       }
     }
   }
+}
+
+mitk::MouseModeSwitcher& mitk::MouseModeSwitcher::GetInstance()
+{
+  if (!s_impl) {
+    s_impl.reset(new mitk::MouseModeSwitcher());
+  }
+  return *s_impl;
+}
+
+void mitk::MouseModeSwitcher::DestroyInstance()
+{
+  s_impl.reset();
 }
 
 mitk::MouseModeSwitcher::MouseModeSwitcher() :

--- a/Modules/Core/src/Interactions/mitkMouseModeSwitcher.cpp
+++ b/Modules/Core/src/Interactions/mitkMouseModeSwitcher.cpp
@@ -13,9 +13,6 @@
  See LICENSE.txt or http://www.mitk.org for details.
 
  ===================================================================*/
-
-#include <boost/scoped_ptr.hpp>
-
 #include "mitkMouseModeSwitcher.h"
 // us
 #include "usGetModuleContext.h"
@@ -24,8 +21,6 @@
 #include "mitkInteractionEventObserver.h"
 
 namespace {
-  boost::scoped_ptr<mitk::MouseModeSwitcher> s_impl;
-
   std::string getNameButton(const unsigned int& button)
   {
     std::string buttonName;
@@ -62,15 +57,8 @@ namespace {
 
 mitk::MouseModeSwitcher& mitk::MouseModeSwitcher::GetInstance()
 {
-  if (!s_impl) {
-    s_impl.reset(new mitk::MouseModeSwitcher());
-  }
-  return *s_impl;
-}
-
-void mitk::MouseModeSwitcher::DestroyInstance()
-{
-  s_impl.reset();
+  static MouseModeSwitcher s_impl;
+  return s_impl;
 }
 
 mitk::MouseModeSwitcher::MouseModeSwitcher() :

--- a/Modules/QtWidgets/include/QmitkMouseModeSwitcher.h
+++ b/Modules/QtWidgets/include/QmitkMouseModeSwitcher.h
@@ -53,7 +53,7 @@ class MITKQTWIDGETS_EXPORT QmitkMouseModeSwitcher : public QToolBar
 
       \todo QmitkMouseModeSwitcher could be enhanced to actively observe mitk::MouseModeSwitcher and change available actions or visibility appropriately.
     */
-    void setMouseModeSwitcher( mitk::MouseModeSwitcher* );
+    void setMouseModeSwitcher( /*mitk::MouseModeSwitcher**/ );
 
   signals:
 
@@ -77,7 +77,7 @@ class MITKQTWIDGETS_EXPORT QmitkMouseModeSwitcher : public QToolBar
     void OnMouseModeChanged(const itk::EventObject&);
 
     QActionGroup* m_ActionGroup;
-    mitk::MouseModeSwitcher* m_MouseModeSwitcher;
+    //mitk::MouseModeSwitcher* m_MouseModeSwitcher;
 
     unsigned long m_ObserverTag;
 

--- a/Modules/QtWidgets/include/QmitkStdMultiWidget.h
+++ b/Modules/QtWidgets/include/QmitkStdMultiWidget.h
@@ -70,7 +70,7 @@ public:
 
   void ForceImmediateUpdate();
 
-  mitk::MouseModeSwitcher* GetMouseModeSwitcher();
+  //mitk::MouseModeSwitcher* GetMouseModeSwitcher();
   void setMouseMode(mitk::MouseModeSwitcher::MouseMode mode, const Qt::MouseButton& button);
 
   QmitkRenderWindow* GetRenderWindow1() const;
@@ -407,7 +407,6 @@ protected:
 
   bool m_GradientBackgroundFlag;
 
-  mitk::MouseModeSwitcher::Pointer m_MouseModeSwitcher;
   mitk::SliceNavigationController* m_TimeNavigationController;
 
   mitk::DataStorage::Pointer m_DataStorage;

--- a/Modules/QtWidgets/src/QmitkMouseModeSwitcher.cpp
+++ b/Modules/QtWidgets/src/QmitkMouseModeSwitcher.cpp
@@ -20,7 +20,6 @@ See LICENSE.txt or http://www.mitk.org for details.
 QmitkMouseModeSwitcher::QmitkMouseModeSwitcher( QWidget* parent )
 :QToolBar(parent)
 ,m_ActionGroup(new QActionGroup(this))
-,m_MouseModeSwitcher(NULL)
 ,m_ObserverTag(0)
 ,m_InObservationReaction(false)
 {
@@ -49,29 +48,18 @@ void QmitkMouseModeSwitcher::addButton( MouseMode id, const QString& toolName, c
 
 QmitkMouseModeSwitcher::~QmitkMouseModeSwitcher()
 {
-  if (m_MouseModeSwitcher)
-  {
-    m_MouseModeSwitcher->RemoveObserver( m_ObserverTag );
-  }
+  mitk::MouseModeSwitcher::GetInstance().RemoveObserver( m_ObserverTag );
 }
 
-void QmitkMouseModeSwitcher::setMouseModeSwitcher( mitk::MouseModeSwitcher* mms )
+void QmitkMouseModeSwitcher::setMouseModeSwitcher( /*mitk::MouseModeSwitcher* mms*/)
 {
   // goodbye / welcome ceremonies
-  if (m_MouseModeSwitcher)
-  {
-    m_MouseModeSwitcher->RemoveObserver( m_ObserverTag );
-  }
+  mitk::MouseModeSwitcher::GetInstance().RemoveObserver(m_ObserverTag);
 
-  m_MouseModeSwitcher = mms;
-
-  if ( m_MouseModeSwitcher )
-  {
-    itk::ReceptorMemberCommand<QmitkMouseModeSwitcher>::Pointer command =
-      itk::ReceptorMemberCommand<QmitkMouseModeSwitcher>::New();
-    command->SetCallbackFunction(this, &QmitkMouseModeSwitcher::OnMouseModeChanged);
-    m_ObserverTag = m_MouseModeSwitcher->AddObserver( mitk::MouseModeSwitcher::MouseModeChangedEvent(), command );
-  }
+  itk::ReceptorMemberCommand<QmitkMouseModeSwitcher>::Pointer command =
+    itk::ReceptorMemberCommand<QmitkMouseModeSwitcher>::New();
+  command->SetCallbackFunction(this, &QmitkMouseModeSwitcher::OnMouseModeChanged);
+  m_ObserverTag = mitk::MouseModeSwitcher::GetInstance().AddObserver(mitk::MouseModeSwitcher::MouseModeChangedEvent(), command);
 }
 
 void QmitkMouseModeSwitcher::modeSelectedByUser()
@@ -86,13 +74,10 @@ void QmitkMouseModeSwitcher::modeSelectedByUser()
     //qDebug() << "Mouse mode '" << qPrintable(action->text()) << "' selected, trigger mode id " << id;
 
 
-    if (m_MouseModeSwitcher)
-    {
       //Deleted mouse mode "PACS"
-      m_MouseModeSwitcher->SetInteractionScheme(mitk::MouseModeSwitcher::InteractionScheme::MITK/*PACS*/);
-      m_MouseModeSwitcher->SelectMouseMode( id );
-    }
-    emit MouseModeSelected( id );
+    mitk::MouseModeSwitcher::GetInstance().SetInteractionScheme(mitk::MouseModeSwitcher::InteractionScheme::MITK/*PACS*/);
+    mitk::MouseModeSwitcher::GetInstance().SelectMouseMode(id);
+    emit MouseModeSelected(id);
 
   }
 }
@@ -102,9 +87,9 @@ void QmitkMouseModeSwitcher::OnMouseModeChanged(const itk::EventObject&)
   m_InObservationReaction = true;
 
   // push button graphically
-  assert( m_MouseModeSwitcher );
+  //assert( m_MouseModeSwitcher );
 
-  MouseMode activeMode = m_MouseModeSwitcher->GetCurrentMouseMode();
+  MouseMode activeMode = mitk::MouseModeSwitcher::GetInstance().GetCurrentMouseMode();
 
   foreach(QAction* action, m_ActionGroup->actions())
   {

--- a/Modules/QtWidgets/src/QmitkStdMultiWidget.cpp
+++ b/Modules/QtWidgets/src/QmitkStdMultiWidget.cpp
@@ -241,7 +241,7 @@ QmitkStdMultiWidget::QmitkStdMultiWidget(QWidget* parent, Qt::WindowFlags f, mit
     connect(GetRenderWindow(i), &QmitkRenderWindow::annotationPositionChanged, this, [this]() { HandleCrosshairPositionEvent(); });
     connect(GetRenderWindow(i), &QmitkRenderWindow::mouseEvent, this, [this](QMouseEvent* e) {
       if (e->buttons() && e->type() == QEvent::MouseMove) {
-        auto modes = GetMouseModeSwitcher()->GetActiveMouseModes();
+        auto modes = mitk::MouseModeSwitcher::GetInstance().GetActiveMouseModes();
         for (auto& mode : modes) {
           if (mode.first == mitk::MouseModeSwitcher::MouseRotation) {
             HandleCrosshairPositionEvent();
@@ -420,10 +420,10 @@ void QmitkStdMultiWidget::InitializeWidget(bool showPlanesIn3d)
   mitkWidget4->GetSliceNavigationController()
     ->ConnectGeometryComponentEvent(m_TimeNavigationController, false);
 
-  m_MouseModeSwitcher = mitk::MouseModeSwitcher::New(mitkWidget1->GetRenderer());
-  m_MouseModeSwitcher->AddRenderer(mitkWidget2->GetRenderer());
-  m_MouseModeSwitcher->AddRenderer(mitkWidget3->GetRenderer());
-  m_MouseModeSwitcher->AddRenderer(mitkWidget4->GetRenderer());
+  mitk::MouseModeSwitcher::GetInstance().AddRenderer(mitkWidget1->GetRenderer());
+  mitk::MouseModeSwitcher::GetInstance().AddRenderer(mitkWidget2->GetRenderer());
+  mitk::MouseModeSwitcher::GetInstance().AddRenderer(mitkWidget3->GetRenderer());
+  mitk::MouseModeSwitcher::GetInstance().AddRenderer(mitkWidget4->GetRenderer());
 
   mitkWidget1->GetSliceNavigationController()->crosshairPositionEvent.AddListener(mitk::MessageDelegate<QmitkStdMultiWidget>(this, &QmitkStdMultiWidget::HandleCrosshairPositionEvent));
   mitkWidget2->GetSliceNavigationController()->crosshairPositionEvent.AddListener(mitk::MessageDelegate<QmitkStdMultiWidget>(this, &QmitkStdMultiWidget::HandleCrosshairPositionEvent));
@@ -1848,7 +1848,7 @@ void QmitkStdMultiWidget::setDirectionOnly(bool directiononly)
 
 void QmitkStdMultiWidget::setSelectionMode(bool selection)
 {
-  m_MouseModeSwitcher->SetSelectionMode(selection);
+  mitk::MouseModeSwitcher::GetInstance().SetSelectionMode(selection);
   mitk::DataNodePickingEventObserver::SetEnabled(selection);
 }
 
@@ -2232,12 +2232,12 @@ void QmitkStdMultiWidget::SetWidgetPlaneMode( int userMode )
     switch(userMode)
     {
       case 0:
-        m_MouseModeSwitcher->SetInteractionScheme(mitk::MouseModeSwitcher::InteractionScheme::MITK);
+        mitk::MouseModeSwitcher::GetInstance().SetInteractionScheme(mitk::MouseModeSwitcher::InteractionScheme::MITK);
         break;
 
       case 3:
         crosshairManager->setCrosshairMode(CrosshairMode::PLANE);
-        m_MouseModeSwitcher->SetInteractionScheme( mitk::MouseModeSwitcher::InteractionScheme::SWIVEL);
+        mitk::MouseModeSwitcher::GetInstance().SetInteractionScheme( mitk::MouseModeSwitcher::InteractionScheme::SWIVEL);
         break;
     }
   }
@@ -2511,11 +2511,12 @@ bool QmitkStdMultiWidget::IsColoredRectanglesEnabled() const
 {
   return m_RectangleProps[0]->GetVisibility()>0;
 }
-
+/*
 mitk::MouseModeSwitcher* QmitkStdMultiWidget::GetMouseModeSwitcher()
 {
   return m_MouseModeSwitcher;
 }
+*/
 
 void QmitkStdMultiWidget::setViewDirectionAnnontation(mitk::Image* image, int slice, int i)
 {
@@ -2657,7 +2658,7 @@ void QmitkStdMultiWidget::setAnnotationVisibility(std::vector<bool>& visibility)
 
 void QmitkStdMultiWidget::setMouseMode(mitk::MouseModeSwitcher::MouseMode mode, const Qt::MouseButton& button)
 {
-  m_MouseModeSwitcher->SelectMouseMode(mode, button);
+  mitk::MouseModeSwitcher::GetInstance().SelectMouseMode(mode, button);
 }
 
 void QmitkStdMultiWidget::ResetTransformation(mitk::VtkPropRenderer* renderer)

--- a/Modules/SegmentationUI/Qmitk/QmitkSmartBrushToolGUI.cpp
+++ b/Modules/SegmentationUI/Qmitk/QmitkSmartBrushToolGUI.cpp
@@ -78,8 +78,8 @@ void QmitkSmartBrushToolGUI::OnNewToolAssociated(mitk::Tool* tool)
   m_SmartBrushTool = dynamic_cast<mitk::SmartBrushTool*>(tool);
 
   if (m_SmartBrushTool.IsNotNull()) {
-    m_SmartBrushTool->radiusChanged -= mitk::MessageDelegate1<QmitkSmartBrushToolGUI, int>(this, &QmitkSmartBrushToolGUI::OnRadiusChanged);
-    m_SmartBrushTool->sensitivityChanged -= mitk::MessageDelegate1<QmitkSmartBrushToolGUI, int>(this, &QmitkSmartBrushToolGUI::OnSensitivityChanged);
+    m_SmartBrushTool->radiusChanged += mitk::MessageDelegate1<QmitkSmartBrushToolGUI, int>(this, &QmitkSmartBrushToolGUI::OnRadiusChanged);
+    m_SmartBrushTool->sensitivityChanged += mitk::MessageDelegate1<QmitkSmartBrushToolGUI, int>(this, &QmitkSmartBrushToolGUI::OnSensitivityChanged);
   }
 }
 

--- a/Plugins/org.mitk.gui.qt.stdmultiwidgeteditor/src/QmitkStdMultiWidgetEditor.cpp
+++ b/Plugins/org.mitk.gui.qt.stdmultiwidgeteditor/src/QmitkStdMultiWidgetEditor.cpp
@@ -275,7 +275,7 @@ void QmitkStdMultiWidgetEditor::CreateQtPartControl(QWidget* parent)
     d->m_RenderWindows.insert("coronal", d->m_StdMultiWidget->GetRenderWindow3());
     d->m_RenderWindows.insert("3d", d->m_StdMultiWidget->GetRenderWindow4());
 
-    d->m_MouseModeToolbar->setMouseModeSwitcher( d->m_StdMultiWidget->GetMouseModeSwitcher() );
+    d->m_MouseModeToolbar->setMouseModeSwitcher( /*d->m_StdMultiWidget->GetMouseModeSwitcher()*/ );
 
     layout->addWidget(d->m_StdMultiWidget);
 
@@ -393,7 +393,7 @@ void QmitkStdMultiWidgetEditor::OnPreferencesChanged(const berry::IBerryPreferen
   // deleted mouse mode "PACS"
   //bool newMode = prefs->GetBool("PACS like mouse interaction", false);
   d->m_MouseModeToolbar->setVisible(false);
-  d->m_StdMultiWidget->GetMouseModeSwitcher()->SetInteractionScheme( /*newMode ? mitk::MouseModeSwitcher::PACS :*/ mitk::MouseModeSwitcher::MITK);
+  mitk::MouseModeSwitcher::GetInstance().SetInteractionScheme( /*newMode ? mitk::MouseModeSwitcher::PACS :*/ mitk::MouseModeSwitcher::MITK);
 
   mitk::DisplayInteractor::SetClockRotationSpeed(prefs->GetInt("Rotation Step", 90));
   d->m_StdMultiWidget->crosshairManager->updateAllWindows();


### PR DESCRIPTION
MouseModeSwitcher переделан на одиночку для того, чтобы и в просмотре, и в редакторе было одно его состояние.
https://jira.smuit.ru/browse/AUT-4694
https://jira.smuit.ru/browse/AUT-4710

Требуются изменения в Автоплане (локально ветки были проверены)
https://github.com/samsmu/AutoplanApplication/pull/3028