### PR TITLE
Структурированный отчёт (переделано на указатель)

### DIFF
--- a/Modules/Core/include/mitkStructuredReport.h
+++ b/Modules/Core/include/mitkStructuredReport.h
@@ -2,10 +2,10 @@
 
 #include "MitkCoreExports.h"
 
-#include "dcmsr/dsrdoc.h"
-
 #include "mitkBaseData.h"
 #include "mitkCommon.h"
+
+class DSRDocument;
 
 namespace mitk {
 
@@ -16,7 +16,7 @@ public:
   itkFactorylessNewMacro(Self);
   itkCloneMacro(Self);
 
-  DSRDocument reportData;
+  std::shared_ptr<DSRDocument> reportData;
 
   std::string GetReportText();
   std::string GetPatientName();
@@ -41,6 +41,10 @@ public:
   void InitializeTimeGeometry(unsigned int timeSteps = 1) override;
   void ClearData() override;
   void PrintSelf(std::ostream& os, itk::Indent indent) const override;
+
+protected:
+  StructuredReport();
+  virtual ~StructuredReport();
 };
 
 };

--- a/Modules/Core/src/DataManagement/mitkStructuredReport.cpp
+++ b/Modules/Core/src/DataManagement/mitkStructuredReport.cpp
@@ -1,18 +1,29 @@
+#include "dcmsr/dsrdoc.h"
+
 #include "mitkStructuredReport.h"
 
 namespace mitk {
 
+StructuredReport::StructuredReport()
+{
+  reportData = std::shared_ptr<DSRDocument>();
+}
+
+StructuredReport::~StructuredReport()
+{
+}
+
 std::string StructuredReport::GetReportText()
 {
   std::ostringstream ss;
-  reportData.renderHTML(ss);
+  reportData->renderHTML(ss);
   return ss.str();
 }
 
 std::string StructuredReport::GetPatientName()
 {
   std::string res;
-  reportData.getPatientName(res);
+  reportData->getPatientName(res);
   return res;
 }
 

--- a/Modules/Core/src/IO/mitkDicomSR_ImageBlockDescriptor.cpp
+++ b/Modules/Core/src/IO/mitkDicomSR_ImageBlockDescriptor.cpp
@@ -14,6 +14,8 @@ See LICENSE.txt or http://www.mitk.org for details.
 
 ===================================================================*/
 
+#include <dcmsr/dsrdoc.h>
+
 #include <dcmtk/dcmdata/dctk.h>
 #include <dcmtk/dcmdata/dcrledrg.h>
 #include <dcmtk/dcmdata/dcistrmb.h>
@@ -414,7 +416,7 @@ bool DicomSeriesReader::ImageBlockDescriptor::loadStructeredReport(DcmFileFormat
   StructuredReport::Pointer report = StructuredReport::New();
 
   DcmDataset* fileData = ff.getDataset();
-  report->reportData.read(*fileData);
+  report->reportData->read(*fileData);
 
   lock.lock();
   info.m_Data = report;


### PR DESCRIPTION
Подключение "dcmsr/dsrdoc.h" перенесено в реализацию, чтобы исключить ситуацию с переопределением типов itk и dcmtk при включении mitkStructuredReport.