### PR TITLE
Fix clipping jitter in VR. AUT-4660

### DIFF
--- a/CMakeExternals/VTK.cmake
+++ b/CMakeExternals/VTK.cmake
@@ -93,6 +93,7 @@ if(NOT DEFINED VTK_DIR)
       COMMAND ${PATCH_COMMAND} -N -p1 -i ${CMAKE_CURRENT_LIST_DIR}/VtkVrStepFix.patch
       COMMAND ${PATCH_COMMAND} -N -p1 -i ${CMAKE_CURRENT_LIST_DIR}/VtkBorderRepresentationFix.patch
       COMMAND ${PATCH_COMMAND} -N -p1 -i ${CMAKE_CURRENT_LIST_DIR}/VTK-gcc-10.patch
+      COMMAND ${PATCH_COMMAND} -N -p1 -i ${CMAKE_CURRENT_LIST_DIR}/VtkClippingJitter.patch
     CMAKE_GENERATOR ${gen}
     CMAKE_ARGS
         ${ep_common_args}

--- a/CMakeExternals/VtkClippingJitter.patch
+++ b/CMakeExternals/VtkClippingJitter.patch
@@ -1,0 +1,36 @@
+diff --git a/Rendering/VolumeOpenGL2/vtkVolumeShaderComposer.h b/Rendering/VolumeOpenGL2/vtkVolumeShaderComposer.h
+index bef04fb..ddb9fb9 100644
+--- a/Rendering/VolumeOpenGL2/vtkVolumeShaderComposer.h
++++ b/Rendering/VolumeOpenGL2/vtkVolumeShaderComposer.h
+@@ -1918,6 +1918,15 @@ namespace vtkvolume
+       \n        {\
+       \n        newObjDataPos /= newObjDataPos.w;\
+       \n        }\
++      \n\
++      \n      bool stop = any(greaterThan(newObjDataPos, in_texMax)) ||\
++      \n        any(lessThan(newObjDataPos, in_texMin));\
++      \n      if (stop)\
++      \n        {\
++      \n        // The ray exits the bounding box before ever intersecting the plane (only\
++      \n        // the clipped space is hit).\
++      \n        discard;\
++      \n        }\
+       \n      if (in_useJittering)\
+       \n        {\
+       \n        g_dataPos = newObjDataPos.xyz + g_rayJitter;\
+@@ -1927,15 +1936,6 @@ namespace vtkvolume
+       \n        g_dataPos = newObjDataPos.xyz + g_dirStep;\
+       \n        }\
+       \n\
+-      \n      bool stop = any(greaterThan(g_dataPos, in_texMax)) ||\
+-      \n        any(lessThan(g_dataPos, in_texMin));\
+-      \n      if (stop)\
+-      \n        {\
+-      \n        // The ray exits the bounding box before ever intersecting the plane (only\
+-      \n        // the clipped space is hit).\
+-      \n        discard;\
+-      \n        }\
+-      \n\
+       \n      bool behindGeometry = dot(terminatePointObj.xyz - planeOrigin.xyz, normalizedPlaneNormal) < 0.0;\
+       \n      if (behindGeometry)\
+       \n        {\


### PR DESCRIPTION
https://jira.smuit.ru/browse/AUT-4660

Джитеринг лучей теперь применяется после того как позиция луча была обрезана коробкой

1. Открыть исследование в вр
2. Включить коробку обрезания
ER; Под разными углами в плотном объеме не появляются прозрачные полосы