### PR TITLE
Fix cursor position for rotation math. LP-108

### DIFF
--- a/Modules/Core/src/Interactions/mitkDisplayInteractor.cpp
+++ b/Modules/Core/src/Interactions/mitkDisplayInteractor.cpp
@@ -807,7 +807,7 @@ void mitk::DisplayInteractor::Rotate(mitk::StateMachineAction *, mitk::Interacti
   const InteractionPositionEvent* posEvent = dynamic_cast<const InteractionPositionEvent*>(event);
   if (posEvent == nullptr) return;
 
-  Point3D cursor = posEvent->GetPositionInWorld();
+  Point3D cursor = posEvent->GetPlanePositionInWorld();
 
   Vector3D toProjected = m_LastCursorPosition - m_CenterOfRotation;
   Vector3D toCursor = cursor - m_CenterOfRotation;


### PR DESCRIPTION
https://jira.smuit.ru/browse/LP-108

Центр вращения расчитывался относительно центрального слайса.

1.  Открыть исследование в редакторе
2. Прокрутить до края
3. Вращать перекрестье
ER: Перекрестье остается ортогональным