### PR TITLE
Cap slice extent in rendering. MIL-65

### DIFF
--- a/Modules/Core/src/Algorithms/mitkExtractSliceFilter.cpp
+++ b/Modules/Core/src/Algorithms/mitkExtractSliceFilter.cpp
@@ -207,6 +207,15 @@ void mitk::ExtractSliceFilter::GenerateData(){
         extent[1] = bottomInIndex.GetNorm();
       }
 
+      // Coresponds to most common max opengl texture size
+      // Can't use opengl to get value cause filter could be started without opengl (?)
+      // vtkTexture will resample to real max dim anyway, if it is too big
+      if (m_VtkOutputRequested) {
+        const double maxDimGL = 32768.;
+        extent[0] = std::min(extent[0], maxDimGL);
+        extent[1] = std::min(extent[1], maxDimGL);
+      }
+
       // Get the extent of the current world geometry and calculate resampling
       // spacing therefrom.
       widthInMM = m_WorldGeometry->GetExtentInMM( 0 );


### PR DESCRIPTION
https://jira.smuit.ru/browse/MIL-65

Убирает падение при выходе за пределы максимальной аллокации памяти

1. Открыть плагин регистрации. 
2. Выбрать изображения. Одно изображение должно быть значительно больше другого (в мм)
3. Уменьшить масштаб меньшего изображения
ER: Автоплан не упал