### PR TITLE
Подключен Boost.Python

### DIFF
--- a/CMakeExternals/Boost-win.patch
+++ b/CMakeExternals/Boost-win.patch
@@ -1,0 +1,12 @@
+diff -bdur Boost0/bootstrap.bat Boost/bootstrap.bat
+--- Boost0/bootstrap.bat	2018-08-02 00:50:46.000000000 +0400
++++ Boost/bootstrap.bat	2020-09-01 19:17:21.488476129 +0400
+@@ -54,6 +54,8 @@
+ ECHO import option ; > project-config.jam
+ ECHO. >> project-config.jam
+ ECHO using %TOOLSET% ; >> project-config.jam
++ECHO %USINGP2% ; >> project-config.jam
++ECHO %USINGP3% ; >> project-config.jam
+ ECHO. >> project-config.jam
+ ECHO option.set keep-going : false ; >> project-config.jam
+ ECHO. >> project-config.jam

--- a/CMakeExternals/Boost.cmake
+++ b/CMakeExternals/Boost.cmake
@@ -17,7 +17,7 @@ set(Boost_DEPENDS ${proj})
 
 if(NOT DEFINED BOOST_ROOT AND NOT MITK_USE_SYSTEM_Boost)
 
-  set(_boost_version 1_60)
+  set(_boost_version 1_68)
   set(_boost_install_include_dir include/boost)
   if(WIN32)
     set(_boost_install_include_dir include/boost-${_boost_version}/boost)
@@ -25,6 +25,7 @@ if(NOT DEFINED BOOST_ROOT AND NOT MITK_USE_SYSTEM_Boost)
 
   set(_boost_libs )
   set(_with_boost_libs )
+  set(_bootstrap_args )
   set(_install_lib_dir )
 
   # Set the boost root to the libraries install directory
@@ -33,6 +34,14 @@ if(NOT DEFINED BOOST_ROOT AND NOT MITK_USE_SYSTEM_Boost)
   if(MITK_USE_Boost_LIBRARIES)
     string(REPLACE ";" "," _boost_libs "${MITK_USE_Boost_LIBRARIES}")
     foreach(_boost_lib ${MITK_USE_Boost_LIBRARIES})
+      if (_boost_lib MATCHES "python[0-9]*")
+        find_package (Python2 COMPONENTS Interpreter Development)
+        if(Python2_FOUND)
+#          list(APPEND _bootstrap_args "--with-python=${Python2_EXECUTABLE}")
+          get_filename_component(_python_basedir ${Python2_INCLUDE_DIRS} DIRECTORY) #< this maybe for windows only
+          list(APPEND _bootstrap_args "--with-python=${_python_basedir}")
+        endif()
+      endif()
       list(APPEND _with_boost_libs --with-${_boost_lib})
     endforeach()
   endif()
