### PR TITLE
Сheck out of range AUT-4611

### DIFF
--- a/Modules/Core/src/Interactions/mitkDisplayInteractor.cpp
+++ b/Modules/Core/src/Interactions/mitkDisplayInteractor.cpp
@@ -1012,7 +1012,9 @@ void mitk::DisplayInteractor::UpdateStatusbar(mitk::StateMachineAction *, mitk::
     }
     else
     {
-      mitk::ScalarType pixelValue = mitk::UnlockedSinglePixelAccess(image3D, p, posEvent->GetSender()->GetTimeStep(), component);
+      unsigned int renderTS = posEvent->GetSender()->GetTimeStep();
+      unsigned int timeStep = renderTS < image3D->GetTimeSteps() ? renderTS : 0;
+      mitk::ScalarType pixelValue = mitk::UnlockedSinglePixelAccess(image3D, p, timeStep, component);
       statusBar->DisplayImageInfo(worldposition, p, posEvent->GetSender()->GetTime(), pixelValue);
     }
   }


### PR DESCRIPTION
Для получения текущего значения пикселя берутся:
   - изображение верхнего слоя;
   - временной шаг из рендера (временный шаг текущего изображения);
а так как сегментация накладывается на исходное изображение, то при выбранном 4D изображении шаг выходит за пределы.  
https://jira.smuit.ru/browse/AUT-4611