### PR TITLE
Set correct layouts when window menu are activated. AUT-4368

### DIFF
--- a/Modules/QtWidgets/src/QmitkStdMultiWidget.cpp
+++ b/Modules/QtWidgets/src/QmitkStdMultiWidget.cpp
@@ -2421,6 +2421,13 @@ void QmitkStdMultiWidget::ActivateMenuWidget( bool state )
   mitkWidget2->ActivateMenuWidget( state, this );
   mitkWidget3->ActivateMenuWidget( state, this );
   mitkWidget4->ActivateMenuWidget( state, this );
+
+  if (state) {
+    mitkWidget1->LayoutDesignListChanged(m_Layout);
+    mitkWidget2->LayoutDesignListChanged(m_Layout);
+    mitkWidget3->LayoutDesignListChanged(m_Layout);
+    mitkWidget4->LayoutDesignListChanged(m_Layout);
+  }
 }
 
 bool QmitkStdMultiWidget::IsMenuWidgetEnabled() const


### PR DESCRIPTION
https://jira.smuit.ru/browse/AUT-4368

Выставляет правильный режим просмотра когда меню для окон создается

1. Отрыть редактор
2. Поменять расположение окон
3. Перейти во вьювер
4. Перейти в редактор
ER: В меню для окон правильный режим просмотра