@@ -139,11 +148,12 @@ if(NOT DEFINED BOOST_ROOT AND NOT MITK_USE_SYSTEM_Boost)
   ExternalProject_Add(${proj}
     LIST_SEPARATOR ${sep}
     URL ${MITK_THIRDPARTY_DOWNLOAD_PREFIX_URL}/boost_${_boost_version}_0.7z
-    URL_MD5 7ce7f5a4e396484da8da6b60d4ed7661
+    URL_MD5 ae25f29cdb82cf07e8e26187ddf7d330
     BINARY_DIR "${ep_prefix}/src/${proj}"
     CONFIGURE_COMMAND "<SOURCE_DIR>/bootstrap${_shell_extension}"
       --with-toolset=${_boost_with_toolset}
       --with-libraries=${_boost_libs}
+      ${_bootstrap_args}
       "--prefix=<INSTALL_DIR>"
     ${_boost_build_cmd}
     INSTALL_COMMAND ${_install_cmd}

--- a/CMakeExternals/Boost.cmake
+++ b/CMakeExternals/Boost.cmake
@@ -27,33 +27,79 @@ if(NOT DEFINED BOOST_ROOT AND NOT MITK_USE_SYSTEM_Boost)
   set(_with_boost_libs )
   set(_bootstrap_args )
   set(_install_lib_dir )
+  set(_env )
 
   # Set the boost root to the libraries install directory
   set(BOOST_ROOT "${ep_prefix}")
 
+  if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    set(_boost_address_model "64")
+  else()
+    set(_boost_address_model "32")
+  endif()
+
   if(MITK_USE_Boost_LIBRARIES)
     string(REPLACE ";" "," _boost_libs "${MITK_USE_Boost_LIBRARIES}")
+    string(REGEX REPLACE "python[0-9]*" "python"  _bootstrap_libs "${_boost_libs}")
     foreach(_boost_lib ${MITK_USE_Boost_LIBRARIES})
       if (_boost_lib MATCHES "python[0-9]*")
         find_package (Python2 COMPONENTS Interpreter Development)
+        find_package (Python3 COMPONENTS Interpreter Development)
+        string(REGEX REPLACE "([^.]*\\.[^.]*)\\..*" "\\1" _p2v "${Python2_VERSION}")
+        string(REGEX REPLACE "([^.]*\\.[^.]*)\\..*" "\\1" _p3v "${Python3_VERSION}")
         if(Python2_FOUND)
-#          list(APPEND _bootstrap_args "--with-python=${Python2_EXECUTABLE}")
-          get_filename_component(_python_basedir ${Python2_INCLUDE_DIRS} DIRECTORY) #< this maybe for windows only
-          list(APPEND _bootstrap_args "--with-python=${_python_basedir}")
+          string(REGEX REPLACE "([\\ ])" "\\\\\\1" _pe "${Python2_EXECUTABLE}")
+          string(REGEX REPLACE "([\\ ])" "\\\\\\1" _pi "${Python2_INCLUDE_DIRS}")
+          string(REGEX REPLACE "([\\ ])" "\\\\\\1" _pl "${Python2_LIBRARY_DIRS}")
+#         list(APPEND _env "USINGP2=using python : ${_p2v} : ${_pe} : ${_pi} : ${_pl} : <address-model>${_boost_address_model} <address-model>")
+          list(APPEND _env "USINGP2=using python : ${_p2v} : ${_pe} : ${_pi} : ${_pl}")
+        else()
+          list(APPEND _env "USINGP2=# no python2")
         endif()
+        if(Python3_FOUND)
+          string(REGEX REPLACE "([\\ ])" "\\\\\\1" _pe "${Python3_EXECUTABLE}")
+          string(REGEX REPLACE "([\\ ])" "\\\\\\1" _pi "${Python3_INCLUDE_DIRS}")
+          string(REGEX REPLACE "([\\ ])" "\\\\\\1" _pl "${Python3_LIBRARY_DIRS}")
+#         list(APPEND _env "USINGP3=using python : ${_p3v} : ${_pe} : ${_pi} : ${_pl} : <address-model>${_boost_address_model} <address-model>")
+          list(APPEND _env "USINGP3=using python : ${_p3v} : ${_pe} : ${_pi} : ${_pl}")
+        else()
+          list(APPEND _env "USINGP3=# no python3")
+        endif()
+        list(APPEND _with_boost_libs --with-python)
+        if(Python3_FOUND AND Python2_FOUND)
+          if(WIN32)
+            get_filename_component(_python_basedir ${Python2_INCLUDE_DIRS} DIRECTORY)
+            list(APPEND _bootstrap_args "--with-python=${_python_basedir}")
+          else()
+            list(APPEND _bootstrap_args "--with-python=${Python2_EXECUTABLE}")
+          endif()
+          list(APPEND _with_boost_libs "python=${_p2v},${_p3v}")
+        elseif(Python2_FOUND)
+          if(WIN32)
+            get_filename_component(_python_basedir ${Python2_INCLUDE_DIRS} DIRECTORY)
+            list(APPEND _bootstrap_args "--with-python=${_python_basedir}")
+          else()
+            list(APPEND _bootstrap_args "--with-python=${Python2_EXECUTABLE}")
+          endif()
+          list(APPEND _with_boost_libs "python=${_p2v}")
+        elseif(Python3_FOUND)
+          if(WIN32)
+            get_filename_component(_python_basedir ${Python3_INCLUDE_DIRS} DIRECTORY)
+            list(APPEND _bootstrap_args "--with-python=${_python_basedir}")
+          else()
+            list(APPEND _bootstrap_args "--with-python=${Python3_EXECUTABLE}")
+          endif()
+          list(APPEND _with_boost_libs "python=${_p3v}")
+        endif()
+      else()
+        list(APPEND _with_boost_libs --with-${_boost_lib})
       endif()
-      list(APPEND _with_boost_libs --with-${_boost_lib})
     endforeach()
-  endif()
-
-  if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-    set(_boost_address_model "address-model=64")
-  else()
-    set(_boost_address_model "address-model=32")
   endif()
 
   if(WIN32)
     set(_shell_extension .bat)
+    set(_patch2 COMMAND ${PATCH_COMMAND} -N -p1 -i ${CMAKE_CURRENT_LIST_DIR}/Boost-win.patch)
     set(_boost_layout)
     if(MSVC)
       mitkFunctionGetMSVCVersion()
@@ -66,6 +112,7 @@ if(NOT DEFINED BOOST_ROOT AND NOT MITK_USE_SYSTEM_Boost)
     set(_windows_move_libs_cmd COMMAND ${CMAKE_COMMAND} -P ${WIN32_CMAKE_SCRIPT})
   else()
     set(_shell_extension .sh)
+    set(_patch2 )
     set(_boost_layout "--layout=tagged")
   endif()
 
@@ -127,7 +174,7 @@ if(NOT DEFINED BOOST_ROOT AND NOT MITK_USE_SYSTEM_Boost)
       link=${_boost_link}
       ${_boost_cxxflags}
       ${_boost_linkflags}
-      ${_boost_address_model}
+      address-model=${_boost_address_model}
       threading=multi
       runtime-link=shared
       # Some distributions site config breaks boost build
@@ -149,10 +196,12 @@ if(NOT DEFINED BOOST_ROOT AND NOT MITK_USE_SYSTEM_Boost)
     LIST_SEPARATOR ${sep}
     URL ${MITK_THIRDPARTY_DOWNLOAD_PREFIX_URL}/boost_${_boost_version}_0.7z
     URL_MD5 ae25f29cdb82cf07e8e26187ddf7d330
+    PATCH_COMMAND ${PATCH_COMMAND} -l -N -p1 -i ${CMAKE_CURRENT_LIST_DIR}/Boost.patch
+      ${_patch2}
     BINARY_DIR "${ep_prefix}/src/${proj}"
-    CONFIGURE_COMMAND "<SOURCE_DIR>/bootstrap${_shell_extension}"
+    CONFIGURE_COMMAND ${CMAKE_COMMAND} -E env ${_env} "<SOURCE_DIR>/bootstrap${_shell_extension}"
       --with-toolset=${_boost_with_toolset}
-      --with-libraries=${_boost_libs}
+      --with-libraries=${_bootstrap_libs}
       ${_bootstrap_args}
       "--prefix=<INSTALL_DIR>"
     ${_boost_build_cmd}

--- a/CMakeExternals/Boost.patch
+++ b/CMakeExternals/Boost.patch
@@ -1,0 +1,24 @@
+diff -bdur Boost0/bootstrap.sh Boost/bootstrap.sh
+--- Boost0/bootstrap.sh	2018-08-02 00:50:46.000000000 +0400
++++ Boost/bootstrap.sh	2020-09-01 19:19:09.556696361 +0400
+@@ -348,17 +348,13 @@
+ EOF
+ 
+ #  - Python configuration
+-if test "x$flag_no_python" = x; then
+-  cat >> project-config.jam <<EOF
++cat >> project-config.jam <<EOF
+ 
+ # Python configuration
+ import python ;
+-if ! [ python.configured ]
+-{
+-    using python : $PYTHON_VERSION : $PYTHON_ROOT ;
+-}
++$USINGP2 ;
++$USINGP3 ;
+ EOF
+-fi
+ 
+ if test "x$ICU_ROOT" != x; then
+   cat >> project-config.jam << EOF


### PR DESCRIPTION
* Обновлён Boost в связи с поддержкой новой версией одновременно нескольких версий Python.
 (требует изменений в cmake-файлах Автоплана использующих старые пути)
* Присутствие python в списке компонентов boost активирует сборку Boost с одной или двумя установленными версиями python (3 или 2), если не используется системный.