### PR TITLE
change point selection logic LP-75

### DIFF
--- a/Modules/PlanarFigure/resource/Interactions/PlanarFigureInteraction.xml
+++ b/Modules/PlanarFigure/resource/Interactions/PlanarFigureInteraction.xml
@@ -92,6 +92,12 @@
       <condition name="hovering_above_annotation" />
       <action name="start_hovering" />
     </transition>
+
+    <transition event_class="InteractionKeyEvent" event_variant="StdDelete" target="Start" > <!-- delete figure -->
+      <condition name="figure_is_selected" />
+      <condition name="figure_can_be_deleted" />
+      <action name="delete_figure" />
+    </transition>
   </state>
 
   <state name="MovingAnnotation">


### PR DESCRIPTION
При выборе инструмента "Точка" контрольная точка подсвечивается красным, при наведении - зеленым, для остальных инструментов оставлена прежняя логика.

Так же в состояние "EditFigure" добавлен переход к стартовому состоянию с удалением фигуры, так как при одновременном выборе фигуры и контрольной точки машина состояний ожидает то ли редактирование фигуры, то ли курсор просто находится над фигурой (контрольной точкой).

https://jira.smuit.ru/browse/LP-75